### PR TITLE
sc7280: camera subsystem, rb3gen2-vision-mezzanine

### DIFF
--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -6,8 +6,11 @@ require conf/machine/include/qcom-qcs6490.inc
 
 MACHINE_FEATURES += "efi pci"
 
+QCOM_DTB_DEFAULT ?= "qcs6490-rb3gen2"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
+                      qcom/qcs6490-rb3gen2-vision-mezzanine.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -9,6 +9,9 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0002-arm64-dts-qcom-sc7280-Add-global-PCIe-interrupt.patch \
     file://qcm6490-board-dts/0001-dt-bindings-PCI-Add-binding-for-Toshiba-TC956x-PCIe-.patch \
     file://qcm6490-board-dts/0002-arm64-dts-qcom-qcs6490-rb3gen2-Add-TC956x-PCIe-switc.patch \
+    file://qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-support-for-camss.patch \
+    file://qcm6490-board-dts/0002-arm64-dts-qcom-qcs6490-rb3gen2-vision-mezzanine-Add-.patch \
+    file://qcm6490-board-dts/0002-media-dt-bindings-update-clocks-for-sc7280-camss.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \
@@ -17,6 +20,7 @@ SRC_URI:append:qcom = " \
     file://drivers/0006-PCI-qcom-Add-support-for-host_stop_link-host_start_l.patch \
     file://drivers/0007-PCI-PCI-Add-pcie_is_link_active-to-determine-if-the-.patch \
     file://drivers/0008-PCI-pwrctrl-Add-power-control-driver-for-tc956x.patch \
+    file://drivers/0001-media-qcom-camss-update-clock-names-for-sc7280.patch \
 "
 
 # Include additional kernel configs.

