### PR TITLE
adb serial number: fall back option to populate serial number

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
@@ -1,5 +1,7 @@
 manufacturer=Qualcomm
 model=`hostname`
 androidserial="$(sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline)"
+[ -z "$androidserial" ] && [ -e /dev/sda ] && scsiserialline=$(udevadm info /dev/sda | grep ID_SCSI_SERIAL) && scsiserialvalue=$(echo "$scsiserialline" | awk -F= '{print $2}') && androidserial=$(echo -n "$scsiserialvalue" | crc32)
+[ -z "$androidserial" ] && [ -e /sys/class/mmc_host/mmc0/mmc0:0001/serial ] && androidserial=$(sed 's/0x//' /sys/class/mmc_host/mmc0/mmc0:0001/serial)
 [ -n "$androidserial" ] && serial="$androidserial"
 true


### PR DESCRIPTION
when androidboot.serialno is not available in cmdline then populate adb serial number from firmware platform-parts-info dt entry.