### PR TITLE
recipes-kernel: Linux 5.15 add SRCREV for 96boards platforms

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -3,7 +3,8 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCBRANCH = "release/sa8155p-adp/qcomlt-5.15"
-SRCREV = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"
+# SRCBRANCH set to "release/qcomlt-5.15" in linux-linaro-qcom.inc
+SRCREV = "b65f90c953f42781cdfe1858b8fbfb209fab3940"
 
-COMPATIBLE_MACHINE = "(sa8155p)"
+SRCBRANCH_sa8155p = "release/sa8155p-adp/qcomlt-5.15"
+SRCREV_sa8155p = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"


### PR DESCRIPTION
The sa8155p MACHINE uses different branch to be supported, current
Linux 5.15 common release  branch is in rc7 but is good enough.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>