### PR TITLE
conf/sa8155p-adp.conf: Use 'userdata' as the intended ROOTFS partition

### DIFF
--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -18,8 +18,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
 "
 
-# /dev/sda6 is 'userdata' partition for adp board, so wipe it and use for our build
-QCOM_BOOTIMG_ROOTFS ?= "/dev/sda6"
+# /dev/sda6 is 'system' partition for adp board, but its very small, so we
+# use 'userdata' partition here.
+# /dev/sda9 is 'userdata' partition for adp board, so wipe it and use for our build
+QCOM_BOOTIMG_ROOTFS ?= "/dev/sda9"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD:ext4 += " -b 4096 "


### PR DESCRIPTION
Since the 'system' partition is quite small (3G),
use 'userdata' partition (around 105G) as the intended
ROOTFS partition.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit 920f19c77c0c40f2db96e34b786a01e30d89e964)