### PR TITLE
Pick up Bluetooth firmware for RB1 and RB2 boards

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qcm2290-wifi ', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3950', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm2290-audio \
     linux-firmware-qcom-qcm2290-modem \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qrb4210-wifi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3988', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qrb4210-audio \
     linux-firmware-qcom-qrb4210-compute \


### PR DESCRIPTION
Make firmware packagegroups for RB1 and RB2 boards select necessary Bluetooth firmware.