### PR TITLE
packagegroup-firmware-rb1: select A702 firmware package

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
@@ -3,7 +3,7 @@ SUMMARY = "Firmware packages for the RB1 Robotics platform"
 inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-qcm2290-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qcm2290-wifi ', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm2290-audio \


### PR DESCRIPTION
Correct c&p error, RB1 (qrb2210) has the Adreno 702, which uses linux-firmware-qcom-adreno-a702 instead of -a630. Select the correct firmware package.