### PR TITLE
Add BSP selection support to machine conf

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -1,5 +1,11 @@
 # Common configurations and variables for Qualcomm platforms.
 
+# Supported BSP selections are: base, custom.
+# Specific MACHINEs or DISTROs may change this
+# selection as needed in their configuration.
+QCOM_SELECTED_BSP ??= "none"
+MACHINEOVERRIDES =. "${@bb.utils.contains_any('QCOM_SELECTED_BSP', 'base custom', 'qcom-${QCOM_SELECTED_BSP}-bsp:', '', d)}"
+
 # Provider for linux kernel
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 


### PR DESCRIPTION
For better configuration of QCOM BSP, introduce BSP selection support with valid selections being ‘base’ and ‘custom’. While neither of these is the default offering, MACHINEs or DISTROs may change the BSP selection as needed. 

For example add following in machine.conf to choose 'base' BSP support. 
QCOM_SELECTED_BSP = "base"