### PR TITLE
Add BSP selection support, linux-qcom 6.12 recipe, and use them in qcs6490-rb3gen2-core-kit compilation

### DIFF
--- a/ci/override-qcom-base-bsp.yml
+++ b/ci/override-qcom-base-bsp.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+local_conf_header:
+  bspoverride: |
+    QCOM_SELECTED_BSP = "base"

--- a/ci/override-qcom-custom-bsp.yml
+++ b/ci/override-qcom-custom-bsp.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+local_conf_header:
+  bspoverride: |
+    QCOM_SELECTED_BSP = "custom"

--- a/ci/qcs6490-rb3gen2-core-kit-base.yml
+++ b/ci/qcs6490-rb3gen2-core-kit-base.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/qcm6490.yml
+  - ci/override-qcom-base-bsp.yml
+
+machine: qcs6490-rb3gen2-core-kit

--- a/ci/qcs6490-rb3gen2-core-kit-custom.yml
+++ b/ci/qcs6490-rb3gen2-core-kit-custom.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/qcm6490.yml
+  - ci/override-qcom-custom-bsp.yml
+
+machine: qcs6490-rb3gen2-core-kit

--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -9,6 +9,7 @@ MACHINEOVERRIDES =. "${@bb.utils.contains('QCOM_SELECTED_BSP', 'custom', 'qcom-b
 
 # Provider for linux kernel
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
+PREFERRED_PROVIDER_virtual/kernel:qcom-base-bsp ?= "linux-qcom"
 
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_IMAGETYPES ?= "Image.gz"

--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -1,5 +1,12 @@
 # Common configurations and variables for Qualcomm platforms.
 
+# Supported BSP selections are: 'base', 'custom'. Where 'custom' selection is an overlay on top of 
+# 'base'.i.e. with 'custom' BSP selection both base & custom overrides come into effect.
+# Specific MACHINEs or DISTROs may change this selection as needed in their configuration.
+QCOM_SELECTED_BSP ??= "none"
+MACHINEOVERRIDES =. "${@bb.utils.contains('QCOM_SELECTED_BSP', 'base', 'qcom-base-bsp:', '', d)}"
+MACHINEOVERRIDES =. "${@bb.utils.contains('QCOM_SELECTED_BSP', 'custom', 'qcom-base-bsp:qcom-custom-bsp:', '', d)}"
+
 # Provider for linux kernel
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -10,6 +10,10 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       "
 
+KERNEL_DEVICETREE:qcom-custom-bsp ?= " \
+                      qcom/qcs6490-addons-rb3gen2.dtb \
+                      "
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     linux-firmware-qcom-adreno-a660 \
     linux-firmware-qcom-qcm6490-adreno \

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -14,9 +14,15 @@ KERNEL_DEVICETREE:qcom-custom-bsp ?= " \
                       qcom/qcs6490-addons-rb3gen2.dtb \
                       "
 
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+MACHINE_FIRMWARE_PKGS ?= " \
     linux-firmware-qcom-adreno-a660 \
     linux-firmware-qcom-qcm6490-adreno \
     linux-firmware-qcom-qcm6490-audio \
     linux-firmware-qcom-qcm6490-compute \
 "
+
+MACHINE_FIRMWARE_PKGS:qcom-custom-bsp ?= " \
+    packagegroup-firmware-rb3gen2 \
+"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${MACHINE_FIRMWARE_PKGS}"

