### PR TITLE
Install Sensors DSP firmware for RB3 and RB5 boards

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
@@ -13,10 +13,12 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x linux-firmware-qcom-sdm845-modem', '', d)} \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \
+    linux-firmware-qcom-sdm845-thundercomm-db845c-sensors \
     linux-firmware-qcom-venus-5.2 \
 "
 
 RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-db845c-adsp \
     hexagon-dsp-binaries-thundercomm-db845c-cdsp \
+    hexagon-dsp-binaries-thundercomm-db845c-sdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb5.bb
@@ -14,10 +14,12 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8250-audio \
     linux-firmware-qcom-sm8250-compute \
+    linux-firmware-qcom-sm8250-thundercomm-rb5-sensors \
     linux-firmware-qcom-vpu \
 "
 
 RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb5-adsp \
     hexagon-dsp-binaries-thundercomm-rb5-cdsp \
+    hexagon-dsp-binaries-thundercomm-rb5-sdsp \
 "


### PR DESCRIPTION
Pull in SLPI firmware for the RB3 and RB5 boards.
While the upstream kernel doesn't yet enable those DSP, installing the firmware helps with the experiments.