### PR TITLE
Follow QCA firmware packages split

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-sdm845-modem', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x linux-firmware-qcom-sdm845-modem', '', d)} \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \
     linux-firmware-qcom-venus-5.2 \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
@@ -6,7 +6,7 @@ RRECOMMENDS:${PN} += " \
     firmware-qcom-rb3gen2 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcs6490-wifi', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \
     linux-firmware-qcom-qcs6490-audio \
     linux-firmware-qcom-qcs6490-compute \
     linux-firmware-qcom-vpu \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6390', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6390', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8250-audio \
     linux-firmware-qcom-sm8250-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-sm8150-hdk \
     linux-firmware-qcom-sm8150-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8350-hdk \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8450-hdk.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a730 linux-firmware-qcom-sm8450-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8450-hdk \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8550-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8550-hdk.bb
@@ -2,7 +2,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a740 linux-firmware-qcom-sm8550-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     firmware-qcom-sm8550-hdk \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8650-hdk.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-g790 linux-firmware-qcom-sm8650-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     firmware-qcom-sm8650-hdk \
     linux-firmware-lt9611uxc \


### PR DESCRIPTION
OE-Core has split single `linux-firmware-qca` package into smaller packages. Follow the split and select only required firmware packages for the Qualcomm boards. 