### PR TITLE
recipes: drop ${SRCPV}

### DIFF
--- a/recipes-bsp/firmware/firmware-ath6kl_git.bb
+++ b/recipes-bsp/firmware/firmware-ath6kl_git.bb
@@ -11,7 +11,7 @@ NO_GENERIC_LICENSE[Firmware-qualcommAthos_ath6kl] = "LICENSE.qca_firmware"
 SRC_URI = "git://github.com/qca/ath6kl-firmware;protocol=https;branch=master"
 SRCREV = "2e02576c1dab6fd35118eea1004f50aaaed3794f"
 
-PV = "3.5.0.349-1+git${SRCPV}"
+PV = "3.5.0.349-1+git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -8,7 +8,7 @@ was submitted for revision and it takes some time to become part of a stable \
 version, or because it is not applicable for upstreaming."
 
 BASEPV = "2024.10"
-PV = "${BASEPV}+git${SRCPV}"
+PV = "${BASEPV}+git"
 
 require recipes-bsp/u-boot/u-boot.inc
 require u-boot-qcom-common_${BASEPV}.inc

--- a/recipes-devtools/debugcc/debugcc_git.bb
+++ b/recipes-devtools/debugcc/debugcc_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
 
 SRCREV = "1f2d56984ec60e6ca0a18718c75c4e593542cefc"
 
-PV = "0.0+git${SRCPV}"
+PV = "0.0+git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/partition-utils/qcom-ptool_git.bb
+++ b/recipes-devtools/partition-utils/qcom-ptool_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git.codelinaro.org/linaro/qcomlt/partioning_tool.git;branch=mas
 
 SRCREV = "3484fc0a88088dea00397774fc93f9acd3a23ce0"
 
-PV = "0.0+git${SRCPV}"
+PV = "0.0+git"
 S = "${WORKDIR}/git"
 
 inherit python3native

--- a/recipes-devtools/pil-squasher/pil-squasher_git.bb
+++ b/recipes-devtools/pil-squasher/pil-squasher_git.bb
@@ -10,7 +10,7 @@ SRC_URI = " \
 	git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https \
 "
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/qc-image-unpacker/qc-image-unpacker_git.bb
+++ b/recipes-devtools/qc-image-unpacker/qc-image-unpacker_git.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
 
 SRCREV = "28a783a9fc25dc87b7416b6d5b6f9ccd497d1c2e"
 
-PV = "0.2.0+${SRCPV}"
+PV = "0.2.0+"
 S = "${WORKDIR}/git/src"
 
 DEPENDS = "zlib"

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
 	file://ath11k-generate-ahb-board-2_json.sh \
 "
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 S = "${WORKDIR}/git"
 
 do_install () {

--- a/recipes-devtools/qmic/qmic_git.bb
+++ b/recipes-devtools/qmic/qmic_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 SRCREV = "815dd495eb087b3b3ea02a8ed43716efac43db1c"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/skales/skales_git.bb
+++ b/recipes-devtools/skales/skales_git.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://mkbootimg;beginline=3;endline=29;md5=114b84083e657f3886bfa2c1e5de7deb"
 
 SRCREV = "1ccd3e924f6955b1c9d5f921e5311c8db8411787"
-PV = "1.5.0+git${SRCPV}"
+PV = "1.5.0+git"
 
 SRC_URI = "git://git.codelinaro.org/clo/qsdk/oss/tools/skales.git;protocol=https;branch=caf_migration/skales/master \
           file://0002-mkbootimg-use-python3.patch \

--- a/recipes-support/fastrpc/fastrpc_git.bb
+++ b/recipes-support/fastrpc/fastrpc_git.bb
@@ -16,7 +16,7 @@ SRC_URI = "\
     file://mount-dsp.sh \
 "
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/pd-mapper/pd-mapper_git.bb
+++ b/recipes-support/pd-mapper/pd-mapper_git.bb
@@ -13,7 +13,7 @@ SRCREV = "10997ba7c43a3787a40b6b1b161408033e716374"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
 "
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/qrtr/qrtr_git.bb
+++ b/recipes-support/qrtr/qrtr_git.bb
@@ -10,7 +10,7 @@ inherit systemd
 SRCREV = "d0d471c96e7d112fac6f48bd11f9e8ce209c04d2"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 
-PV = "0.3+${SRCPV}"
+PV = "0.3+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/rmtfs/rmtfs_git.bb
+++ b/recipes-support/rmtfs/rmtfs_git.bb
@@ -11,7 +11,7 @@ SRCREV = "7a5ae7e0a57be3e09e0256b51b9075ee6b860322"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 DEPENDS = "qmic-native qrtr udev"
 
-PV = "0.2+${SRCPV}"
+PV = "0.2+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/tqftpserv/tqftpserv_git.bb
+++ b/recipes-support/tqftpserv/tqftpserv_git.bb
@@ -13,7 +13,7 @@ SRCREV = "de42697a2466cc5ee267ffe36ab4e8494f005fb0"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
 "
 
-PV = "0.0+${SRCPV}"
+PV = "0.0+"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-test/bootrr/bootrr_git.bb
+++ b/recipes-test/bootrr/bootrr_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-PV = "0.0+git${SRCPV}"
+PV = "0.0+git"
 
 inherit allarch
 

--- a/recipes-test/diag/diag_git.bb
+++ b/recipes-test/diag/diag_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f6832ae4af693c6f31ffd931e25ef580"
 
 SRC_URI = "git://github.com/andersson/diag.git;branch=master;protocol=https"
 
-PV = "0.0+git${SRCPV}"
+PV = "0.0+git"
 SRCREV = "d06e599d197790c9e84ac41a51bf124a69768c4f"
 
 S = "${WORKDIR}/git"

--- a/recipes-test/mybw/mybw_git.bb
+++ b/recipes-test/mybw/mybw_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/andersson/mybw;protocol=https;branch=main \
 
 S = "${WORKDIR}/git"
 
-PV = "0.0+git${SRCPV}"
+PV = "0.0+git"
 
 do_compile () {
 	oe_runmake


### PR DESCRIPTION
Drop SRCPV similarly like oe-core did in 2023. The SRCPV is now handled as a part of PKGV handling:

 https://git.openembedded.org/openembedded-core/commit/?h=nanbield&id=843f82a246a535c353e08072f252d1dc78217872