### PR TITLE
Add boot essential user space package groups to qcs6490 & qcs9100 images

### DIFF
--- a/conf/machine/include/qcom-qcs6490.inc
+++ b/conf/machine/include/qcom-qcs6490.inc
@@ -9,4 +9,12 @@ require conf/machine/include/arm/arch-armv8-2a.inc
 
 KERNEL_CMDLINE_EXTRA ?= "pcie_pme=nomsi earlycon"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"
+
 EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qcs6490 qcom-gen-partition-bins"

--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -9,4 +9,12 @@ require conf/machine/include/arm/arch-armv8-2a.inc
 
 KERNEL_CMDLINE_EXTRA ?= "pci=noaer pcie_pme=nomsi earlycon"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"
+
 EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qcs9100 qcom-gen-partition-bins"

--- a/conf/machine/include/qcom-sa8155p.inc
+++ b/conf/machine/include/qcom-sa8155p.inc
@@ -4,12 +4,9 @@ DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    pd-mapper \
-    qrtr \
-    rmtfs \
-    tqftpserv \
+    packagegroup-qcom-boot-essential \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \
-    fastrpc \
+    packagegroup-qcom-boot-additional \
 "

--- a/conf/machine/include/qcom-sdm845.inc
+++ b/conf/machine/include/qcom-sdm845.inc
@@ -4,12 +4,9 @@ DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    pd-mapper \
-    qrtr \
-    rmtfs \
-    tqftpserv \
+    packagegroup-qcom-boot-essential \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \
-    fastrpc \
+    packagegroup-qcom-boot-additional \
 "

--- a/conf/machine/include/qcom-sm8250.inc
+++ b/conf/machine/include/qcom-sm8250.inc
@@ -4,12 +4,9 @@ DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    pd-mapper \
-    qrtr \
-    rmtfs \
-    tqftpserv \
+    packagegroup-qcom-boot-essential \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \
-    fastrpc \
+    packagegroup-qcom-boot-additional \
 "

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -52,14 +52,11 @@ KERNEL_CMDLINE_EXTRA[sdm845-db845c] ?= "clk_ignore_unused pd_ignore_unused"
 
 # Userspace tools
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    pd-mapper \
-    qrtr \
-    rmtfs \
-    tqftpserv \
+    packagegroup-qcom-boot-essential \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \
-    fastrpc \
+    packagegroup-qcom-boot-additional \
 "
 
 # Modules and firmware for all supported machines

--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Extra userspace packages for QCOM platforms"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-boot-essential \
+    ${PN}-boot-additional \
+"
+
+RRECOMMENDS:${PN}-boot-essential = " \
+    pd-mapper \
+    qrtr \
+    rmtfs \
+    tqftpserv \
+"
+
+RRECOMMENDS:${PN}-boot-additional = " \
+    fastrpc \
+"

--- a/recipes-devtools/debugcc/debugcc_git.bb
+++ b/recipes-devtools/debugcc/debugcc_git.bb
@@ -1,12 +1,12 @@
 SUMMARY = "A tool to debug Qualcomm clock controllers."
-HOMEPAGE = "https://github.com/andersson/debugcc/"
+HOMEPAGE = "https://github.com/linux-msm/debugcc/"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://debugcc.c;beginline=5;endline=29;md5=5598b6b886a3af944e4d19bb7d947095"
 
 SRC_URI = "\
-    git://github.com/andersson/debugcc.git;branch=master;protocol=https \
+    git://github.com/linux-msm/debugcc.git;branch=master;protocol=https \
 "
 
 SRCREV = "1f2d56984ec60e6ca0a18718c75c4e593542cefc"

--- a/recipes-devtools/pil-squasher/pil-squasher_git.bb
+++ b/recipes-devtools/pil-squasher/pil-squasher_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "MDT to MBN conversion tool"
-HOMEPAGE = "https://github.com/andersson/pil-squasher.git"
+HOMEPAGE = "https://github.com/linux-msm/pil-squasher.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"