--- a/recipes-kernel/linux/linux-qcom-headers_6.12.bb
+++ b/recipes-kernel/linux/linux-qcom-headers_6.12.bb
@@ -1,0 +1,68 @@
+SECTION = "kernel"
+
+DESCRIPTION = "Linux ${PV} kernel headers required to build userspace."
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+inherit kernel-arch
+
+COMPATIBLE_MACHINE = "(qcom)"
+
+LINUX_QCOM_GIT ?= "git://git.codelinaro.org/clo/la/kernel/qcom.git;protocol=https"
+SRCBRANCH ?= "qclinux.6.12.y"
+SRC_URI = "${LINUX_QCOM_GIT};branch=${SRCBRANCH}"
+
+SRCREV = "608736233891ff0d6575f440d94cc2c821a7b87f"
+PV = "6.12+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "flex-native bison-native rsync-native"
+
+do_configure[noexrec] = "1"
+do_compile[noexec] = "1"
+
+do_install () {
+    cd ${B}
+    headerdir=${B}/headers
+    kerneldir=${D}${includedir}/linux-kernel-qcom
+    install -d $kerneldir
+
+    # Install all headers inside B and copy only required ones to D
+    oe_runmake_call -C ${B} ARCH=${ARCH} headers_install O=$headerdir
+
+    if [ -d $headerdir/include/generated ]; then
+        mkdir -p $kerneldir/include/generated/
+        cp -fR $headerdir/include/generated/* $kerneldir/include/generated/
+    fi
+
+    if [ -d $headerdir/arch/${ARCH}/include/generated ]; then
+        mkdir -p $kerneldir/arch/${ARCH}/include/generated/
+        cp -fR $headerdir/arch/${ARCH}/include/generated/* $kerneldir/arch/${ARCH}/include/generated/
+    fi
+
+    if [ -d $headerdir/${includedir} ]; then
+        mkdir -p $kerneldir/${includedir}
+        cp -fR $headerdir/${includedir}/* $kerneldir/${includedir}
+    fi
+
+    # Remove .install and .cmd files
+    find $kerneldir/ -type f -name .install | xargs rm -f
+    find $kerneldir/ -type f -name "*.cmd" | xargs rm -f
+}
+
+# kernel headers are generally machine specific
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Allow to build empty main package, to include -dev package into the SDK
+ALLOW_EMPTY_${PN} = "1"
+
+FILES_${PN}-dev += "linux-qcom/*"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+python () {
+    mach_overrides = d.getVar('MACHINEOVERRIDES').split(":")
+    if ('qcom-custom-bsp' not in mach_overrides):
+        raise bb.parse.SkipRecipe("linux-qcom-headers are compatible only with qcom-custom-bsp")
+}

--- a/recipes-kernel/linux/linux-qcom/0001-QCLINUX-soc-qcom-ice-Type-cast-return-error-code-as-.patch
+++ b/recipes-kernel/linux/linux-qcom/0001-QCLINUX-soc-qcom-ice-Type-cast-return-error-code-as-.patch
@@ -1,0 +1,41 @@
+From e06b31ea954e8908a9a81d5c5c6c4da4239df7a8 Mon Sep 17 00:00:00 2001
+From: Shivendra Pratap <quic_spratap@quicinc.com>
+Date: Tue, 11 Feb 2025 21:52:52 +0530
+Subject: [PATCH] QCLINUX: soc: qcom: ice: Type cast return error code as per
+ return type
+
+Type cast base pointer as per return type of the function. Change
+PTR_ERR(base) with ERR_CAST(base) to match return type of the
+function.
+
+Signed-off-by: Shivendra Pratap <quic_spratap@quicinc.com>
+
+Upstream-Status: Pending
+---
+ drivers/soc/qcom/ice.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/soc/qcom/ice.c b/drivers/soc/qcom/ice.c
+index 976e572a4888..12a9f7c5d971 100644
+--- a/drivers/soc/qcom/ice.c
++++ b/drivers/soc/qcom/ice.c
+@@ -5,6 +5,7 @@
+  * Copyright (c) 2013-2019, The Linux Foundation. All rights reserved.
+  * Copyright (c) 2019, Google LLC
+  * Copyright (c) 2023, Linaro Limited
++ * Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/bitfield.h>
+@@ -632,7 +633,7 @@ struct qcom_ice *of_qcom_ice_get(struct device *dev)
+ 	base = devm_platform_ioremap_resource(pdev, 0);
+ 	if (IS_ERR(base)) {
+ 		dev_warn(&pdev->dev, "ICE registers not found\n");
+-		return PTR_ERR(base);
++		return ERR_CAST(base);
+ 	}
+ 
+ 	ice = qcom_ice_create(&pdev->dev, base);
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-qcom_6.12.bb
+++ b/recipes-kernel/linux/linux-qcom_6.12.bb
@@ -1,0 +1,73 @@
+SECTION = "kernel"
+
+DESCRIPTION = "Linux ${PV} kernel for QCOM devices"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+inherit kernel
+
+COMPATIBLE_MACHINE = "(qcom)"
+
+LINUX_QCOM_GIT ?= "git://git.codelinaro.org/clo/la/kernel/qcom.git;protocol=https"
+SRCBRANCH ?= "qclinux.6.12.y"
+SRC_URI = "${LINUX_QCOM_GIT};branch=${SRCBRANCH}"
+
+SRCREV = "608736233891ff0d6575f440d94cc2c821a7b87f"
+PV = "6.12+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+KERNEL_CONFIG ??= "qcom_defconfig"
+
+# Additional configs for qcom custom variant kernel.
+KERNEL_CONFIG_FRAGMENTS:append:qcom-custom-bsp = " ${S}/arch/arm64/configs/qcom_addons.config"
+
+kernel_conf_variable() {
+    sed -e "/CONFIG_$1[ =]/d;" -i ${B}/.config
+    if test "$2" = "n"
+    then
+        echo "# CONFIG_$1 is not set" >> ${B}/.config
+    else
+        echo "CONFIG_$1=$2" >> ${B}/.config
+    fi
+}
+
+do_configure:prepend() {
+    if [ ! -f "${S}/arch/${ARCH}/configs/${KERNEL_CONFIG}" ]; then
+        bbfatal "KERNEL_CONFIG '${KERNEL_CONFIG}' was specified, but not present in the source tree"
+    else
+        cp '${S}/arch/${ARCH}/configs/${KERNEL_CONFIG}' '${B}/.config'
+    fi
+
+    # Check for kernel config fragments.  The assumption is that the config
+    # fragment will be specified with the absolute path.  For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one.  If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]
+    then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}
+        do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]
+            then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+}
+
+do_configure:append() {
+    oe_runmake -C ${S} O=${B} savedefconfig && cp ${B}/defconfig ${WORKDIR}/defconfig.saved
+}

--- a/recipes-kernel/linux/linux-qcom_6.12.bb
+++ b/recipes-kernel/linux/linux-qcom_6.12.bb
@@ -12,6 +12,9 @@ LINUX_QCOM_GIT ?= "git://git.codelinaro.org/clo/la/kernel/qcom.git;protocol=http
 SRCBRANCH ?= "qclinux.6.12.y"
 SRC_URI = "${LINUX_QCOM_GIT};branch=${SRCBRANCH}"
 
+# Patch to address a compilation issue in ice driver with GCC 14.2
+SRC_URI:append = " file://0001-QCLINUX-soc-qcom-ice-Type-cast-return-error-code-as-.patch"
+
 SRCREV = "608736233891ff0d6575f440d94cc2c821a7b87f"
 PV = "6.12+git${SRCPV}"
 


### PR DESCRIPTION
For better configuration of QCOM BSP, This PR introduces BSP selection support with valid selections being ‘base’ and ‘custom’. While neither of these is the default offering, MACHINEs or DISTROs may change the BSP selection as needed.
For example add following in machine.conf to choose 'base' BSP support.
QCOM_SELECTED_BSP = "base"

This PR also add a recipe to compile linux-qcom 6.12 kernel and demonstrates how base and custom BSP variant overrides can be setup on a same machine to choose device tree and defconfig fragments. When none of the BSP overrides are set effectively linux-yocto-dev is built.

This PR also updated firmware selection loigc based on 'base' and 'custom' BSP variant in use.