### PR TITLE
initramfs-test-image: add v4l-utils package

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -52,6 +52,7 @@ PACKAGE_INSTALL_openembedded-layer += " \
     lmsensors-sensors \
     media-ctl \
     read-edid \
+    v4l-utils \
     yavta \
 "
 


### PR DESCRIPTION
The v4l-utils package contains a set of utils useful to test and debug V4L2 devices, CEC devices and (in the next release branch) will get the edid-decode binary. Add the v4l-utils package to the list of packages included into the initramfs-test-image.

Drawback: the image grows by about 850 KBytes.