### PR TITLE
Rework MACHINE_FEATURES

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -1,6 +1,9 @@
 SOC_FAMILY:prepend = "qcom:"
 require conf/machine/include/soc-family.inc
 
+# Set a default set of MACHINE_FEATURES, indivudual MACHINEs can append it
+MACHINE_FEATURES = "alsa bluetooth usbgadget ushbost wifi"
+
 XSERVER_OPENGL ?= " \
     xf86-video-modesetting \
     xserver-xorg-extension-glx \

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
+MACHINE_FEATURES += "efi pci"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \

--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -17,7 +17,7 @@ require conf/machine/include/arm/armv7a/tune-cortexa15.inc
 # Android boot image settings
 QCOM_BOOTIMG_PAGE_SIZE = "2048"
 
-MACHINE_FEATURES = "alsa screen alsa bluetooth ext2 ext3 opengl usb usbhost usbgadget"
+MACHINE_FEATURES += "screen ext2 ext3 opengl usb"
 
 KERNEL_IMAGETYPE ?= "zImage"
 KERNEL_DEVICETREE ?= " \

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -1,7 +1,7 @@
 require conf/machine/include/qcom-common.inc
 require conf/machine/include/arm/arch-armv8a.inc
 
-MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
+MACHINE_FEATURES += "screen ext2"
 
 # UFS partitions in 820/845/RB5 setup with 4096 logical sector size
 EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES += "efi"
+MACHINE_FEATURES += "efi pci"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
+MACHINE_FEATURES += "efi"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi"
+MACHINE_FEATURES += "efi"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs9100-ride.dtb \

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi"
+MACHINE_FEATURES += "efi pci"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs9100-ride.dtb \


### PR DESCRIPTION
Pulled out from #756, this PR puts all common `MACHINE_FEATURES` in qcom-common.inc and adds `pci` to RB3.