### PR TITLE
Fix default vfat sector size for the UFS devices and partitions

### DIFF
--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -17,7 +17,7 @@ do_qcom_dtbbin_deploy() {
         dtb_base_name=`basename $dtb .$dtb_ext`
         mkdir -p ${DTBBIN_DEPLOYDIR}/$dtb_base_name
         cp ${D}/${KERNEL_DTBDEST}/$dtb_base_name.dtb ${DTBBIN_DEPLOYDIR}/$dtb_base_name/combined-dtb.dtb
-        mkfs.vfat $@ -C ${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat ${DTBBIN_SIZE}
+        mkfs.vfat -C ${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat ${DTBBIN_SIZE}
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat" -vsmpQ ${DTBBIN_DEPLOYDIR}/$dtb_base_name/* ::/
         rm -rf ${DTBBIN_DEPLOYDIR}/$dtb_base_name
     done

--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -17,7 +17,7 @@ do_qcom_dtbbin_deploy() {
         dtb_base_name=`basename $dtb .$dtb_ext`
         mkdir -p ${DTBBIN_DEPLOYDIR}/$dtb_base_name
         cp ${D}/${KERNEL_DTBDEST}/$dtb_base_name.dtb ${DTBBIN_DEPLOYDIR}/$dtb_base_name/combined-dtb.dtb
-        mkfs.vfat -C ${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat ${DTBBIN_SIZE}
+        mkfs.vfat -S ${QCOM_VFAT_SECTOR_SIZE} -C ${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat ${DTBBIN_SIZE}
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat" -vsmpQ ${DTBBIN_DEPLOYDIR}/$dtb_base_name/* ::/
         rm -rf ${DTBBIN_DEPLOYDIR}/$dtb_base_name
     done

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -32,6 +32,9 @@ IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "4096"
 
+# Default vfat sector size to 4096, compatible with UFS
+QCOM_VFAT_SECTOR_SIZE ??= "4096"
+
 # Default serial console for QCOM devices
 SERIAL_CONSOLES ?= "115200;ttyMSM0"
 

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -13,9 +13,7 @@ inherit image
 IMAGE_FSTYPES = "vfat"
 IMAGE_FSTYPES_DEBUGFS = ""
 
-# UFS requires vfat sector size of 4096 (default is 512)
-VFAT_SECTOR_SIZE ?= "4096"
-EXTRA_IMAGECMD:vfat += " -S ${VFAT_SECTOR_SIZE}"
+EXTRA_IMAGECMD:vfat += " -S ${QCOM_VFAT_SECTOR_SIZE}"
 
 # Align image size with the expected partition size (512MB)
 IMAGE_ROOTFS_SIZE = "524288"


### PR DESCRIPTION
Set default vfat sector size for UFS devices and partitions.