### PR TITLE
Restructure packagegroups

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -67,11 +67,11 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
-    packagegroup-firmware-dragonboard410c \
-    packagegroup-firmware-dragonboard820c \
-    packagegroup-firmware-dragonboard845c \
-    packagegroup-firmware-rb1 \
-    packagegroup-firmware-rb2 \
-    packagegroup-firmware-rb3gen2 \
-    packagegroup-firmware-rb5 \
+    packagegroup-dragonboard410c-firmware \
+    packagegroup-dragonboard820c-firmware \
+    packagegroup-dragonboard845c-firmware \
+    packagegroup-rb1-firmware \
+    packagegroup-rb2-firmware \
+    packagegroup-rb3gen2-firmware \
+    packagegroup-rb5-firmware \
 "

--- a/recipes-bsp/images/initramfs-firmware-db8074-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-db8074-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Dragonboard APQ8074 firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-dragonboard-apq8074 \
+    packagegroup-dragonboard-apq8074-firmware \
 "
 
 require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-dragonboard820c-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-dragonboard820c-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Dragonboard 820c firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-dragonboard820c \
+    packagegroup-dragonboard820c-firmware \
 "
 
 require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-image.bb
@@ -4,13 +4,13 @@ DESCRIPTION = "Tiny ramdisk image with firmware files"
 PACKAGE_INSTALL = ""
 
 PACKAGE_INSTALL:qcom-armv8a = " \
-    packagegroup-firmware-dragonboard410c \
-    packagegroup-firmware-dragonboard820c \
-    packagegroup-firmware-dragonboard845c \
-    packagegroup-firmware-rb1 \
-    packagegroup-firmware-rb2 \
-    packagegroup-firmware-rb3gen2 \
-    packagegroup-firmware-rb5 \
+    packagegroup-dragonboard410c-firmware \
+    packagegroup-dragonboard820c-firmware \
+    packagegroup-dragonboard845c-firmware \
+    packagegroup-rb1-firmware \
+    packagegroup-rb2-firmware \
+    packagegroup-rb3gen2-firmware \
+    packagegroup-rb5-firmware \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "
 

--- a/recipes-bsp/images/initramfs-firmware-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-image.bb
@@ -14,17 +14,4 @@ PACKAGE_INSTALL:qcom-armv8a = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "
 
-BAD_RECOMMENDATIONS = " \
-    hexagon-dsp-binaries-qcom-db820c-adsp \
-    hexagon-dsp-binaries-thundercomm-db845c-adsp \
-    hexagon-dsp-binaries-thundercomm-db845c-cdsp \
-    hexagon-dsp-binaries-thundercomm-db845c-sdsp \
-    hexagon-dsp-binaries-thundercomm-rb1-adsp \
-    hexagon-dsp-binaries-thundercomm-rb2-adsp \
-    hexagon-dsp-binaries-thundercomm-rb2-cdsp \
-    hexagon-dsp-binaries-thundercomm-rb5-adsp \
-    hexagon-dsp-binaries-thundercomm-rb5-cdsp \
-    hexagon-dsp-binaries-thundercomm-rb5-sdsp \
-"
-
 require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -7,28 +7,28 @@ PACKAGE_INSTALL = " \
 
 # Qualcomm Dragonboard / Robotics platforms
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-dragonboard-apq8074 \
-    packagegroup-firmware-dragonboard410c \
-    packagegroup-firmware-dragonboard820c \
-    packagegroup-firmware-dragonboard845c \
-    packagegroup-firmware-rb1 \
-    packagegroup-firmware-rb2 \
-    packagegroup-firmware-rb3gen2 \
-    packagegroup-firmware-rb5 \
+    packagegroup-dragonboard-apq8074-firmware \
+    packagegroup-dragonboard410c-firmware \
+    packagegroup-dragonboard820c-firmware \
+    packagegroup-dragonboard845c-firmware \
+    packagegroup-rb1-firmware \
+    packagegroup-rb2-firmware \
+    packagegroup-rb3gen2-firmware \
+    packagegroup-rb5-firmware \
 "
 
 # Qualcomm HDKs
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8150-hdk \
-    packagegroup-firmware-sm8350-hdk \
-    packagegroup-firmware-sm8450-hdk \
-    packagegroup-firmware-sm8550-hdk \
-    packagegroup-firmware-sm8650-hdk \
+    packagegroup-sm8150-hdk-firmware \
+    packagegroup-sm8350-hdk-firmware \
+    packagegroup-sm8450-hdk-firmware \
+    packagegroup-sm8550-hdk-firmware \
+    packagegroup-sm8650-hdk-firmware \
 "
 
 # Other Qualcomm DevKits
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-qar2130p \
+    packagegroup-qar2130p-firmware \
 "
 
 require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -15,6 +15,12 @@ PACKAGE_INSTALL += " \
     packagegroup-rb2-firmware \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb5-firmware \
+    packagegroup-dragonboard820c-hexagon-dsp-binaries \
+    packagegroup-dragonboard845c-hexagon-dsp-binaries \
+    packagegroup-rb1-hexagon-dsp-binaries \
+    packagegroup-rb2-hexagon-dsp-binaries \
+    packagegroup-rb3gen2-hexagon-dsp-binaries \
+    packagegroup-rb5-hexagon-dsp-binaries \
 "
 
 # Qualcomm HDKs

