### PR TITLE
qcom-commonc.inc: fix `ushbost` typo

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -2,7 +2,7 @@ SOC_FAMILY:prepend = "qcom:"
 require conf/machine/include/soc-family.inc
 
 # Set a default set of MACHINE_FEATURES, indivudual MACHINEs can append it
-MACHINE_FEATURES = "alsa bluetooth usbgadget ushbost wifi"
+MACHINE_FEATURES = "alsa bluetooth usbgadget usbhost wifi"
 
 XSERVER_OPENGL ?= " \
     xf86-video-modesetting \


### PR DESCRIPTION
It should say `usbhost` instead