### PR TITLE
Disable seccomp for dhcpcd

### DIFF
--- a/recipes-support/dhcpcd/dhcpcd_10.1.0.bbappend
+++ b/recipes-support/dhcpcd/dhcpcd_10.1.0.bbappend
@@ -1,0 +1,3 @@
+# SECCOMP is very dependant on libc vs kernel,
+# Disable seccomp to prevent dhcpcd break
+EXTRA_OECONF:append = " --disable-seccomp"


### PR DESCRIPTION
SECCOMP is enabled by default, causing SIGSYS errors for dhcpcd wlan0.  Due to the dependency of Linux SECCOMP on the libc and kernel versions, privilege separation is being disabled entirely to accommodate changes in libc/kernel compatibility.