### PR TITLE
qcs6490-rb3gen2-core-kit: add `packagegroup-rb3gen2-firmware` to `MACHINE_ESSENTIAL_RECOMMENDS`

### DIFF
--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -11,8 +11,5 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    linux-firmware-qcom-adreno-a660 \
-    linux-firmware-qcom-qcm6490-adreno \
-    linux-firmware-qcom-qcm6490-audio \
-    linux-firmware-qcom-qcm6490-compute \
+    packagegroup-rb3gen2-firmware \
 "


### PR DESCRIPTION
This machine config doesn't include qcom-armv8.inc, on purpose, so include the firmwares here manually.