--- a/recipes-kernel/linux/linux-yocto-dev/drivers/0001-media-qcom-camss-update-clock-names-for-sc7280.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/drivers/0001-media-qcom-camss-update-clock-names-for-sc7280.patch
@@ -1,0 +1,94 @@
+From 306753e5d8a48b29ee3f73837efea50b421bff5a Mon Sep 17 00:00:00 2001
+From: Vikram Sharma <quic_vikramsa@quicinc.com>
+Date: Tue, 21 Jan 2025 23:37:46 +0530
+Subject: [PATCH 1/2] media: qcom: camss: update clock names for sc7280
+
+Update clock names to make them consistent with existing platform i.e
+sc8280xp. Rename gcc_cam_hf_axi to gcc_axi_hf and add gcc_axi_sf.
+
+Signed-off-by: Vikram Sharma <quic_vikramsa@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250121180746.1989996-1-quic_vikramsa@quicinc.com/]
+---
+ drivers/media/platform/qcom/camss/camss.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index a85e9df0f301..b1358457c66e 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -1443,12 +1443,13 @@ static const struct camss_subdev_resources vfe_res_7280[] = {
+ 		.regulators = {},
+ 
+ 		.clock = { "camnoc_axi", "cpas_ahb", "icp_ahb", "vfe0",
+-			   "vfe0_axi", "gcc_cam_hf_axi" },
++			   "vfe0_axi", "gcc_axi_hf", "gcc_axi_sf" },
+ 		.clock_rate = { { 150000000, 240000000, 320000000, 400000000, 480000000 },
+ 				{ 80000000 },
+ 				{ 0 },
+ 				{ 380000000, 510000000, 637000000, 760000000 },
+ 				{ 0 },
++				{ 0 },
+ 				{ 0 } },
+ 
+ 		.reg = { "vfe0" },
+@@ -1468,12 +1469,13 @@ static const struct camss_subdev_resources vfe_res_7280[] = {
+ 		.regulators = {},
+ 
+ 		.clock = { "camnoc_axi", "cpas_ahb", "icp_ahb", "vfe1",
+-			   "vfe1_axi", "gcc_cam_hf_axi" },
++			   "vfe1_axi", "gcc_axi_hf", "gcc_axi_sf" },
+ 		.clock_rate = { { 150000000, 240000000, 320000000, 400000000, 480000000 },
+ 				{ 80000000 },
+ 				{ 0 },
+ 				{ 380000000, 510000000, 637000000, 760000000 },
+ 				{ 0 },
++				{ 0 },
+ 				{ 0 } },
+ 
+ 		.reg = { "vfe1" },
+@@ -1493,12 +1495,13 @@ static const struct camss_subdev_resources vfe_res_7280[] = {
+ 		.regulators = {},
+ 
+ 		.clock = { "camnoc_axi", "cpas_ahb", "icp_ahb", "vfe2",
+-			   "vfe2_axi", "gcc_cam_hf_axi" },
++			   "vfe2_axi", "gcc_axi_hf", "gcc_axi_sf" },
+ 		.clock_rate = { { 150000000, 240000000, 320000000, 400000000, 480000000 },
+ 				{ 80000000 },
+ 				{ 0 },
+ 				{ 380000000, 510000000, 637000000, 760000000 },
+ 				{ 0 },
++				{ 0 },
+ 				{ 0 } },
+ 
+ 		.reg = { "vfe2" },
+@@ -1516,11 +1519,12 @@ static const struct camss_subdev_resources vfe_res_7280[] = {
+ 	/* VFE3 (lite) */
+ 	{
+ 		.clock = { "camnoc_axi", "cpas_ahb", "icp_ahb",
+-			   "vfe_lite0", "gcc_cam_hf_axi" },
++			   "vfe_lite0", "gcc_axi_hf", "gcc_axi_sf" },
+ 		.clock_rate = { { 150000000, 240000000, 320000000, 400000000, 480000000 },
+ 				{ 80000000 },
+ 				{ 0 },
+ 				{ 320000000, 400000000, 480000000, 600000000 },
++				{ 0 },
+ 				{ 0 } },
+ 
+ 		.regulators = {},
+@@ -1537,11 +1541,12 @@ static const struct camss_subdev_resources vfe_res_7280[] = {
+ 	/* VFE4 (lite) */
+ 	{
+ 		.clock = { "camnoc_axi", "cpas_ahb", "icp_ahb",
+-			   "vfe_lite1", "gcc_cam_hf_axi" },
++			   "vfe_lite1", "gcc_axi_hf", "gcc_axi_sf" },
+ 		.clock_rate = { { 150000000, 240000000, 320000000, 400000000, 480000000 },
+ 				{ 80000000 },
+ 				{ 0 },
+ 				{ 320000000, 400000000, 480000000, 600000000 },
++				{ 0 },
+ 				{ 0 } },
+ 
+ 		.regulators = {},
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-support-for-camss.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-support-for-camss.patch
@@ -1,0 +1,209 @@
+From 57787a744cccf95fdce5b48fa95d584ba8a4dbdc Mon Sep 17 00:00:00 2001
+From: Vikram Sharma <quic_vikramsa@quicinc.com>
+Date: Sun, 9 Feb 2025 04:21:42 +0530
+Subject: [PATCH 1/2] arm64: dts: qcom: sc7280: Add support for camss
+
+Add changes to support the camera subsystem on the SC7280.
+
+Signed-off-by: Suresh Vankadara <quic_svankada@quicinc.com>
+Signed-off-by: Trishansh Bhardwaj <quic_tbhardwa@quicinc.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Vikram Sharma <quic_vikramsa@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250208225143.2868279-1-quic_vikramsa@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/sc7280.dtsi | 178 +++++++++++++++++++++++++++
+ 1 file changed, 178 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 835102813588..7c4f48783656 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -4438,6 +4438,184 @@ cci1_i2c1: i2c-bus@1 {
+ 			};
+ 		};
+ 
++		camss: isp@acb3000 {
++			compatible = "qcom,sc7280-camss";
++
++			reg = <0x0 0x0acb3000 0x0 0x1000>,
++			      <0x0 0x0acba000 0x0 0x1000>,
++			      <0x0 0x0acc1000 0x0 0x1000>,
++			      <0x0 0x0acc8000 0x0 0x1000>,
++			      <0x0 0x0accf000 0x0 0x1000>,
++			      <0x0 0x0ace0000 0x0 0x2000>,
++			      <0x0 0x0ace2000 0x0 0x2000>,
++			      <0x0 0x0ace4000 0x0 0x2000>,
++			      <0x0 0x0ace6000 0x0 0x2000>,
++			      <0x0 0x0ace8000 0x0 0x2000>,
++			      <0x0 0x0acaf000 0x0 0x4000>,
++			      <0x0 0x0acb6000 0x0 0x4000>,
++			      <0x0 0x0acbd000 0x0 0x4000>,
++			      <0x0 0x0acc4000 0x0 0x4000>,
++			      <0x0 0x0accb000 0x0 0x4000>;
++			reg-names = "csid0",
++				    "csid1",
++				    "csid2",
++				    "csid_lite0",
++				    "csid_lite1",
++				    "csiphy0",
++				    "csiphy1",
++				    "csiphy2",
++				    "csiphy3",
++				    "csiphy4",
++				    "vfe0",
++				    "vfe1",
++				    "vfe2",
++				    "vfe_lite0",
++				    "vfe_lite1";
++
++			clocks = <&camcc CAM_CC_CAMNOC_AXI_CLK>,
++				 <&camcc CAM_CC_CPAS_AHB_CLK>,
++				 <&camcc CAM_CC_CSIPHY0_CLK>,
++				 <&camcc CAM_CC_CSI0PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY1_CLK>,
++				 <&camcc CAM_CC_CSI1PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY2_CLK>,
++				 <&camcc CAM_CC_CSI2PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY3_CLK>,
++				 <&camcc CAM_CC_CSI3PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY4_CLK>,
++				 <&camcc CAM_CC_CSI4PHYTIMER_CLK>,
++				 <&gcc GCC_CAMERA_HF_AXI_CLK>,
++				 <&gcc GCC_CAMERA_SF_AXI_CLK>,
++				 <&camcc CAM_CC_ICP_AHB_CLK>,
++				 <&camcc CAM_CC_IFE_0_CLK>,
++				 <&camcc CAM_CC_IFE_0_AXI_CLK>,
++				 <&camcc CAM_CC_IFE_0_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_0_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_1_CLK>,
++				 <&camcc CAM_CC_IFE_1_AXI_CLK>,
++				 <&camcc CAM_CC_IFE_1_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_1_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_2_CLK>,
++				 <&camcc CAM_CC_IFE_2_AXI_CLK>,
++				 <&camcc CAM_CC_IFE_2_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_2_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_0_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_0_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_0_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_1_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_1_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_1_CSID_CLK>;
++			clock-names = "camnoc_axi",
++				      "cpas_ahb",
++				      "csiphy0",
++				      "csiphy0_timer",
++				      "csiphy1",
++				      "csiphy1_timer",
++				      "csiphy2",
++				      "csiphy2_timer",
++				      "csiphy3",
++				      "csiphy3_timer",
++				      "csiphy4",
++				      "csiphy4_timer",
++				      "gcc_axi_hf",
++				      "gcc_axi_sf",
++				      "icp_ahb",
++				      "vfe0",
++				      "vfe0_axi",
++				      "vfe0_cphy_rx",
++				      "vfe0_csid",
++				      "vfe1",
++				      "vfe1_axi",
++				      "vfe1_cphy_rx",
++				      "vfe1_csid",
++				      "vfe2",
++				      "vfe2_axi",
++				      "vfe2_cphy_rx",
++				      "vfe2_csid",
++				      "vfe_lite0",
++				      "vfe_lite0_cphy_rx",
++				      "vfe_lite0_csid",
++				      "vfe_lite1",
++				      "vfe_lite1_cphy_rx",
++				      "vfe_lite1_csid";
++
++			interrupts = <GIC_SPI 464 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 466 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 640 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 468 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 359 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 477 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 478 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 479 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 448 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 122 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 465 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 467 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 641 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 469 IRQ_TYPE_EDGE_RISING>,
++				     <GIC_SPI 360 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "csid0",
++					  "csid1",
++					  "csid2",
++					  "csid_lite0",
++					  "csid_lite1",
++					  "csiphy0",
++					  "csiphy1",
++					  "csiphy2",
++					  "csiphy3",
++					  "csiphy4",
++					  "vfe0",
++					  "vfe1",
++					  "vfe2",
++					  "vfe_lite0",
++					  "vfe_lite1";
++
++			interconnects = <&gem_noc  MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &cnoc2 SLAVE_CAMERA_CFG QCOM_ICC_TAG_ACTIVE_ONLY>,
++					<&mmss_noc MASTER_CAMNOC_HF  QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "ahb",
++					     "hf_0";
++
++			iommus = <&apps_smmu 0x800 0x4e0>;
++
++			power-domains = <&camcc CAM_CC_IFE_0_GDSC>,
++					<&camcc CAM_CC_IFE_1_GDSC>,
++					<&camcc CAM_CC_IFE_2_GDSC>,
++					<&camcc CAM_CC_TITAN_TOP_GDSC>;
++			power-domain-names = "ife0",
++					     "ife1",
++					     "ife2",
++					     "top";
++
++			status = "disabled";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++				};
++
++				port@1 {
++					reg = <1>;
++				};
++
++				port@2 {
++					reg = <2>;
++				};
++
++				port@3 {
++					reg = <3>;
++				};
++
++				port@4 {
++					reg = <4>;
++				};
++			};
++		};
++
+ 		camcc: clock-controller@ad00000 {
+ 			compatible = "qcom,sc7280-camcc";
+ 			reg = <0 0x0ad00000 0 0x10000>;
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-qcs6490-rb3gen2-vision-mezzanine-Add-.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-qcs6490-rb3gen2-vision-mezzanine-Add-.patch
@@ -1,0 +1,146 @@
+From 2ea225aa946d3c1be842eb1ac758fcc3d584b5ab Mon Sep 17 00:00:00 2001
+From: Vikram Sharma <quic_vikramsa@quicinc.com>
+Date: Sun, 9 Feb 2025 04:21:43 +0530
+Subject: [PATCH 2/2] arm64: dts: qcom: qcs6490-rb3gen2-vision-mezzanine: Add
+ vision mezzanine
+
+The Vision Mezzanine for the Qualcomm RB3 Gen 2 ships with an imx577
+camera sensor. Enable IMX577 on the vision mezzanine.
+
+An example media-ctl pipeline for the imx577 is:
+
+media-ctl --reset
+media-ctl -V '"imx577 '17-001a'":0[fmt:SRGGB10/4056x3040 field:none]'
+media-ctl -V '"msm_csiphy3":0[fmt:SRGGB10/4056x3040]'
+media-ctl -V '"msm_csid0":0[fmt:SRGGB10/4056x3040]'
+media-ctl -V '"msm_vfe0_rdi0":0[fmt:SRGGB10/4056x3040]'
+media-ctl -l '"msm_csiphy3":1->"msm_csid0":0[1]'
+media-ctl -l '"msm_csid0":1->"msm_vfe0_rdi0":0[1]'
+
+yavta -B capture-mplane -c -I -n 5 -f SRGGB10P -s 4056x3040 -F /dev/video0
+
+Signed-off-by: Hariram Purushothaman <quic_hariramp@quicinc.com>
+Signed-off-by: Trishansh Bhardwaj <quic_tbhardwa@quicinc.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Vikram Sharma <quic_vikramsa@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250208225143.2868279-1-quic_vikramsa@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/Makefile             |  4 +
+ .../qcs6490-rb3gen2-vision-mezzanine.dtso     | 89 +++++++++++++++++++
+ 2 files changed, 93 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-vision-mezzanine.dtso
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index 140b0b2abfb5..213d941b1b79 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -116,6 +116,10 @@ dtb-$(CONFIG_ARCH_QCOM)	+= qcs404-evb-1000.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs404-evb-4000.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2.dtb
++
++qcs6490-rb3gen2-vision-mezzanine-dtbs := qcs6490-rb3gen2.dtb qcs6490-rb3gen2-vision-mezzanine.dtbo
++
++dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2-vision-mezzanine.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs8300-ride.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs8550-aim300-aiot.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride.dtb
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-vision-mezzanine.dtso b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-vision-mezzanine.dtso
+new file mode 100644
+index 000000000000..b9e4a5214f70
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-vision-mezzanine.dtso
+@@ -0,0 +1,89 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++/*
++ * Camera Sensor overlay on top of rb3gen2 core kit.
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/clock/qcom,camcc-sc7280.h>
++#include <dt-bindings/gpio/gpio.h>
++
++&camss {
++	vdda-phy-supply = <&vreg_l10c_0p88>;
++	vdda-pll-supply = <&vreg_l6b_1p2>;
++
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		/* The port index denotes CSIPHY id i.e. csiphy3 */
++		port@3 {
++			reg = <3>;
++
++			csiphy3_ep: endpoint {
++				clock-lanes = <7>;
++				data-lanes = <0 1 2 3>;
++				remote-endpoint = <&imx577_ep>;
++			};
++		};
++	};
++};
++
++&cci1 {
++	status = "okay";
++};
++
++&cci1_i2c1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	camera@1a {
++		compatible = "sony,imx577";
++
++		reg = <0x1a>;
++
++		reset-gpios = <&tlmm 78 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "suspend";
++		pinctrl-0 = <&cam2_default>;
++		pinctrl-1 = <&cam2_suspend>;
++
++		clocks = <&camcc CAM_CC_MCLK3_CLK>;
++		assigned-clocks = <&camcc CAM_CC_MCLK3_CLK>;
++		assigned-clock-rates = <24000000>;
++
++		dovdd-supply = <&vreg_l18b_1p8>;
++		avdd-supply = <&vph_pwr>;
++		dvdd-supply = <&vph_pwr>;
++
++		port {
++			imx577_ep: endpoint {
++				link-frequencies = /bits/ 64 <600000000>;
++				data-lanes = <1 2 3 4>;
++				remote-endpoint = <&csiphy3_ep>;
++			};
++		};
++	};
++};
++
++&tlmm {
++	cam2_default: cam2-default-state {
++		pins = "gpio67";
++		function = "cam_mclk";
++		drive-strength = <2>;
++		bias-disable;
++	};
++
++	cam2_suspend: cam2-suspend-state {
++		pins = "gpio67";
++		function = "cam_mclk";
++		drive-strength = <2>;
++		bias-pull-down;
++	};
++};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-media-dt-bindings-update-clocks-for-sc7280-camss.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-media-dt-bindings-update-clocks-for-sc7280-camss.patch
@@ -1,0 +1,61 @@
+From f710ff82818a878e3137e9948e00d83116b1b4cd Mon Sep 17 00:00:00 2001
+From: Vikram Sharma <quic_vikramsa@quicinc.com>
+Date: Tue, 21 Jan 2025 23:37:45 +0530
+Subject: [PATCH 2/2] media: dt-bindings: update clocks for sc7280-camss
+
+Update clock names to make them consistent with existing platform i.e
+qcom,sc8280xp-camss.yaml. Rename gcc_cam_hf_axi to gcc_axi_hf and add
+gcc_axi_sf.
+
+gcc_camera_ahb is always on and we don't need to enable it explicitly.
+gcc_axi_sf is added to avoid unexpected hardware behaviour.
+
+This change will not break ABI because the ABI hasn't been cemented yet as
+the dtsi changes are not merged yet and there are no users for this driver
+as of now.
+
+Signed-off-by: Vikram Sharma <quic_vikramsa@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250121180746.1989996-1-quic_vikramsa@quicinc.com/]
+---
+ .../devicetree/bindings/media/qcom,sc7280-camss.yaml   | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/media/qcom,sc7280-camss.yaml b/Documentation/devicetree/bindings/media/qcom,sc7280-camss.yaml
+index e11141b812a0..ee35e3bc97ff 100644
+--- a/Documentation/devicetree/bindings/media/qcom,sc7280-camss.yaml
++++ b/Documentation/devicetree/bindings/media/qcom,sc7280-camss.yaml
+@@ -55,8 +55,8 @@ properties:
+       - const: csiphy3_timer
+       - const: csiphy4
+       - const: csiphy4_timer
+-      - const: gcc_camera_ahb
+-      - const: gcc_cam_hf_axi
++      - const: gcc_axi_hf
++      - const: gcc_axi_sf
+       - const: icp_ahb
+       - const: vfe0
+       - const: vfe0_axi
+@@ -310,8 +310,8 @@ examples:
+                      <&camcc CAM_CC_CSI3PHYTIMER_CLK>,
+                      <&camcc CAM_CC_CSIPHY4_CLK>,
+                      <&camcc CAM_CC_CSI4PHYTIMER_CLK>,
+-                     <&gcc GCC_CAMERA_AHB_CLK>,
+                      <&gcc GCC_CAMERA_HF_AXI_CLK>,
++                     <&gcc GCC_CAMERA_SF_AXI_CLK>,
+                      <&camcc CAM_CC_ICP_AHB_CLK>,
+                      <&camcc CAM_CC_IFE_0_CLK>,
+                      <&camcc CAM_CC_IFE_0_AXI_CLK>,
+@@ -343,8 +343,8 @@ examples:
+                           "csiphy3_timer",
+                           "csiphy4",
+                           "csiphy4_timer",
+-                          "gcc_camera_ahb",
+-                          "gcc_cam_hf_axi",
++                          "gcc_axi_hf",
++                          "gcc_axi_sf",
+                           "icp_ahb",
+                           "vfe0",
+                           "vfe0_axi",
+-- 
+2.34.1
+


