### PR TITLE
CI base.yml: add `wifi` to `DISTRO_FEATURES`

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -39,7 +39,7 @@ local_conf_header:
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
-    DISTRO_FEATURES:append = " efi"
+    DISTRO_FEATURES:append = " efi wifi"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
 


### PR DESCRIPTION
The magic in recipes-bsp/packagegroups demands 'wifi' to be present before it includes the wifi firmware.