### PR TITLE
Add a recipe to compile qcom staging kernel.

### DIFF
--- a/ci/staging-kernel-provider.yml
+++ b/ci/staging-kernel-provider.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+local_conf_header:
+  kernelprovider: |
+    PREFERRED_PROVIDER_virtual/kernel = "linux-qcom-staging"

--- a/recipes-kernel/linux/linux-qcom-staging_6.12.bb
+++ b/recipes-kernel/linux/linux-qcom-staging_6.12.bb
@@ -1,0 +1,65 @@
+SECTION = "kernel"
+
+DESCRIPTION = "Linux ${PV} staging kernel for QCOM devices"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+inherit kernel
+
+COMPATIBLE_MACHINE = "(qcom)"
+
+LINUX_QCOM_GIT ?= "git://git.codelinaro.org/clo/la/kernel/qcom.git;protocol=https"
+SRCBRANCH ?= "qclinux.6.12.y"
+SRC_URI = "${LINUX_QCOM_GIT};branch=${SRCBRANCH}"
+
+# To build bleeding edge qcom staging kernel set preferred
+# provider of virtual/kernel to 'linux-qcom-staging-tip'
+BBCLASSEXTEND = "devupstream:target"
+PN:class-devupstream = "linux-qcom-staging-tip"
+SRCREV:class-devupstream = "${AUTOREV}"
+
+SRCREV = "10325dc2277dc03687683b9f5f57a472b37de0b4"
+PV = "6.12+git"
+
+S = "${WORKDIR}/git"
+
+KERNEL_CONFIG ?= "qcom_defconfig"
+
+# Additional fragment for qcom value add features
+KERNEL_CONFIG_FRAGMENTS += " ${S}/arch/arm64/configs/qcom_addons.config"
+
+do_configure:prepend() {
+    if [ ! -f "${S}/arch/${ARCH}/configs/${KERNEL_CONFIG}" ]; then
+        bbfatal "KERNEL_CONFIG '${KERNEL_CONFIG}' was specified, but not present in the source tree"
+    else
+        cp '${S}/arch/${ARCH}/configs/${KERNEL_CONFIG}' '${B}/.config'
+    fi
+
+    # Check for kernel config fragments.  The assumption is that the config
+    # fragment will be specified with the absolute path.  For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one.  If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]
+    then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}
+        do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]
+            then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+}


### PR DESCRIPTION
This PR is submitted based on the discussions that happened in [PR745](https://github.com/qualcomm-linux/meta-qcom/pull/745) and sync-ups with @ndechesne and @ricardosalveti about the need for a recipe to build a staging kernel tree with additional patches, especially for boards based on QCS9100 & QCS6490. For the early enablement of other Qcom technologies such as Multimedia and Connectivity on these boards, we need this staging kernel to be built.

This staging kernel tree includes additional patches on top of the 6.12 kernel, many of which are in the process of being upstreamed. Starting with 6.12, this tree will continue to catch up with the latest releases (6.13, 6.14, etc.), with patches being dropped and rebased in the process. Eventually, all patches from this staging kernel will be available in the mainline kernel.

This patch series brings a recipe for the staging kernel and a CI yml file to build linux-qcom-staging. The machine configuration files are untouched and continue to build the linux-yocto-dev kernel. To build the staging kernel, run the kas command as below: `kas build meta-qcom/ci/qcs6490-rb3gen2-core-kit.yml:meta-qcom/ci/staging-kernel-provider.yml`

I’ll further work with @ndechesne, @koenkooi, and @ricardosalveti to enable this staging kernel in GitHub CI to avoid regressions.