### PR TITLE
Fix support for QCS9100/SA8775p-ride-sx

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -75,7 +75,7 @@ jobs:
         machine:
           - qcm6490-idp
           - qcs6490-rb3gen2-core-kit
-          - sa8775p-ride-sx
+          - qcs9100-ride-sx
           - qcom-armv8a
           - qcom-armv7a
           - qcom-armv7a-modem

--- a/ci/qcs9100-ride-sx.yml
+++ b/ci/qcs9100-ride-sx.yml
@@ -5,4 +5,4 @@ header:
   includes:
   - ci/base.yml
 
-machine: sa8775p-ride-sx
+machine: qcs9100-ride-sx

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -1,13 +1,16 @@
 #@TYPE: Machine
-#@NAME: Qualcomm SA8775P Ride SX 4.0 Automotive Development Kit
-#@DESCRIPTION: Machine configuration for Qualcomm Ride SX development platform, with sa8775p
+#@NAME: Qualcomm QCS9100 Ride SX Beta Evaluation Kit (EVK)
+#@DESCRIPTION: Machine configuration for Qualcomm QCS9100 Ride SX Beta Evaluation Kit (EVK)
 
 require conf/machine/include/qcom-qcs9100.inc
 
 MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi"
 
 KERNEL_DEVICETREE ?= " \
+                      qcom/qcs9100-ride.dtb \
+                      qcom/qcs9100-ride-r3.dtb \
                       qcom/sa8775p-ride.dtb \
+                      qcom/sa8775p-ride-r3.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00006.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00006.0.bb
@@ -12,9 +12,9 @@ BOOTBINARIES = "QCS9100_bootbinaries"
 SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries"
 SRC_URI[bootbinaries.sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
 
-SRC_URI:append:sa8775p-ride-sx = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx.zip;downloadfilename=cdt-sa8775p-ride-sx_${PV}.zip;name=sa8775p-ride-sx"
-SRC_URI[sa8775p-ride-sx.sha256sum] = "f5e37d1260627e9d6976827ea5bdc7ffa81c90b7561acfccf24a94bc1313dea5"
+SRC_URI:append:qcs9100-ride-sx = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx.zip;downloadfilename=cdt-qcs9100-ride-sx_${PV}.zip;name=qcs9100-ride-sx"
+SRC_URI[qcs9100-ride-sx.sha256sum] = "f5e37d1260627e9d6976827ea5bdc7ffa81c90b7561acfccf24a94bc1313dea5"
 
-CDT_FILE:sa8775p-ride-sx ?= "cdt_ride_sx"
+CDT_FILE:qcs9100-ride-sx ?= "cdt_ride_sx"
 
 include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00058.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00058.0.bb
@@ -4,13 +4,13 @@ LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-In
 
 COMPATIBLE_MACHINE = "qcs9100"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_integrationandtest_publictest"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCS9100_bootbinaries"
 
 SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries"
-SRC_URI[bootbinaries.sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
+SRC_URI[bootbinaries.sha256sum] = "bd024ffe419f13b19907b285d0369bf9dfdf77b7e95052b9e4869957ddcaf07f"
 
 SRC_URI:append:qcs9100-ride-sx = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx.zip;downloadfilename=cdt-qcs9100-ride-sx_${PV}.zip;name=qcs9100-ride-sx"
 SRC_URI[qcs9100-ride-sx.sha256sum] = "f5e37d1260627e9d6976827ea5bdc7ffa81c90b7561acfccf24a94bc1313dea5"

--- a/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
@@ -20,11 +20,11 @@
 #   --sparse      false
 
 # This is LUN 0 - Guest VM(s) LUN"
---partition --lun=0 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891a3b7-0ccc-4705-bb53-2673cac193bd
---partition --lun=0 --name=reserved1_a --size=65536KB --type-guid=4ef7c492-d028-41c6-b47a-bbd33850cb31
---partition --lun=0 --name=reserved2_a --size=65536KB --type-guid=4e351956-aa2a-479e-b5f7-163da39f14f6
---partition --lun=0 --name=efi --size=524288KB --type-guid=c12a7328-f81f-11d2-ba4b-00a0c93ec93b --filename=efi.bin
---partition --lun=0 --name=rootfs --size=29390848KB --type-guid=b921b045-1df0-41c3-af44-4c6f280d3fae --filename=rootfs.img
+--partition --lun=0 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
+--partition --lun=0 --name=reserved1_a --size=65536KB --type-guid=4EF7C492-D028-41C6-B47A-BBD33850CB31
+--partition --lun=0 --name=reserved2_a --size=65536KB --type-guid=4E351956-AA2A-479E-B5F7-163DA39F14F6
+--partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --lun=0 --name=rootfs --size=29390848KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
@@ -43,7 +43,7 @@
 # This is LUN 3 - OTP LUN
 # QCOM development requirement: Ensure all partitions in LUN3 is a multiple of 128k
 # Linux Android customers can ignore this requirement
---partition --lun=3 --name=ALIGN_TO_128K_1 --size=104KB --type-guid=50d0abe4-f594-4641-981b-df602e400f34
+--partition --lun=3 --name=ALIGN_TO_128K_1 --size=104KB --type-guid=50D0ABE4-F594-4641-981B-DF602E400F34
 --partition --lun=3 --name=cdt --size=4KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1
 --partition --lun=3 --name=ddr --size=1600KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --lun=3 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
@@ -58,8 +58,8 @@
 --partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 --partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E
---partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2a1a52fc-aa0b-401c-a808-5ea0f91068f8 --filename=dtb.bin
---partition --lun=4 --name=dtb_b --size=65536KB --type-guid=a166f11a-2b39-4faa-b7e7-f8aa080d0587 --filename=dtb.bin
+--partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
 --partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
@@ -67,7 +67,7 @@
 --partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
 --partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
@@ -77,24 +77,24 @@
 --partition --lun=4 --name=usb4fw_a --size=61KB --type-guid=3FA03C7A-9FDC-498B-A2A8-DE11EE339790
 --partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=e42e2b4c-33b0-429b-b1ef-d341c547022c
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
 --partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
 --partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
 --partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=e7e5eff9-d224-4eb3-8f0b-1d2a4be18665
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
 --partition --lun=4 --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
---partition --lun=4 --name=secdata --size=128KB --type-guid=76cfc7ef-039d-4e2c-b81e-4dd8c2cb2a93
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=softsku --size=8KB --type-guid=69cfd37f-3d6b-48ed-9739-23015606be65
+--partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
 # - Below are PVM images
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06ef844e-08fc-494e-89eb-396d4d6c5b27
---partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989af30-5c02-4154-ad00-1d34c816cac1
---partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889c942-ff80-4da8-a5b8-3f32f285c0d8
---partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78ebfd49-e8b1-4e75-abc0-3f2dbc7428dd
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
+--partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
+--partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 # This is LUN 5 - Primary VM Read-write LUN
---partition --lun=5 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891a3b7-0ccc-4705-bb53-2673cac193bd
+--partition --lun=5 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
 # These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 # For convinience sake we keep all the B partitions with the same GUID
 --partition --lun=5 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
@@ -105,17 +105,17 @@
 --partition --lun=5 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=5 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
 --partition --lun=5 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
---partition --lun=5 --name=multiimgqti_b --size=32KB --type-guid=749e5def-7b57-4bc6-ab51-aaee077c2d56 --filename=multi_image_qti.mbn
+--partition --lun=5 --name=multiimgqti_b --size=32KB --type-guid=749E5DEF-7B57-4BC6-AB51-AAEE077C2D56 --filename=multi_image_qti.mbn
 --partition --lun=5 --name=imagefv_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf
---partition --lun=5 --name=gearvm_b --size=16000KB --type-guid=06ef844e-08fc-494e-89eb-396d4d6c5b27
+--partition --lun=5 --name=gearvm_b --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
 --partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 # This is LUN 6 - Protected Read-write LUN
---partition --lun=6 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891a3b7-0ccc-4705-bb53-2673cac193bd
+--partition --lun=6 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
 --partition --lun=6 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 # This is LUN 7 - Protected Read-write LUN
 --partition --lun=7 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=7 --name=ALIGN_TO_128K_4 --size=104KB --type-guid=6891a3b7-0ccc-4705-bb53-2673cac193bd
+--partition --lun=7 --name=ALIGN_TO_128K_4 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
 --partition --lun=7 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
 --partition --lun=7 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0

--- a/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
@@ -100,7 +100,7 @@
 --partition --lun=5 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --lun=5 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=5 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=5 --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=keymint.mbn
+--partition --lun=5 --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=5 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
 --partition --lun=5 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=5 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9

--- a/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcs9100-partitions.conf
@@ -19,62 +19,74 @@
 #   --readonly    true
 #   --sparse      false
 
-# This is LUN 0 - Guest VM(s) LUN"
---partition --lun=0 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
---partition --lun=0 --name=reserved1_a --size=65536KB --type-guid=4EF7C492-D028-41C6-B47A-BBD33850CB31
---partition --lun=0 --name=reserved2_a --size=65536KB --type-guid=4E351956-AA2A-479E-B5F7-163DA39F14F6
+# This is LUN 0 - HLOS LUN"
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=29390848KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
---partition --lun=1 --name=xbl_bkup_a --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE
---partition --lun=1 --name=xbl_config_a --size=516KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
---partition --lun=1 --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --lun=1 --name=xbl_b --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --lun=1 --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --lun=1 --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
 --partition --lun=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 # This is LUN 2 - Boot LUN B
---partition --lun=2 --name=xbl_b --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
---partition --lun=2 --name=xbl_bkup_b --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE
---partition --lun=2 --name=xbl_config_b --size=516KB --type-guid=A4CDBB5A-5A73-436E-B129-689EC01DBFE3 --filename=xbl_config.elf
---partition --lun=2 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --lun=2 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --lun=2 --name=xbl_b --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --lun=2 --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --lun=2 --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
 --partition --lun=2 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 # This is LUN 3 - OTP LUN
 # QCOM development requirement: Ensure all partitions in LUN3 is a multiple of 128k
-# Linux Android customers can ignore this requirement
---partition --lun=3 --name=ALIGN_TO_128K_1 --size=104KB --type-guid=50D0ABE4-F594-4641-981B-DF602E400F34
+--partition --lun=3 --name=ALIGN_TO_128K_1 --size=104KB --type-guid=FDE1604B-D68B-4BD4-973D-962AE7A1ED88
 --partition --lun=3 --name=cdt --size=4KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1
---partition --lun=3 --name=ddr --size=1600KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --lun=3 --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --lun=3 --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
 --partition --lun=3 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
-# This is LUN 4 - Primary VM Read-write LUN
-# QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
-# ****Linux Android customers can ignore this requirement ****
+# This is LUN 4 - Firmware LUN
+# These are the 'A' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 --partition --lun=4 --name=aop_a --size=256KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
+--partition --lun=4 --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
---partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
 --partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
---partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
---partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
---partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
 --partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
---partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
---partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
---partition --lun=4 --name=usb4fw_a --size=61KB --type-guid=3FA03C7A-9FDC-498B-A2A8-DE11EE339790
+--partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+# These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
+--partition --lun=4 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
+--partition --lun=4 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E --filename=XblRamdump.elf
+--partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --lun=4 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --lun=4 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
+--partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
+--partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
+--partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
+--partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
+--partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
+--partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+# These are non A/B partitions. In a A/B build these would not BE UPDATED VIA A OTA UPDATE
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
 --partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
 --partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
@@ -82,40 +94,14 @@
 --partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
 --partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
 --partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
 --partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
 # - Below are PVM images
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
 --partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
 --partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
 --partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
+--partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
-
-# This is LUN 5 - Primary VM Read-write LUN
---partition --lun=5 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
-# These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
-# For convinience sake we keep all the B partitions with the same GUID
---partition --lun=5 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
---partition --lun=5 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
---partition --lun=5 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=5 --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --lun=5 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
---partition --lun=5 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
---partition --lun=5 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
---partition --lun=5 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
---partition --lun=5 --name=multiimgqti_b --size=32KB --type-guid=749E5DEF-7B57-4BC6-AB51-AAEE077C2D56 --filename=multi_image_qti.mbn
---partition --lun=5 --name=imagefv_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf
---partition --lun=5 --name=gearvm_b --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
---partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
-
-# This is LUN 6 - Protected Read-write LUN
---partition --lun=6 --name=ALIGN_TO_128K_2 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
---partition --lun=6 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
-
-# This is LUN 7 - Protected Read-write LUN
---partition --lun=7 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=7 --name=ALIGN_TO_128K_4 --size=104KB --type-guid=6891A3B7-0CCC-4705-BB53-2673CAC193BD
---partition --lun=7 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=7 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0

--- a/recipes-bsp/partition/qcom-partition-confs_1.0.bb
+++ b/recipes-bsp/partition/qcom-partition-confs_1.0.bb
@@ -36,7 +36,7 @@ do_compile:prepend:qcs6490-rb3gen2-core-kit() {
     fixup_cdt
 }
 
-do_compile:prepend:sa8775p-ride-sx() {
+do_compile:prepend:qcs9100-ride-sx() {
     fixup_cdt
 }
 


### PR DESCRIPTION
Aligning the machine name with qclinux 1.2/1.3, which is now qcs9100-ride-sx (essentially the same, new naming) and bringing the latest partition configuration and boot firmware.

With these changes I'm able to boot my sa8775p/qcs9100-ride-sx with mainline.