### PR TITLE
ci/distro.yml: enable meta-xfce and its dependencies

### DIFF
--- a/ci/distro.yml
+++ b/ci/distro.yml
@@ -13,6 +13,9 @@ repos:
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
     layers:
-      meta-oe:
+      meta-gnome:
+      meta-multimedia: 
       meta-networking:
+      meta-oe:
       meta-python:
+      meta-xfce:


### PR DESCRIPTION
This enables meta-xfce and friends for DISTRO='qcom-distro'
