### PR TITLE
lk: add support for building LK bootloaders for db410c/db820c

### DIFF
--- a/recipes-bsp/lk/lk-db410c-sd-boot_git.bb
+++ b/recipes-bsp/lk/lk-db410c-sd-boot_git.bb
@@ -1,0 +1,8 @@
+require lk.inc
+
+LK_BRANCH = "release/LA.BR.1.2.7-03810-8x16.0+sdboot"
+LK_REVISION = "089944963d354403ab3b6a37b504c29f0949ecdc"
+LK_MACHINE = "dragonboard-410c"
+LK_FLAVOUR = "-sd-boot"
+
+

--- a/recipes-bsp/lk/lk-db410c-sd-rescue_git.bb
+++ b/recipes-bsp/lk/lk-db410c-sd-rescue_git.bb
@@ -1,0 +1,7 @@
+require lk.inc
+
+LK_BRANCH = "release/LA.BR.1.2.7-03810-8x16.0+rescue"
+LK_REVISION = "7647debfbe543a652f056d075b0fcaeb47cbde3b"
+LK_MACHINE = "dragonboard-410c"
+LK_FLAVOUR = "-sd-rescue"
+

--- a/recipes-bsp/lk/lk-db410c_git.bb
+++ b/recipes-bsp/lk/lk-db410c_git.bb
@@ -1,0 +1,6 @@
+require lk.inc
+
+LK_BRANCH = "release/LA.BR.1.2.7-03810-8x16.0"
+LK_REVISION = "0a10f81d847e005244cfa59d7f4dd8c6acfd82f6"
+LK_MACHINE = "dragonboard-410c"
+LK_FLAVOUR = ""

--- a/recipes-bsp/lk/lk-db820c-sd-rescue_git.bb
+++ b/recipes-bsp/lk/lk-db820c-sd-rescue_git.bb
@@ -1,0 +1,9 @@
+require lk.inc
+
+LK_BRANCH = "release/LA.HB.1.3.2-19600-8x96.0+rescue"
+LK_REVISION = "5f94a3cf27d6c6fa65efbad51f85d57df83efb28"
+LK_SOC = "msm8996"
+LK_MACHINE = "dragonboard-820c"
+LK_FLAVOUR = "-sd-rescue"
+
+EXTRA_OEMAKE += "VERIFIED_BOOT=1"

--- a/recipes-bsp/lk/lk-db820c_git.bb
+++ b/recipes-bsp/lk/lk-db820c_git.bb
@@ -1,0 +1,9 @@
+require lk.inc
+
+LK_BRANCH = "release/LA.HB.1.3.2-19600-8x96.0"
+LK_REVISION = "80e6b971bcb1d229ea90824b724b51398658c29a"
+LK_SOC = "msm8996"
+LK_MACHINE = "dragonboard-820c"
+LK_FLAVOUR = ""
+
+EXTRA_OEMAKE += "VERIFIED_BOOT=1"

--- a/recipes-bsp/lk/lk.inc
+++ b/recipes-bsp/lk/lk.inc
@@ -1,0 +1,42 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5a1abdab641eec675725c843f43f03af"
+
+LK_BRANCH ?= "master"
+LK_URI ?= "git://git.linaro.org/landing-teams/working/qualcomm/lk.git;protocol=https;branch=${LK_BRANCH};name=lk"
+LK_REVISION ?= "179191bda57a555ca1803e157a03d2f0d33fa3c5"
+LK_SOC ?= "msm8916"
+LK_BUILDARGS ?= "EMMC_BOOT=1 TOOLCHAIN_PREFIX=${WORKDIR}/gcc/bin/arm-eabi- LD=${WORKDIR}/gcc/bin/arm-eabi-ld NOECHO="
+LK_PV ?= "1.2.7-03810"
+
+LK_MACHINE ?= "none"
+LK_FLAVOUR ?= ""
+
+# Use the "original" gcc for now
+LK_GCC_URI ?= "git://git.codelinaro.org/clo/la/platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.8.git;protocol=https;name=gcc;subdir=gcc;nobranch=1"
+#caf_migration/LA.BR.1.1.3.c4
+LK_GCC_REVISION = "26e93f6af47f7bd3a9beb5c102a5f45e19bfa38a"
+
+SRC_URI = " \
+    ${LK_URI} \
+    ${LK_GCC_URI} \
+"
+SRCREV_lk = "${LK_REVISION}"
+SRCREV_gcc = "${LK_GCC_REVISION}"
+
+EXTRA_OEMAKE = "${LK_SOC} ${LK_BUILDARGS}"
+
+S = "${WORKDIR}/git"
+SRCREV_FORMAT = "lk_gcc"
+PV = "${LK_PV}+git${SRCPV}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${LK_MACHINE}
+    install -D -p -m644 ${S}/build-${LK_SOC}/emmc_appsboot.mbn ${DEPLOYDIR}/${LK_MACHINE}/emmc_appsboot${LK_FLAVOUR}-unsigned.mbn
+}
+
+addtask deploy before do_build after do_compile
+


### PR DESCRIPTION
Make another step for migrating db410c/db820c build fully to OE. Add
support for building LK bootloaders for these two machines.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>