### PR TITLE
Add Hexagon DSP bin pkgs to qcs6490 & qcs9100 based machines

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -12,4 +12,5 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
+    packagegroup-rb3gen2-hexagon-dsp-binaries \
 "

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -11,6 +11,5 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    linux-firmware-qcom-qcm6490-audio \
-    linux-firmware-qcom-qcm6490-compute \
+    packagegroup-rb3gen2-firmware \
 "

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -12,4 +12,5 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
+    packagegroup-rb3gen2-hexagon-dsp-binaries \
 "

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -15,4 +15,5 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-sa8775p-ride-firmware \
+    packagegroup-sa8775p-ride-hexagon-dsp-binaries \
 "


### PR DESCRIPTION
Add qcom-sa8775p-ride hexagon dsp firmware binary packages to qcs9100-ride-sx images to use DSP and NPU.