### PR TITLE
ci: update the link of meta-yocto

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -23,7 +23,7 @@ repos:
       .: excluded
 
   meta-yocto:
-    url: https://git.yoctoproject.org/git/meta-yocto
+    url: https://git.yoctoproject.org/meta-yocto
     layers:
       meta-poky:
 


### PR DESCRIPTION
I believe the extra /git/ is an artifact of the past/legacy architecture. I just checked with the YP admins and they confirm that we should use the link without the extra /git/.