--- a/recipes-devtools/qmic/qmic_git.bb
+++ b/recipes-devtools/qmic/qmic_git.bb
@@ -1,12 +1,12 @@
 SUMMARY = "QMI compiler"
-HOMEPAGE = "https://github.com/andersson/qmic.git"
+HOMEPAGE = "https://github.com/linux-msm/qmic.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 
 SRCREV = "815dd495eb087b3b3ea02a8ed43716efac43db1c"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.0+"
 

--- a/recipes-support/pd-mapper/pd-mapper_git.bb
+++ b/recipes-support/pd-mapper/pd-mapper_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Qualcomm pd-mapper application"
-HOMEPAGE = "https://github.com/andersson/pd-mapper.git"
+HOMEPAGE = "https://github.com/linux-msm/pd-mapper.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
@@ -10,7 +10,7 @@ DEPENDS = "qrtr xz"
 inherit systemd
 
 SRCREV = "10997ba7c43a3787a40b6b1b161408033e716374"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https \
 "
 
 PV = "0.0+"

--- a/recipes-support/qrtr/qrtr_git.bb
+++ b/recipes-support/qrtr/qrtr_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Qualcomm QRTR applications and library"
-HOMEPAGE = "https://github.com/andersson/qrtr.git"
+HOMEPAGE = "https://github.com/linux-msm/qrtr.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=15329706fbfcb5fc5edcc1bc7c139da5"
 inherit systemd
 
 SRCREV = "d0d471c96e7d112fac6f48bd11f9e8ce209c04d2"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.3+"
 

--- a/recipes-support/rmtfs/rmtfs_git.bb
+++ b/recipes-support/rmtfs/rmtfs_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "RMTFS QMI service"
-HOMEPAGE = "https://github.com/andersson/mrtfs.git"
+HOMEPAGE = "https://github.com/linux-msm/rmtfs.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 inherit systemd
 
 SRCREV = "7a5ae7e0a57be3e09e0256b51b9075ee6b860322"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 DEPENDS = "qmic-native qrtr udev"
 
 PV = "0.2+"

--- a/recipes-support/tqftpserv/tqftpserv_git.bb
+++ b/recipes-support/tqftpserv/tqftpserv_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Qualcomm tqftpserv application"
-HOMEPAGE = "https://github.com/andersson/tqftpserv.git"
+HOMEPAGE = "https://github.com/linux-msm/tqftpserv.git"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
@@ -10,7 +10,7 @@ DEPENDS = "qrtr"
 inherit systemd
 
 SRCREV = "de42697a2466cc5ee267ffe36ab4e8494f005fb0"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https \
 "
 
 PV = "0.0+"

--- a/recipes-test/diag/diag_git.bb
+++ b/recipes-test/diag/diag_git.bb
@@ -1,9 +1,9 @@
 SUMMARY = "DIAG implements routing of diagnostics related messages between host and various subsystems."
-HOMEPAGE = "https://github.com/andersson/diag"
+HOMEPAGE = "https://github.com/linux-msm/diag"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f6832ae4af693c6f31ffd931e25ef580"
 
-SRC_URI = "git://github.com/andersson/diag.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.0+git"
 SRCREV = "d06e599d197790c9e84ac41a51bf124a69768c4f"

--- a/recipes-test/images/initramfs-tiny-image.bb
+++ b/recipes-test/images/initramfs-tiny-image.bb
@@ -10,11 +10,8 @@ PACKAGE_INSTALL = " \
 
 PACKAGE_INSTALL += " \
     debugcc \
-    fastrpc \
-    pd-mapper \
-    qrtr \
-    rmtfs \
-    tqftpserv \
+    packagegroup-qcom-boot-additional \
+    packagegroup-qcom-boot-essential \
 "
 
 # Do not pollute the initrd image with rootfs features


### PR DESCRIPTION
Define and add qcom-boot-essential & qcom-boot-additional user space package groups to qcs6490 & qcs9100 images to ensure all basic user space pkgs required for booting the device are present