### PR TITLE
Package Hexagon DSP binaries for Qualcomm HDK boards

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-qar2130p.bb
+++ b/recipes-bsp/firmware/firmware-qcom-qar2130p.bb
@@ -2,7 +2,7 @@
 # NHLOS_URI:pn-firmware-qcom-sar2130p = "..."  to local.conf. Use "file://"
 # if the file is provided locally.
 
-DESCRIPTION = "QCOM Firmware for SAR2130P boards"
+DESCRIPTION = "QCOM Firmware for QAR2130P device"
 
 LICENSE = "CLOSED"
 

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20250211.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20250211.bb
@@ -4,13 +4,19 @@ Linux firmware release. It contains libraries and executables to be used \
 with the corresponding DSP firmware using the FastRPC interface in order \
 to provide additional functionality by the DSPs."
 
-LICENSE = "dspso-qcom"
+LICENSE = " \
+    dspso-WHENCE \
+    & dspso-qcom \
+    & dspso-qcom-2 \
+"
 LIC_FILES_CHKSUM = "\
     file://LICENSE.qcom;md5=56e86b6c508490dadc343f39468b5f5e \
     file://LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0 \
+    file://WHENCE;md5=7ead1f3b8aa8267faf946ab6600d2690 \
 "
 NO_GENERIC_LICENSE[dspso-qcom] = "LICENSE.qcom"
 NO_GENERIC_LICENSE[dspso-qcom-2] = "LICENSE.qcom-2"
+NO_GENERIC_LICENSE[dspso-WHENCE] = "WHENCE"
 
 SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk \
@@ -31,12 +37,9 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 do_install () {
 	oe_runmake install 'DESTDIR=${D}'
-        install -m 0644 LICENSE.qcom ${D}${datadir}/qcom/
 }
 
 PACKAGES =+ "\
-    ${PN}-qcom-license \
-    ${PN}-qcom-2-license \
     ${PN}-qcom-db820c-adsp \
     ${PN}-qcom-sa8775p-ride-adsp \
     ${PN}-qcom-sa8775p-ride-cdsp \
@@ -54,24 +57,38 @@ PACKAGES =+ "\
     ${PN}-thundercomm-rb5-sdsp \
 "
 
