### PR TITLE
Revert "linux-firmware: make qcom-qcm6490-wifi package provide -qcs64…

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -7,6 +7,3 @@ inherit ${ALTERNATIVES_CLASS}
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"
-
-# temporal workaround until this RPROVIDES is merged into OE-Core
-RPROVIDES:${PN}-qcom-qcm6490-wifi:qcom = "${PN}-qcom-qcs6490-wifi"


### PR DESCRIPTION
…90-"

This reverts commit 48c05f0fdd70 ("linux-firmware: make qcom-qcm6490-wifi package provide -qcs6490-"). Corresponding change has been merged to OE-Core.