### PR DESCRIPTION
Frame Capture Test

```
media-ctl --reset
media-ctl -v -V '"imx577 '19-001a'":0[fmt:SRGGB10/4056x3040 field:none]'
media-ctl -V '"msm_csiphy3":0[fmt:SRGGB10/4056x3040]'
media-ctl -V '"msm_csid0":0[fmt:SRGGB10/4056x3040]'
media-ctl -V '"msm_vfe0_rdi0":0[fmt:SRGGB10/4056x3040]'
media-ctl -l '"msm_csiphy3":1->"msm_csid0":0[1]'
media-ctl -l '"msm_csid0":1->"msm_vfe0_rdi0":0[1]'

read -p "Start capturing " foo
yavta -B capture-mplane -c -I -n 5 -f SRGGB10P -s 4056x3040 -F /dev/video0

```

Videosink test (gstreamer)

`gst-launch libcamerasrc ! videoconvert ! autovideosink`

**Notes**
Note that the 12MP camera sensor (`imx577`) is multiplanar and therefore[ not supported natively](https://github.com/PipeWire/pipewire/blob/master/spa/plugins/v4l2/v4l2-utils.c#L80) by Pipewire. The libcamera spa (`libspa-0.2-libcamera`) is required for Pipewire to be able to detect the camera as a source.

Also, the camera generates `SRGGB10P` (10 bit packed format) and since there is no ISP converting Bayer to RGB, this must be done via software (libcamera takes care of that as well: run gst-launch in a verbose way to check the cpu involvement).

Convenient to enable CONFIG_UDMABUF for the Gstreamer pipeline.


