### PR TITLE
image_types_qcom: create image-specific subfolders

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -105,7 +105,9 @@ jobs:
           mkdir -p $build_dir
           img_dir=$build_dir/${{ matrix.machine }}
           [ -d $img_dir ] && rm -rf $img_dir
-          mv ../kas/build/tmp/deploy/images/${{matrix.machine}} $img_dir
+          deploy_dir=../kas/build/tmp/deploy/images/${{matrix.machine}}
+          find $deploy_dir/ -maxdepth 1 -name "*.rootfs*.qcomflash" -exec rm -rf {} \;
+          mv $deploy_dir $img_dir
 
           # Instruct our file server to make these files available for download
           url="${BASE_ARTIFACT_URL}/${{ matrix.machine }}/"

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -18,7 +18,7 @@ QCOM_DTB_FILE ?= "dtb.bin"
 QCOM_ROOTFS_FILE ?= "rootfs.img"
 IMAGE_QCOMFLASH_FS_TYPE ??= "ext4"
 
-QCOMFLASH_DIR = "${WORKDIR}/qcomflash"
+QCOMFLASH_DIR = "${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash"
 IMAGE_CMD:qcomflash = "create_qcomflash_pkg"
 do_image_qcomflash[dirs] = "${QCOMFLASH_DIR}"
 do_image_qcomflash[cleandirs] = "${QCOMFLASH_DIR}"
@@ -67,6 +67,9 @@ create_qcomflash_pkg() {
     for bfw in `find ${DEPLOY_DIR_IMAGE} -type f -name '*.elf' -o -name '*.mbn' -o -name '*.fv'`; do
         install -m 0644 ${bfw} .
     done
+
+    # Create symlink to ${QCOMFLASH_DIR} dir
+    ln -rsf ${QCOMFLASH_DIR} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash
 
     # Create qcomflash tarball
     ${IMAGE_CMD_TAR} --sparse --numeric-owner --transform="s,^\./,${IMAGE_BASENAME}-${MACHINE}/," -cf- . | gzip -f -9 -n -c --rsyncable > ${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash.tar.gz


### PR DESCRIPTION
Create image-specific subfolder in DEPLOY_DIR_IMAGE besides qcomflash tarball archive. This allows to run QDL for device flashing on that folder directly for local builds.