### PR TITLE
Update rb3gen2 partition conf and boot firmware with the qclinux 1.3 release

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00058.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00058.0.bb
@@ -4,13 +4,13 @@ LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-In
 
 COMPATIBLE_MACHINE = "qcm6490"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_integrationandtest_publictest"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCM6490_bootbinaries"
 
 SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries"
-SRC_URI[bootbinaries.sha256sum] = "5e597229af9103cfea5b398c7e83a05dd078a18af010a40f1b9adf92967d4c1e"
+SRC_URI[bootbinaries.sha256sum] = "08c0798f1ab9f380c94b54141847c7b365c87f2a072a2461779cf282809aeeb4"
 
 SRC_URI:append:qcs6490-rb3gen2-core-kit = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit"
 SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"

--- a/recipes-bsp/partition/qcom-partition-confs/qcm6490-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm6490-partitions.conf
@@ -25,11 +25,15 @@
 #This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
 --partition --lun=1 --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --lun=1 --name=xbl_b --size=3604KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE
+--partition --lun=1 --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548
 --partition --lun=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 2 - Boot LUN B
---partition --lun=2 --name=xbl_b --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98
---partition --lun=2 --name=xbl_config_b --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A
+--partition --lun=2 --name=xbl_a --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --lun=2 --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --lun=2 --name=xbl_b --size=3604KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE
+--partition --lun=2 --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548
 --partition --lun=2 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 3 - OTP LUN
@@ -37,7 +41,8 @@
 #Linux Android customers can ignore this requirement
 --partition --lun=3 --name=ALIGN_TO_128K_1 --size=104KB --type-guid=FDE1604B-D68B-4BD4-973D-962AE7A1ED88
 --partition --lun=3 --name=cdt --size=128KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1
---partition --lun=3 --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --lun=3 --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --lun=3 --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
 --partition --lun=3 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 4 - Protected Read-only LUN
@@ -46,47 +51,50 @@
 # These are the 'A' partition's needed for the A/B boot/ota update feature.
 # If you add something to this section remember to add it to B as well
 --partition --lun=4 --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2a1a52fc-aa0b-401c-a808-5ea0f91068f8 --filename=dtb.bin
---partition --lun=4 --name=dtb_b --size=65536KB --type-guid=a166f11a-2b39-4faa-b7e7-f8aa080d0587
+--partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
---partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
---partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
 --partition --lun=4 --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
 --partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
---partition --lun=4 --name=qupfw_a --size=80KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f --filename=qupv3fw.elf
+--partition --lun=4 --name=qupfw_a --size=80KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
 --partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
 --partition --lun=4 --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
 --partition --lun=4 --name=shrm_a --size=128KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
---partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9
 --partition --lun=4 --name=qweslicstore_a  --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8
 
 #These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 #For convinience sake we keep all the B partitions with the same GUID
 --partition --lun=4 --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896
+--partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
+--partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D
+--partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
 --partition --lun=4 --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E
---partition --lun=4 --name=hyp_b --size=8192KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D
+--partition --lun=4 --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E
 --partition --lun=4 --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=4 --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2
---partition --lun=4 --name=qupfw_b --size=80KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF
+--partition --lun=4 --name=qupfw_b --size=80KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C
 --partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165
 --partition --lun=4 --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687
 --partition --lun=4 --name=shrm_b --size=128KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836
---partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
 
 #These are non A/B partitions. In a A/B build these would not be updated via a OTA update
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
 --partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
+--partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9
 --partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
 --partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
 --partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
 --partition --lun=4 --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786
@@ -94,16 +102,14 @@
 --partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
 --partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
---partition --lun=4 --name=secdata --size=25KB --type-guid=76cfc7ef-039d-4e2c-b81e-4dd8c2cb2a93
---partition --lun=4 --name=quantumfv --size=512KB --type-guid=80c23c26-c3f9-4a19-bb38-1e457daceb09
---partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=e12d830b-7f62-4f0b-b48a-8178c5bf3ac1
+--partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09
+--partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
 --partition --lun=4 --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN
 #QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
---partition --lun=5 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891a3b7-0ccc-4705-bb53-2673cac193bd
 --partition --lun=5 --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
 --partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
 --partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB


### PR DESCRIPTION
PR to bring the latest partition conf and boot firmware from qclinux 1.3.

Relevant boot firmware changes:
- KVM support via xbl_config_kvm.elf
- UEFI variable runtime support (read-only since write requires RPMB)
- UEFI Capsule Update via capsule as file

As with qclinux 1.3, it requires UFS reprovisioning as described at https://docs.qualcomm.com/bundle/publicresource/topics/80-70017-253/set_up_the_device.html?vproduct=1601111740013072&version=1.3#ubuntu-machine