### PR TITLE
recipes-connectivity: Add networkmanager-qcom to set DB845c eth mac

### DIFF
--- a/recipes-connectivity/networkmanager/files/COPYING
+++ b/recipes-connectivity/networkmanager/files/COPYING
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Linaro Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes-connectivity/networkmanager/files/eth-mac-addr.conf
+++ b/recipes-connectivity/networkmanager/files/eth-mac-addr.conf
@@ -1,0 +1,2 @@
+[connection-mac-randomization]
+ethernet.cloned-mac-address=stable

--- a/recipes-connectivity/networkmanager/networkmanager-qcom.bb
+++ b/recipes-connectivity/networkmanager/networkmanager-qcom.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Network Manager Ethernet MAC address configuration"
+
+SRC_URI = " \
+    file://eth-mac-addr.conf \
+    file://COPYING \
+"
+
+S = "${WORKDIR}"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=8b392b2a392ec74791be385beaed2012"
+
+do_install () {
+    install -d ${D}/${libdir}/NetworkManager/conf.d
+    install -m 0644 ${WORKDIR}/eth-mac-addr.conf ${D}/${libdir}/NetworkManager/conf.d/eth-mac-addr.conf
+}
+
+FILES_${PN} = "${libdir}/NetworkManager/conf.d"

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN}_append_dragonboard-845c = " networkmanager-qcom"


### PR DESCRIPTION
The dragonboard 845c dosen't come with unique MAC address on ethernet so
use Network Manager feature to set it preserving across connections.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>