-RDEPENDS:${PN}-qcom-db820c-adsp = "${PN}-qcom-license linux-firmware-qcom-apq8096-audio (= 1:${PV})"
-RDEPENDS:${PN}-qcom-sa8775p-ride-adsp = "${PN}-qcom-2-license linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
-RDEPENDS:${PN}-qcom-sa8775p-ride-cdsp = "${PN}-qcom-2-license linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
-RDEPENDS:${PN}-qcom-sa8775p-ride-gdsp = "${PN}-qcom-2-license linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-db845c-adsp = "${PN}-qcom-license linux-firmware-qcom-sdm845-audio (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-db845c-cdsp = "${PN}-qcom-license linux-firmware-qcom-sdm845-compute (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-db845c-sdsp = "${PN}-qcom-license linux-firmware-qcom-sdm845-thundercomm-db845c-sensors (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb1-adsp = "${PN}-qcom-license linux-firmware-qcom-qcm2290-audio (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb2-adsp = "${PN}-qcom-license linux-firmware-qcom-qrb4210-audio (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb2-cdsp = "${PN}-qcom-license linux-firmware-qcom-qrb4210-compute (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb3gen2-adsp = "${PN}-qcom-license linux-firmware-qcom-qcm6490-audio (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb3gen2-cdsp = "${PN}-qcom-license linux-firmware-qcom-qcm6490-compute (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb5-adsp = "${PN}-qcom-license linux-firmware-qcom-sm8250-audio (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb5-cdsp = "${PN}-qcom-license linux-firmware-qcom-sm8250-compute (= 1:${PV})"
-RDEPENDS:${PN}-thundercomm-rb5-sdsp = "${PN}-qcom-license linux-firmware-qcom-sm8250-thundercomm-rb5-sensors (= 1:${PV})"
+LICENSE:${PN} = "dspso-WHENCE"
+LICENSE:${PN}-qcom-db820c-adsp = "dspso-qcom"
+LICENSE:${PN}-qcom-sa8775p-ride-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sa8775p-ride-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sa8775p-ride-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-thundercomm-db845c-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-db845c-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-db845c-sdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb1-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb2-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb2-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb3gen2-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb3gen2-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-sdsp = "dspso-qcom"
 
-FILES:${PN}-qcom-license   = "${datadir}/qcom/LICENSE.qcom"
-FILES:${PN}-qcom-2-license   = "${datadir}/qcom/LICENSE.qcom-2"
+RDEPENDS:${PN}-qcom-db820c-adsp = "linux-firmware-qcom-apq8096-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-adsp = "linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-cdsp = "linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-gdsp = "linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-adsp = "linux-firmware-qcom-sdm845-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-cdsp = "linux-firmware-qcom-sdm845-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-sdsp = "linux-firmware-qcom-sdm845-thundercomm-db845c-sensors (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb1-adsp = "linux-firmware-qcom-qcm2290-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb2-adsp = "linux-firmware-qcom-qrb4210-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb2-cdsp = "linux-firmware-qcom-qrb4210-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb3gen2-adsp = "linux-firmware-qcom-qcm6490-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb3gen2-cdsp = "linux-firmware-qcom-qcm6490-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-adsp = "linux-firmware-qcom-sm8250-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-cdsp = "linux-firmware-qcom-sm8250-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-sdsp = "linux-firmware-qcom-sm8250-thundercomm-rb5-sensors (= 1:${PV})"
 
 FILES:${PN}-qcom-db820c-adsp = "${datadir}/qcom/apq8096/Qualcomm/db820c/dsp/adsp"
 FILES:${PN}-qcom-sa8775p-ride-adsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-qar2130p = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for QAR2130P device"
+
+DSPSO_SOC = "sar2130p"
+DSPSO_DEVICE = "QAR2130P"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-sm8150-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for SM8150 HDK (aka HDK855) board"
+
+DSPSO_SOC = "sm8150"
+DSPSO_DEVICE = "SM8150-HDK"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-sm8350-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for SM8350 HDK (aka HDK888) board"
+
+DSPSO_SOC = "sm8350"
+DSPSO_DEVICE = "SM8350-HDK"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-sm8450-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for SM8450 HDK board"
+
+DSPSO_SOC = "sm8450"
+DSPSO_DEVICE = "SM8450-HDK"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-sm8550-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for SM8550 HDK board"
+
+DSPSO_SOC = "sm8550"
+DSPSO_DEVICE = "SM8550-HDK"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
@@ -1,0 +1,14 @@
+# Specify location of the corresponding dspso.bin file by adding
+# DSPSO_URI:pn-firmware-qcom-sm8650-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "Hexagon DSP binaries for SM8650 HDK board"
+
+DSPSO_SOC = "sm8650"
+DSPSO_DEVICE = "SM8650-HDK"
+
+LICENSE = "CLOSED"
+DEPENDS = "firmware-${DSP_PKG_NAME}"
+S = "${UNPACKDIR}"
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -1,0 +1,71 @@
+# Handle dspso.bin unpacking in a generic way
+# If DSPSO_URI is defined, the image will be dissected automatically
+
+DSPSO_URI ??= ""
+
+DSPSO_SOC ?= "unknown"
+DSPSO_VENDOR ?= "Qualcomm"
+DSPSO_DEVICE ?= "Unknown"
+
+# Conditionally populate SRC_URI. We have to do it here rather than in python
+# script to let base.bbclass to pick up dependencies
+SRC_URI += "${DSPSO_URI}"
+
+# Extract package name part
+DSP_PKG_NAME ?= "${@d.getVar("PN").split("hexagon-dspso-")[-1]}"
+
+DSP_QCOM_BASE_PATH = "${datadir}/qcom"
+DSP_QCOM_PATH = "${DSP_QCOM_BASE_PATH}/${DSPSO_SOC}/${DSPSO_VENDOR}/${DSPSO_DEVICE}"
+
+DEPENDS += "e2fsprogs-native"
+
+inherit allarch
+
+PACKAGES = " \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
+"
+
+FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "${DSP_QCOM_PATH}/dsp/adsp"
+FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "${DSP_QCOM_PATH}/dsp/cdsp"
+FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "${DSP_QCOM_PATH}/dsp/sdsp"
+
+INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "arch libdir file-rdeps textrel"
+
+# If the URL is the file:// URI, the whole local path will be duplicated in the UNPACKDIR.
+# Otherwise we just need the last (filename) part of the path.
+def get_dspso_path(path):
+    from urllib.parse import urlparse
+    if path == "":
+        return ""
+    url = urlparse(path)
+    if url.scheme == "file":
+        return url.path
+    return url.path.rsplit('/', 1)[1]
+
+handle_dspso_image() {
+    for path in adsp cdsp sdsp ; do
+        mkdir -p ${B}/dspso-$path
+        debugfs $1 -R "ls -p /$path" | \
+            grep '^/[0-9]*/100' | cut -d/ -f6 | \
+            while read name ; do echo "dump /$path/$name ${B}/dspso-$path/$name" ; done | \
+            debugfs ${1}
+    done
+}
+
+do_compile:prepend() {
+    if [ -z "${DSPSO_URI}" ] ; then
+        bbwarn "${PN}: not packaging DSPSO firmware. Please provide DSPSO_URI"
+    else
+        handle_dspso_image ${UNPACKDIR}/${@get_dspso_path(d.getVar("DSPSO_URI"))}
+    fi
+}
+
+do_install:prepend() {
+    ls ${B}/dspso-adsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/adsp && install -m 0644 ${B}/dspso-adsp/* ${D}${DSP_QCOM_PATH}/dsp/adsp
+    ls ${B}/dspso-cdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/cdsp && install -m 0644 ${B}/dspso-cdsp/* ${D}${DSP_QCOM_PATH}/dsp/cdsp
+    ls ${B}/dspso-sdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/sdsp && install -m 0644 ${B}/dspso-sdsp/* ${D}${DSP_QCOM_PATH}/dsp/sdsp
+}

--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -30,11 +30,17 @@ PACKAGE_INSTALL += " \
     packagegroup-sm8450-hdk-firmware \
     packagegroup-sm8550-hdk-firmware \
     packagegroup-sm8650-hdk-firmware \
+    packagegroup-sm8150-hdk-hexagon-dsp-binaries \
+    packagegroup-sm8350-hdk-hexagon-dsp-binaries \
+    packagegroup-sm8450-hdk-hexagon-dsp-binaries \
+    packagegroup-sm8550-hdk-hexagon-dsp-binaries \
+    packagegroup-sm8650-hdk-hexagon-dsp-binaries \
 "
 
 # Other Qualcomm DevKits
 PACKAGE_INSTALL += " \
     packagegroup-qar2130p-firmware \
+    packagegroup-qar2130p-hexagon-dsp-binaries \
 "
 
 require initramfs-firmware-image.inc

--- a/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
@@ -8,7 +8,7 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-adreno-gmu-a621 linux-firmware-qcom-sar2130p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
-    firmware-qcom-sar2130p \
+    firmware-qcom-qar2130p \
     linux-firmware-qcom-sar2130p-audio \
     linux-firmware-qcom-sar2130p-compute \
 "

--- a/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
@@ -2,6 +2,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -11,4 +12,9 @@ RRECOMMENDS:${PN}-firmware = " \
     firmware-qcom-qar2130p \
     linux-firmware-qcom-sar2130p-audio \
     linux-firmware-qcom-sar2130p-compute \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-qar2130p-adsp \
+    hexagon-dsp-binaries-qcom-qar2130p-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -16,4 +17,10 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8150-ipa \
     linux-firmware-qcom-sm8150-modem \
     linux-firmware-qcom-sm8150-sensors \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8150-hdk-adsp \
+    hexagon-dsp-binaries-qcom-sm8150-hdk-cdsp \
+    hexagon-dsp-binaries-qcom-sm8150-hdk-sdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -19,4 +20,10 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8350-modem \
     linux-firmware-qcom-sm8350-sensors \
     linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8350-hdk-adsp \
+    hexagon-dsp-binaries-qcom-sm8350-hdk-cdsp \
+    hexagon-dsp-binaries-qcom-sm8350-hdk-sdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -16,4 +17,10 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8450-compute \
     linux-firmware-qcom-sm8450-modem \
     linux-firmware-qcom-sm8450-sensors \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8450-hdk-adsp \
+    hexagon-dsp-binaries-qcom-sm8450-hdk-cdsp \
+    hexagon-dsp-binaries-qcom-sm8450-hdk-sdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
@@ -2,6 +2,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -14,4 +15,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8550-compute \
     linux-firmware-qcom-sm8550-ipa \
     linux-firmware-qcom-sm8550-modem \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8550-hdk-adsp \
+    hexagon-dsp-binaries-qcom-sm8550-hdk-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -16,4 +17,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8650-audio-tplg \
     linux-firmware-qcom-sm8650-compute \
     linux-firmware-qcom-sm8650-ipa \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8650-hdk-adsp \
+    hexagon-dsp-binaries-qcom-sm8650-hdk-cdsp \
 "


### PR DESCRIPTION
Follow the firmware-qcom-nhlos.inc / firmware-qcom-adreno.inc approach and provide a way to create packages with  DSP libraries for the Qualcomm devkits. The developer must manually specify DSPSO_URI:pn-hexagon-dspso-qcom-foo variable in conf/local.conf.
