### PR TITLE
Follow the ath10k and ath11k firmware packages split

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-qca6174', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-qcom-apq8096-audio \
     linux-firmware-qcom-apq8096-modem \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb3gen2 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k linux-firmware-qcom-qcs6490-wifi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcs6490-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-qcom-qcs6490-audio \
     linux-firmware-qcom-qcs6490-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6390', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8250-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8350-hdk \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8350-adreno \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8450-hdk.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a730 linux-firmware-qcom-sm8450-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8450-hdk \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8450-audio \

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,5 +8,5 @@ inherit ${ALTERNATIVES_CLASS}
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"
 
-ALTERNATIVE:${PN}-ath11k:qcom += "wcn6750-hw10-board-2"
+ALTERNATIVE:${PN}-ath11k-wcn6750:qcom += "wcn6750-hw10-board-2"
 ALTERNATIVE_LINK_NAME[wcn6750-hw10-board-2] = "${nonarch_base_libdir}/firmware/ath11k/WCN6750/hw1.0/board-2.bin"


### PR DESCRIPTION
Make individual packagegroups depend on the split ath10k / adht11k packages.