### PR TITLE
packagegroup-firmware-dragonboard-820c: use split qca fw package

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-qca6174', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-serial', '', d)} \
     linux-firmware-qcom-apq8096-audio \
     linux-firmware-qcom-apq8096-modem \
     linux-firmware-qcom-venus-4.2 \


### PR DESCRIPTION
Follow the qca firmware package split and RRECOMMEND only the linux-firmware-qca-qca61x4-serial package.