### PR TITLE
Add custom BSP selection support

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -1,5 +1,11 @@
 # Common configurations and variables for Qualcomm platforms.
 
+# 'custom' BSP selection on top of the default BSP, provides additional functionality
+# such as addon DT overlays, downstream DLKMs, and QCOM-specific user space frameworks.
+# Specific MACHINEs or DISTROs may choose this configuration to utilize addon features.
+QCOM_SELECTED_BSP ??= ""
+MACHINEOVERRIDES =. "${@bb.utils.contains('QCOM_SELECTED_BSP', 'custom', 'qcom-custom-bsp:', '', d)}"
+
 # Provider for linux kernel
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -10,6 +10,12 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \
                       "
 
+# The addon DTs produced by the linux-qcom-staging kernel are not yet upstreamed.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcm6490-addons-idp.dtb \
+                      qcom/qcm6490-addons-idp-amoled.dtb \
+                      "
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -10,6 +10,11 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       "
 
+# The addon DTs produced by the linux-qcom-staging kernel are not yet upstreamed.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcs6490-addons-rb3gen2.dtb \
+                      "
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -13,6 +13,14 @@ KERNEL_DEVICETREE ?= " \
                       qcom/sa8775p-ride-r3.dtb \
                       "
 
+# The addon DTs produced by the linux-qcom-staging kernel are not yet upstreamed.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcs9100-addons-ride.dtb \
+                      qcom/qcs9100-addons-ride-r3.dtb \
+                      qcom/sa8775p-addons-ride.dtb \
+                      qcom/sa8775p-addons-ride-r3.dtb \
+                      "
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-sa8775p-ride-firmware \
     packagegroup-sa8775p-ride-hexagon-dsp-binaries \

--- a/recipes-kernel/linux/linux-qcom-staging_6.12.bb
+++ b/recipes-kernel/linux/linux-qcom-staging_6.12.bb
@@ -26,7 +26,7 @@ S = "${WORKDIR}/git"
 KERNEL_CONFIG ?= "qcom_defconfig"
 
 # Additional fragment for qcom value add features
-KERNEL_CONFIG_FRAGMENTS += " ${S}/arch/arm64/configs/qcom_addons.config"
+KERNEL_CONFIG_FRAGMENTS:append:qcom-custom-bsp = " ${S}/arch/arm64/configs/qcom_addons.config"
 
 do_configure:prepend() {
     if [ ! -f "${S}/arch/${ARCH}/configs/${KERNEL_CONFIG}" ]; then


### PR DESCRIPTION
To enable additional value adds of the QCOM BSP, introduce custom BSP selection support. Selecting this override would bring in add-on device-tree overlays, additional kernel modules, and the option to choose user space frameworks specific to QCOM value adds.
    
The 'custom BSP' can be selected by adding `QCOM_SELECTED_BSP = "custom"` in a configuration file like local.conf. This results in `MACHINEOVERRIDES = "xxx:qcom-custom-bsp:yyy"`.