### PR TITLE
packagegroup-firmware-rb3gen2: add Adreno ZAP binary

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
@@ -3,7 +3,7 @@ SUMMARY = "Firmware packages for the RB3Gen2 platform"
 inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcm6490-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcm6490-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \
     linux-firmware-qcom-qcm6490-audio \


### PR DESCRIPTION
Add Adreno Zap shader to the list of RB3 Gen2 firmware packages.
