### PR TITLE
qcom-qcommon.inc: increase INITRAMFS_MAXSIZE

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -34,3 +34,8 @@ QCOM_BOOTIMG_PAGE_SIZE ?= "4096"
 
 # Default serial console for QCOM devices
 SERIAL_CONSOLES ?= "115200;ttyMSM0"
+
+# Increase INITRAMFS_MAXSIZE to 384 MiB to cover initramfs-kerneltest-full
+# image.  All our boards (except db410c) have 2GiB and db410c has 1GiB of RAM,
+# so this image would fit.
+INITRAMFS_MAXSIZE = "393216"


### PR DESCRIPTION
Default INITRAMFS_MAXSIZE is specified as 128 MiB, which can be easily
exceeded by e.g. initramfs-kerneltest-full-image. Increase the maximum
size to 384 MiB, allowing all initramfs test images to fit.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>