--- a/recipes-bsp/images/initramfs-firmware-qar2130p-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-qar2130p-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with QAR2130P devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-qar2130p \
+    packagegroup-qar2130p-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-rb12-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-rb12-image.bb
@@ -6,9 +6,6 @@ PACKAGE_INSTALL += " \
 "
 
 BAD_RECOMMENDATIONS = " \
-    hexagon-dsp-binaries-thundercomm-rb1-adsp \
-    hexagon-dsp-binaries-thundercomm-rb2-adsp \
-    hexagon-dsp-binaries-thundercomm-rb2-cdsp \
     linux-firmware-qcom-venus-6.0 \
 "
 

--- a/recipes-bsp/images/initramfs-firmware-rb12-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-rb12-image.bb
@@ -1,8 +1,8 @@
 DESCRIPTION = "Tiny ramdisk image with RB1/RB2 devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-rb1 \
-    packagegroup-firmware-rb2 \
+    packagegroup-rb1-firmware \
+    packagegroup-rb2-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-sm8150-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8150-hdk-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SM8150 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8150-hdk \
+    packagegroup-sm8150-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-sm8350-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8350-hdk-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SM8350 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8350-hdk \
+    packagegroup-sm8350-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-sm8450-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8450-hdk-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SM8450 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8450-hdk \
+    packagegroup-sm8450-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-sm8550-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8550-hdk-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SM8550 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8550-hdk \
+    packagegroup-sm8550-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-sm8650-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8650-hdk-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SM8650 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sm8650-hdk \
+    packagegroup-sm8650-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard-apq8074.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard-apq8074.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the Dragonboard APQ8074 board"
+SUMMARY = "Packages for the Dragonboard APQ8074 board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard-apq8074.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard-apq8074.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the Dragonboard APQ8074 board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
     linux-firmware-qcom-apq8074-audio \
     linux-firmware-qcom-apq8074-modem \

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard410c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard410c.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the DragonBoard 410c board"
+SUMMARY = "Packages for the DragonBoard 410c board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard410c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard410c.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the DragonBoard 410c board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-qcom-apq8016-wifi', '', d)} \
     linux-firmware-qcom-apq8016-modem \

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the DragonBoard 820c board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-qca6174', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-serial', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the DragonBoard 820c board"
+SUMMARY = "Packages for the DragonBoard 820c board"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -13,5 +14,8 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-apq8096-audio \
     linux-firmware-qcom-apq8096-modem \
     linux-firmware-qcom-venus-4.2 \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-db820c-adsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the DragonBoard 845c board"
+SUMMARY = "Packages for the DragonBoard 845c board"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -13,6 +14,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \
     linux-firmware-qcom-venus-5.2 \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-db845c-adsp \
     hexagon-dsp-binaries-thundercomm-db845c-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the DragonBoard 845c board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-sdm845-modem', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x linux-firmware-qcom-sdm845-modem', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
@@ -1,6 +1,10 @@
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-adreno-gmu-a621 linux-firmware-qcom-sar2130p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb1.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the RB1 Robotics platform"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-qcm2290-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qcm2290-wifi ', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3950', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb1.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the RB1 Robotics platform"
+SUMMARY = "Packages for the RB1 Robotics platform"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -14,5 +15,8 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-qcm2290-audio \
     linux-firmware-qcom-qcm2290-modem \
     linux-firmware-qcom-venus-6.0 \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb1-adsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb2.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the RB2 Robotics platform"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qrb4210-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3988', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb2.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the RB2 Robotics platform"
+SUMMARY = "Packages for the RB2 Robotics platform"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -15,6 +16,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-qrb4210-compute \
     linux-firmware-qcom-qrb4210-modem \
     linux-firmware-qcom-venus-6.0 \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb2-adsp \
     hexagon-dsp-binaries-thundercomm-rb2-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the RB3Gen2 platform"
+SUMMARY = "Packages for the RB3Gen2 platform"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -13,6 +14,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-qcm6490-audio \
     linux-firmware-qcom-qcm6490-compute \
     linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb3gen2-adsp \
     hexagon-dsp-binaries-thundercomm-rb3gen2-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the RB3Gen2 platform"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcm6490-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcm6490-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb5.bb
@@ -1,9 +1,10 @@
-SUMMARY = "Firmware packages for the RB5 Robotics platform"
+SUMMARY = "Packages for the RB5 Robotics platform"
 
 inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -14,6 +15,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8250-audio \
     linux-firmware-qcom-sm8250-compute \
     linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb5-adsp \
     hexagon-dsp-binaries-thundercomm-rb5-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb5.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the RB5 Robotics platform"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6390', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6390', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the SM8150-HDK (aka HDK855) board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the SM8150-HDK (aka HDK855) board"
+SUMMARY = "Packages for the SM8150-HDK (aka HDK855) board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the SM8350-HDK (aka HDK888) board"
+SUMMARY = "Packages for the SM8350-HDK (aka HDK888) board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the SM8350-HDK (aka HDK888) board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the SM8450-HDK board"
+SUMMARY = "Packages for the SM8450-HDK board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the SM8450-HDK board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a730 linux-firmware-qcom-sm8450-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
@@ -1,6 +1,10 @@
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a740 linux-firmware-qcom-sm8550-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Firmware packages for the SM8650-HDK board"
+SUMMARY = "Packages for the SM8650-HDK board"
 
 inherit packagegroup
 

--- a/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
@@ -2,7 +2,11 @@ SUMMARY = "Firmware packages for the SM8650-HDK board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-g790 linux-firmware-qcom-sm8650-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \


### PR DESCRIPTION
It makes sense to define several packagegroups for each of the boards:
- firmware
- hexagon-dsp-binaries
- kernel modules
- (maybe other)

Restructure current recipes by splitting the DSP binaries to separate packagegroups. It makes it easier to add per-board packagegroups in future.