### PR TITLE
RB3 gen2: enable more hardware

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -24,6 +24,22 @@ PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"
 
 PREFERRED_VERSION_linux-yocto ?= "6.12%"
 
+# Add a default set of upstream kernel modules that are needed to make
+# the included hardware work in core-image-* derivatives. Since they end
+# up as runtime recommendations for the package manager, the build will
+# succeed if they are missing, this is behaviour both desired and by
+# design.
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+	kernel-module-fastrpc \
+	kernel-module-msm \
+	kernel-module-qcom-stats \
+	kernel-module-rtc-pm8xxx \
+	kernel-module-venus-dec \
+	kernel-module-venus-enc \
+	"
+
+
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -11,8 +11,5 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    linux-firmware-qcom-adreno-a660 \
-    linux-firmware-qcom-qcm6490-adreno \
-    linux-firmware-qcom-qcm6490-audio \
-    linux-firmware-qcom-qcm6490-compute \
+    packagegroup-firmware-rb3gen2 \
 "

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -11,5 +11,35 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-module-ath11k-ahb \
+    kernel-module-camcc-sc7280 \
+    kernel-module-crct10dif-ce \
+    kernel-module-dispcc-sc7280 \
+    kernel-module-display-connector \
+    kernel-module-gpucc-sc7280 \
+    kernel-module-i2c-qcom-geni \
+    kernel-module-icc-bwmon \
+    kernel-module-icc-osm-l3 \
+    kernel-module-lontium-lt9611uxc \
+    kernel-module-lpassaudiocc-sc7280 \
+    kernel-module-nb7vpq904m \
+    kernel-module-nvmem-qcom-spmi-sdam \
+    kernel-module-nvmem-reboot-mode \
+    kernel-module-phy-qcom-qmp-combo \
+    kernel-module-phy-qcom-snps-femto-v \
+    kernel-module-pinctrl-sc7280-lpass-lpi \
+    kernel-module-pmic-glink-altmode \
+    kernel-module-qcom-pd-mapper \
+    kernel-module-qcom-pon \
+    kernel-module-qcom-q6v5-pas \
+    kernel-module-qcom-rng \
+    kernel-module-qcom-spmi-adc5 \
+    kernel-module-qcom-spmi-temp-alarm \
+    kernel-module-qcrypto \
+    kernel-module-qrtr-smd \
+    kernel-module-rpmsg-ctrl \
+    kernel-module-snd-soc-hdmi-codec \
+    kernel-module-ucsi-glink \
+    kernel-module-videocc-sc7280 \
     packagegroup-firmware-rb3gen2 \
 "


### PR DESCRIPTION
The machine configs in meta-qcom don't enable all hardware by default, this PR makes wifi work for core-image-* and enables `pci` as `MACHINE_FEATURE`.