### PR TITLE
linux-linaro-qcomlt: fix overrides for the sa8155p-adp machine

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -6,5 +6,5 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 # SRCBRANCH set to "release/qcomlt-5.15" in linux-linaro-qcom.inc
 SRCREV = "b65f90c953f42781cdfe1858b8fbfb209fab3940"
 
-SRCBRANCH_sa8155p = "release/sa8155p-adp/qcomlt-5.15"
-SRCREV_sa8155p = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"
+SRCBRANCH:sa8155p = "release/sa8155p-adp/qcomlt-5.15"
+SRCREV:sa8155p = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"


### PR DESCRIPTION
Fix override syntax in the linux-linaro-qcomlt_5.15.bb used to select
machine-specific kernel for sa8155p-adp.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>