### PR TITLE
CI: rework to enable optional meta-qcom-distro configs

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -12,10 +12,19 @@ defaults:
 repos:
   meta-qcom:
 
-  poky:
-    url: https://git.yoctoproject.org/git/poky
+  oe-core:
+    url: https://git.openembedded.org/openembedded-core
     layers:
       meta:
+
+  bitbake:
+    url: https://git.openembedded.org/bitbake
+    layers:
+      .: excluded
+
+  meta-yocto:
+    url: https://git.yoctoproject.org/git/meta-yocto
+    layers:
       meta-poky:
 
 local_conf_header:

--- a/ci/distro.yml
+++ b/ci/distro.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+distro: qcom-wayland
+
+repos:
+  meta-qcom-distro:
+    url: https://github.com/qualcomm-linux/meta-qcom-distro
+    branch: main

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -15,7 +15,7 @@ CMD="$CMD $TOPDIR"
 # Disable auto layer discovery
 CMD="$CMD --no-auto"
 # Layers to process for dependencies
-CMD="$CMD --dependency $KAS_WORK_DIR/poky/meta"
+CMD="$CMD --dependency $KAS_WORK_DIR/oe-core/meta"
 # Disable automatic testing of dependencies
 CMD="$CMD --no-auto-dependency"
 # Set machines to all machines defined in this BSP layer

--- a/ci/yocto-patchreview.sh
+++ b/ci/yocto-patchreview.sh
@@ -9,7 +9,7 @@ TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
 export KAS_WORK_DIR=$(realpath ${KAS_WORK_DIR:-$(mktemp -d)})
 
 echo "Running kas in $KAS_WORK_DIR"
-kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/poky/scripts/contrib/patchreview.py -v -b -j status.json $TOPDIR"
+kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/oe-core/scripts/contrib/patchreview.py -v -b -j status.json $TOPDIR"
 
 # return an error if any malformed patch is found
 cat $KAS_WORK_DIR/build/status.json |


### PR DESCRIPTION
Consume the upstream repos directly, not through the combo repo.