### PR TITLE
rb3gen2: lpass 

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -21,6 +21,7 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Modify-WSA-and-VA-mac.patch \
     file://qcm6490-board-dts/0004-arm64-dts-qcom-qcs6490-rb3gen2-add-WSA8830-speakers-.patch \
     file://qcm6490-board-dts/0005-arm64-dts-qcom-qcs6490-rb3gen2-Add-sound-card.patch \
+    file://qcm6490-board-dts/0001-dts-rb3gen2-soundwire-checkin.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -13,6 +13,9 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0002-arm64-dts-qcom-qcs6490-rb3gen2-vision-mezzanine-Add-.patch \
     file://qcm6490-board-dts/0002-media-dt-bindings-update-clocks-for-sc7280-camss.patch \
     file://qcm6490-board-dts/0001-PENDING-enable-xHCI.patch \
+    file://qcm6490-board-dts/0001-dt-bindings-clock-qcom-Add-compatible-for.patch \
+    file://qcm6490-board-dts/0002-arm64-dts-qcom-qcm6490-idp-Update-the-LPASS.patch \
+    file://qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Update-the-LPASS-audi.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \
@@ -22,6 +25,7 @@ SRC_URI:append:qcom = " \
     file://drivers/0007-PCI-PCI-Add-pcie_is_link_active-to-determine-if-the-.patch \
     file://drivers/0008-PCI-pwrctrl-Add-power-control-driver-for-tc956x.patch \
     file://drivers/0001-media-qcom-camss-update-clock-names-for-sc7280.patch \
+    file://drivers/0004-clk-qcom-lpassaudiocc-sc7280-Add-support-for-LPASS-r.patch \
 "
 
 # Include additional kernel configs.

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -16,6 +16,11 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0001-dt-bindings-clock-qcom-Add-compatible-for.patch \
     file://qcm6490-board-dts/0002-arm64-dts-qcom-qcm6490-idp-Update-the-LPASS.patch \
     file://qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Update-the-LPASS-audi.patch \
+    file://qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-gpr-node.patch \
+    file://qcm6490-board-dts/0002-arm64-dts-qcom-sc7280-Add-WSA-SoundWire-and-LPASS-su.patch \
+    file://qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Modify-WSA-and-VA-mac.patch \
+    file://qcm6490-board-dts/0004-arm64-dts-qcom-qcs6490-rb3gen2-add-WSA8830-speakers-.patch \
+    file://qcm6490-board-dts/0005-arm64-dts-qcom-qcs6490-rb3gen2-Add-sound-card.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \

--- a/recipes-kernel/linux/linux-yocto-dev/drivers/0004-clk-qcom-lpassaudiocc-sc7280-Add-support-for-LPASS-r.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/drivers/0004-clk-qcom-lpassaudiocc-sc7280-Add-support-for-LPASS-r.patch
@@ -1,0 +1,89 @@
+From a475928e65aa6808a9fdd56b8612f355b3c16c67 Mon Sep 17 00:00:00 2001
+From: Taniya Das <quic_tdas@quicinc.com>
+Date: Sat, 22 Feb 2025 09:17:15 +0100
+Subject: [PATCH 4/4] clk: qcom: lpassaudiocc-sc7280: Add support for LPASS
+ resets for QCM6490
+
+On the QCM6490 boards, the LPASS firmware controls the complete clock
+controller functionalities and associated power domains. However, only
+the LPASS resets required to be controlled by the high level OS. Thus,
+add support for the resets in the clock driver to enable the Audio SW
+driver to assert/deassert the audio resets as needed.
+
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Signed-off-by: Taniya Das <quic_tdas@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250221-lpass_qcm6490_resets-v5-2-6be0c0949a83@quicinc.com/]
+---
+ drivers/clk/qcom/lpassaudiocc-sc7280.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/clk/qcom/lpassaudiocc-sc7280.c b/drivers/clk/qcom/lpassaudiocc-sc7280.c
+index 45e726477086..22169da08a51 100644
+--- a/drivers/clk/qcom/lpassaudiocc-sc7280.c
++++ b/drivers/clk/qcom/lpassaudiocc-sc7280.c
+@@ -1,6 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
+  * Copyright (c) 2021, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/clk-provider.h>
+@@ -713,14 +714,24 @@ static const struct qcom_reset_map lpass_audio_cc_sc7280_resets[] = {
+ 	[LPASS_AUDIO_SWR_WSA_CGCR] = { 0xb0, 1 },
+ };
+ 
++static const struct regmap_config lpass_audio_cc_sc7280_reset_regmap_config = {
++	.name = "lpassaudio_cc_reset",
++	.reg_bits = 32,
++	.reg_stride = 4,
++	.val_bits = 32,
++	.fast_io = true,
++	.max_register = 0xc8,
++};
++
+ static const struct qcom_cc_desc lpass_audio_cc_reset_sc7280_desc = {
+-	.config = &lpass_audio_cc_sc7280_regmap_config,
++	.config = &lpass_audio_cc_sc7280_reset_regmap_config,
+ 	.resets = lpass_audio_cc_sc7280_resets,
+ 	.num_resets = ARRAY_SIZE(lpass_audio_cc_sc7280_resets),
+ };
+ 
+ static const struct of_device_id lpass_audio_cc_sc7280_match_table[] = {
+-	{ .compatible = "qcom,sc7280-lpassaudiocc" },
++	{ .compatible = "qcom,qcm6490-lpassaudiocc", .data = &lpass_audio_cc_reset_sc7280_desc },
++	{ .compatible = "qcom,sc7280-lpassaudiocc", .data = &lpass_audio_cc_sc7280_desc },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, lpass_audio_cc_sc7280_match_table);
+@@ -752,13 +763,17 @@ static int lpass_audio_cc_sc7280_probe(struct platform_device *pdev)
+ 	struct regmap *regmap;
+ 	int ret;
+ 
++	desc = device_get_match_data(&pdev->dev);
++
++	if (of_device_is_compatible(pdev->dev.of_node, "qcom,qcm6490-lpassaudiocc"))
++		return qcom_cc_probe_by_index(pdev, 1, desc);
++
+ 	ret = lpass_audio_setup_runtime_pm(pdev);
+ 	if (ret)
+ 		return ret;
+ 
+ 	lpass_audio_cc_sc7280_regmap_config.name = "lpassaudio_cc";
+ 	lpass_audio_cc_sc7280_regmap_config.max_register = 0x2f000;
+-	desc = &lpass_audio_cc_sc7280_desc;
+ 
+ 	regmap = qcom_cc_map(pdev, desc);
+ 	if (IS_ERR(regmap)) {
+@@ -772,7 +787,7 @@ static int lpass_audio_cc_sc7280_probe(struct platform_device *pdev)
+ 	regmap_write(regmap, 0x4, 0x3b);
+ 	regmap_write(regmap, 0x8, 0xff05);
+ 
+-	ret = qcom_cc_really_probe(&pdev->dev, &lpass_audio_cc_sc7280_desc, regmap);
++	ret = qcom_cc_really_probe(&pdev->dev, desc, regmap);
+ 	if (ret) {
+ 		dev_err(&pdev->dev, "Failed to register LPASS AUDIO CC clocks\n");
+ 		goto exit;
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-gpr-node.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-Add-gpr-node.patch
@@ -1,0 +1,75 @@
+From d917cb1baa4c2144317c3d38a3977c7e6dea9cf7 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Date: Mon, 17 Mar 2025 11:11:44 +0530
+Subject: [PATCH 1/5] arm64: dts: qcom: sc7280: Add gpr node
+
+Add GPR node along with APM(Audio Process Manager) and PRM(Proxy
+resource Manager) audio services.
+
+Signed-off-by: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Co-developed-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Signed-off-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250317054151.6095-1-quic_pkumpatl@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/sc7280.dtsi | 37 ++++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 7c4f48783656..4ec39782f772 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -25,6 +25,8 @@
+ #include <dt-bindings/reset/qcom,sdm845-aoss.h>
+ #include <dt-bindings/reset/qcom,sdm845-pdc.h>
+ #include <dt-bindings/soc/qcom,apr.h>
++#include <dt-bindings/soc/qcom,gpr.h>
++#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
+ #include <dt-bindings/soc/qcom,rpmh-rsc.h>
+ #include <dt-bindings/sound/qcom,lpass.h>
+ #include <dt-bindings/thermal/thermal.h>
+@@ -3865,6 +3867,41 @@ q6routing: routing {
+ 					};
+ 				};
+ 
++				gpr {
++					compatible = "qcom,gpr";
++					qcom,glink-channels = "adsp_apps";
++					qcom,domain = <GPR_DOMAIN_ID_ADSP>;
++					qcom,intents = <512 20>;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					q6apm: service@1 {
++						compatible = "qcom,q6apm";
++						reg = <GPR_APM_MODULE_IID>;
++						#sound-dai-cells = <0>;
++
++						q6apmdai: dais {
++							compatible = "qcom,q6apm-dais";
++							iommus = <&apps_smmu 0x1801 0x0>;
++						};
++
++						q6apmbedai: bedais {
++							compatible = "qcom,q6apm-lpass-dais";
++							#sound-dai-cells = <1>;
++						};
++					};
++
++					q6prm: service@2 {
++						compatible = "qcom,q6prm";
++						reg = <GPR_PRM_MODULE_IID>;
++
++						q6prmcc: clock-controller {
++							compatible = "qcom,q6prm-lpass-clocks";
++							#clock-cells = <2>;
++						};
++					};
++				};
++
+ 				fastrpc {
+ 					compatible = "qcom,fastrpc";
+ 					qcom,glink-channels = "fastrpcglink-apps-dsp";
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-dt-bindings-clock-qcom-Add-compatible-for.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-dt-bindings-clock-qcom-Add-compatible-for.patch
@@ -1,0 +1,43 @@
+From d6e1925bc276590b40943d233cf198a64fb9bd19 Mon Sep 17 00:00:00 2001
+From: Taniya Das <quic_tdas@quicinc.com>
+Date: Wed, 5 Mar 2025 16:19:25 +0100
+Subject: [PATCH 1/4] dt-bindings: clock: qcom: Add compatible for
+
+On the QCM6490 boards, the LPASS firmware controls the complete clock
+controller functionalities and associated power domains. However, only
+the LPASS resets required to be controlled by the high level OS. Thus,
+add the new QCM6490 compatible to support the reset functionality for
+Low Power Audio subsystem.
+
+Signed-off-by: Taniya Das <quic_tdas@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250221-lpass_qcm6490_resets-v5-1-6be0c0949a83@quicinc.com/]
+---
+ .../devicetree/bindings/clock/qcom,sc7280-lpasscorecc.yaml   | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/devicetree/bindings/clock/qcom,sc7280-lpasscorecc.yaml b/Documentation/devicetree/bindings/clock/qcom,sc7280-lpasscorecc.yaml
+index 488d63959424..99ab9106009f 100644
+--- a/Documentation/devicetree/bindings/clock/qcom,sc7280-lpasscorecc.yaml
++++ b/Documentation/devicetree/bindings/clock/qcom,sc7280-lpasscorecc.yaml
+@@ -20,6 +20,7 @@ description: |
+ properties:
+   compatible:
+     enum:
++      - qcom,qcm6490-lpassaudiocc
+       - qcom,sc7280-lpassaoncc
+       - qcom,sc7280-lpassaudiocc
+       - qcom,sc7280-lpasscorecc
+@@ -68,7 +69,9 @@ allOf:
+       properties:
+         compatible:
+           contains:
+-            const: qcom,sc7280-lpassaudiocc
++            enum:
++              - qcom,qcm6490-lpassaudiocc
++              - qcom,sc7280-lpassaudiocc
+ 
+     then:
+       properties:
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-dts-rb3gen2-soundwire-checkin.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-dts-rb3gen2-soundwire-checkin.patch
@@ -1,0 +1,40 @@
+From d8535dbed058a3cb8c43a343624b315501b16433 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Date: Wed, 26 Mar 2025 17:49:03 +0100
+Subject: [PATCH] dts: rb3gen2: fix soundwire probe
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Upstream-Status: Pending [shared internally]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index b993665ca953..041bb96ca69a 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -1116,8 +1116,8 @@ tc956x_rst_state: tc956x-rst-state {
+ };
+ 
+ &swr2 {
+-	qcom,din-ports = <0>;
+-	qcom,dout-ports = <8>;
++	qcom,din-ports = <2>;
++	qcom,dout-ports = <6>;
+ 
+ 	left_spkr: speaker@0,1 {
+ 		compatible = "sdw10217020200";
+@@ -1142,6 +1142,10 @@ right_spkr: speaker@0,2 {
+ 	};
+ };
+ 
++&swr2 {
++       status = "okay";
++};
++
+ &tlmm {
+ 	gpio-reserved-ranges = <32 2>, /* ADSP */
+ 			       <48 4>; /* NFC */
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-qcm6490-idp-Update-the-LPASS.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-qcm6490-idp-Update-the-LPASS.patch
@@ -1,0 +1,33 @@
+From 1946a1cd6f785c856016a08ec23b76ba485ea6e6 Mon Sep 17 00:00:00 2001
+From: Taniya Das <quic_tdas@quicinc.com>
+Date: Sat, 22 Feb 2025 09:18:51 +0100
+Subject: [PATCH 2/4] arm64: dts: qcom: qcm6490-idp: Update the LPASS
+
+Update the lpassaudio node to support the new compatible as the
+lpassaudio needs to support the reset functionality on the
+QCM6490 IDP board and the rest of the Audio functionality would be
+provided from the LPASS firmware.
+
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Signed-off-by: Taniya Das <quic_tdas@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250221-lpass_qcm6490_resets-v5-3-6be0c0949a83@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index 391f1e9efc8b..8b7d67874fce 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -799,3 +799,8 @@ &wifi {
+ 
+ 	status = "okay";
+ };
++
++&lpass_audiocc {
++	compatible = "qcom,qcm6490-lpassaudiocc";
++	/delete-property/ power-domains;
++};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-sc7280-Add-WSA-SoundWire-and-LPASS-su.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0002-arm64-dts-qcom-sc7280-Add-WSA-SoundWire-and-LPASS-su.patch
@@ -1,0 +1,105 @@
+From edafdd4685bf195d72396dfac5c1578204314e55 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Date: Mon, 17 Mar 2025 11:11:45 +0530
+Subject: [PATCH 2/5] arm64: dts: qcom: sc7280: Add WSA SoundWire and LPASS
+ support
+
+Add WSA macroLPASS Codecs along with SoundWire controller.
+
+Signed-off-by: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Co-developed-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Signed-off-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250317054151.6095-1-quic_pkumpatl@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/sc7280.dtsi | 68 ++++++++++++++++++++++++++++
+ 1 file changed, 68 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 4ec39782f772..e8937c49a1e2 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -2610,6 +2610,64 @@ swr1: soundwire@3230000 {
+ 			status = "disabled";
+ 		};
+ 
++		lpass_wsa_macro: codec@3240000 {
++			compatible = "qcom,sc7280-lpass-wsa-macro";
++			reg = <0x0 0x03240000 0x0 0x1000>;
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&lpass_wsa_swr_clk>, <&lpass_wsa_swr_data>;
++
++			clocks = <&lpass_aon LPASS_AON_CC_TX_MCLK_CLK>,
++				 <&lpass_aon LPASS_AON_CC_TX_MCLK_2X_CLK>,
++				 <&lpass_va_macro>;
++			clock-names = "mclk", "npl", "fsgen";
++
++			power-domains = <&lpass_hm LPASS_CORE_CC_LPASS_CORE_HM_GDSC>,
++					<&lpass_aon LPASS_AON_CC_LPASS_AUDIO_HM_GDSC>;
++			power-domain-names = "macro", "dcodec";
++
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++
++			status = "disabled";
++		};
++
++		swr2: soundwire@3250000 {
++			compatible = "qcom,soundwire-v1.6.0";
++			reg = <0x0 0x03250000 0x0 0x2000>;
++
++			interrupts = <GIC_SPI 170 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&lpass_wsa_macro>;
++			clock-names = "iface";
++
++			qcom,din-ports = <2>;
++			qcom,dout-ports = <6>;
++
++			resets = <&lpass_audiocc LPASS_AUDIO_SWR_WSA_CGCR>;
++			reset-names = "swr_audio_cgcr";
++
++			qcom,ports-sinterval-low = /bits/ 8 <0x07 0x1f 0x3f 0x07
++								0x1f 0x3f 0x0f 0x0f>;
++			qcom,ports-offset1 = /bits/ 8 <0x01 0x02 0x0c 0x06 0x12 0x0d 0x07 0x0a>;
++			qcom,ports-offset2 = /bits/ 8 <0xff 0x00 0x1f 0xff 0x00 0x1f 0x00 0x00>;
++			qcom,ports-hstart = /bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
++			qcom,ports-hstop = /bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
++			qcom,ports-word-length = /bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
++			qcom,ports-block-pack-mode = /bits/ 8 <0xff 0xff 0x01 0xff 0xff 0x01
++							       0xff 0xff>;
++			qcom,ports-block-group-count = /bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff
++								0xff 0xff>;
++			qcom,ports-lane-control = /bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff
++							    0xff 0xff>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++			#sound-dai-cells = <1>;
++
++			status = "disabled";
++		};
++
+ 		lpass_audiocc: clock-controller@3300000 {
+ 			compatible = "qcom,sc7280-lpassaudiocc";
+ 			reg = <0 0x03300000 0 0x30000>,
+@@ -2816,6 +2874,16 @@ lpass_tx_swr_data: tx-swr-data-state {
+ 				pins = "gpio1", "gpio2", "gpio14";
+ 				function = "swr_tx_data";
+ 			};
++
++			lpass_wsa_swr_clk: wsa-swr-clk-state {
++				pins = "gpio10";
++				function = "wsa_swr_clk";
++			};
++
++			lpass_wsa_swr_data: wsa-swr-data-state {
++				pins = "gpio11";
++				function = "wsa_swr_data";
++			};
+ 		};
+ 
+ 		gpu: gpu@3d00000 {
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Modify-WSA-and-VA-mac.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Modify-WSA-and-VA-mac.patch
@@ -1,0 +1,70 @@
+From 0c90f9d90ff75ac50db39ec199b25725d97c0620 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Date: Mon, 17 Mar 2025 11:11:46 +0530
+Subject: [PATCH 3/5] arm64: dts: qcom: qcs6490-rb3gen2: Modify WSA and VA
+ macro clock nodes for audioreach solution
+
+Modify and enable WSA, VA and lpass_tlmm clock properties.
+For audioreach solution mclk, npl and fsgen clocks
+are enabled through the q6prm clock driver.
+
+Signed-off-by: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Co-developed-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Signed-off-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250317054151.6095-1-quic_pkumpatl@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 31 ++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index e962b3ae3400..5de90307e440 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -12,6 +12,7 @@
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+ #include <dt-bindings/regulator/qcom,rpmh-regulator.h>
++#include <dt-bindings/sound/qcom,q6afe.h>
+ #include "sc7280.dtsi"
+ #include "pm7250b.dtsi"
+ #include "pm7325.dtsi"
+@@ -716,6 +717,36 @@ redriver_usb_con_sbu: endpoint {
+ 	};
+ };
+ 
++&lpass_tlmm {
++	clocks = <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++	clock-names = "core", "audio";
++};
++
++&lpass_va_macro {
++	/delete-property/ power-domains;
++	/delete-property/ power-domain-names;
++	clocks = <&q6prmcc LPASS_CLK_ID_VA_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++	clock-names = "mclk", "macro", "dcodec";
++
++	status = "okay";
++};
++
++&lpass_wsa_macro {
++	/delete-property/ power-domains;
++	/delete-property/ power-domain-names;
++	clocks = <&q6prmcc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_CLK_ID_TX_CORE_NPL_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++		 <&lpass_va_macro>;
++	clock-names = "mclk", "npl", "macro", "dcodec", "fsgen";
++
++	status = "okay";
++};
++
+ &mdss {
+ 	status = "okay";
+ };
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Update-the-LPASS-audi.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0003-arm64-dts-qcom-qcs6490-rb3gen2-Update-the-LPASS-audi.patch
@@ -1,0 +1,34 @@
+From 0dcf3d16e8053e2c168b166a061782fa3f5bb06a Mon Sep 17 00:00:00 2001
+From: Taniya Das <quic_tdas@quicinc.com>
+Date: Wed, 5 Mar 2025 16:24:17 +0100
+Subject: [PATCH] arm64: dts: qcom: qcs6490-rb3gen2: Update the LPASS audio
+ node
+
+Update the lpassaudio node to support the new compatible as the
+lpassaudio needs to support the reset functionality on the
+QCS6490 RB3Gen2 board and the rest of the Audio functionality would be
+provided from the LPASS firmware.
+
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Signed-off-by: Taniya Das <quic_tdas@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250221-lpass_qcm6490_resets-v5-4-6be0c0949a83@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 13dbb24a3179..ecbb0373e2ab 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -1102,3 +1102,8 @@ sd_cd: sd-cd-state {
+ 		bias-pull-up;
+ 	};
+ };
++
++&lpass_audiocc {
++	compatible = "qcom,qcm6490-lpassaudiocc";
++	/delete-property/ power-domains;
++};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0004-arm64-dts-qcom-qcs6490-rb3gen2-add-WSA8830-speakers-.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0004-arm64-dts-qcom-qcs6490-rb3gen2-add-WSA8830-speakers-.patch
@@ -1,0 +1,57 @@
+From 41a4a1b2fb8086905655654b910a10c16ace3c63 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Date: Tue, 25 Mar 2025 17:19:40 +0100
+Subject: [PATCH 4/5] arm64: dts: qcom: qcs6490-rb3gen2: add WSA8830 speakers
+ amplifier
+
+Add nodes for WSA8830 speakers amplifier on qcs6490-rb3gen2 board.
+
+Signed-off-by: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Co-developed-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Signed-off-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250317054151.6095-1-quic_pkumpatl@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 27 ++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 5de90307e440..d35878783d5d 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -1035,6 +1035,33 @@ tc956x_rst_state: tc956x-rst-state {
+ 	};
+ };
+ 
++&swr2 {
++	qcom,din-ports = <0>;
++	qcom,dout-ports = <8>;
++
++	left_spkr: speaker@0,1 {
++		compatible = "sdw10217020200";
++		reg = <0 1>;
++		powerdown-gpios = <&tlmm 158 GPIO_ACTIVE_LOW>;
++		#sound-dai-cells = <0>;
++		sound-name-prefix = "SpkrLeft";
++		#thermal-sensor-cells = <0>;
++		vdd-supply = <&vreg_l18b_1p8>;
++		qcom,port-mapping = <1 2 3 7>;
++	};
++
++	right_spkr: speaker@0,2 {
++		compatible = "sdw10217020200";
++		reg = <0 2>;
++		powerdown-gpios = <&tlmm 158 GPIO_ACTIVE_LOW>;
++		#sound-dai-cells = <0>;
++		sound-name-prefix = "SpkrRight";
++		#thermal-sensor-cells = <0>;
++		vdd-supply = <&vreg_l18b_1p8>;
++		qcom,port-mapping = <4 5 6 8>;
++	};
++};
++
+ &tlmm {
+ 	gpio-reserved-ranges = <32 2>, /* ADSP */
+ 			       <48 4>; /* NFC */
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0005-arm64-dts-qcom-qcs6490-rb3gen2-Add-sound-card.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0005-arm64-dts-qcom-qcs6490-rb3gen2-Add-sound-card.patch
@@ -1,0 +1,117 @@
+From 2a9acb925633a309018a393ea4f64cdafcde5ef9 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Date: Tue, 25 Mar 2025 17:21:22 +0100
+Subject: [PATCH 5/5] arm64: dts: qcom: qcs6490-rb3gen2: Add sound card
+
+Add the sound card node with tested playback over WSA8835 speakers
+and msm mics.
+
+Signed-off-by: Mohammad Rafi Shaik <quic_mohs@quicinc.com>
+Co-developed-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Signed-off-by: Prasad Kumpatla <quic_pkumpatl@quicinc.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250317054151.6095-1-quic_pkumpatl@quicinc.com/]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 80 ++++++++++++++++++++
+ 1 file changed, 80 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index d35878783d5d..b993665ca953 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -269,6 +269,56 @@ vreg-pcie0_3p3v-dual {
+ 
+ 		regulator-always-on;
+ 	};
++
++	sound: sound {
++		compatible = "qcom,qcs6490-rb3gen2-sndcard";
++		model = "qcs6490-rb3gen2-snd-card";
++
++		audio-routing =
++			"SpkrLeft IN", "WSA_SPK1 OUT",
++			"SpkrRight IN", "WSA_SPK2 OUT",
++			"VA DMIC0", "vdd-micb",
++			"VA DMIC1", "vdd-micb",
++			"VA DMIC2", "vdd-micb",
++			"VA DMIC3", "vdd-micb";
++
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++		wsa-dai-link {
++			link-name = "CODEC_DMA-LPAIF_WSA-RX-0";
++
++			cpu {
++				sound-dai = <&q6apmbedai WSA_CODEC_DMA_RX_0>;
++			};
++
++			codec {
++				sound-dai = <&left_spkr>, <&right_spkr>, <&swr2 0>,
++					    <&lpass_wsa_macro 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		va-dai-link {
++			link-name = "CODEC_DMA-LPAIF_VA-TX-0";
++
++			cpu {
++				sound-dai = <&q6apmbedai VA_CODEC_DMA_TX_0>;
++			};
++
++			codec {
++				sound-dai = <&lpass_va_macro 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++	};
++
+ };
+ 
+ &apps_rsc {
+@@ -747,6 +797,36 @@ &lpass_wsa_macro {
+ 	status = "okay";
+ };
+ 
++&lpass_dmic01_clk {
++	drive-strength = <8>;
++	bias-disable;
++};
++
++&lpass_dmic01_data {
++	bias-pull-down;
++};
++
++&lpass_dmic23_clk {
++	drive-strength = <8>;
++	bias-disable;
++};
++
++&lpass_dmic23_data {
++	bias-pull-down;
++};
++
++&lpass_wsa_swr_clk {
++	drive-strength = <2>;
++	slew-rate = <1>;
++	bias-disable;
++};
++
++&lpass_wsa_swr_data {
++	drive-strength = <2>;
++	slew-rate = <1>;
++	bias-bus-hold;
++};
++
+ &mdss {
+ 	status = "okay";
+ };
+-- 
+2.34.1
+


### PR DESCRIPTION
Enable audio support on RB3Gen2.

Tested:
 **- output:**
  `aplay` to main board speaker outputs
**- input**
  microphone not tested
```

amixer -c 0 cset iface=MIXER,name='SpkrLeft PA Volume' '20'
amixer -c 0 cset iface=MIXER,name='WSA RX0 MUX' 'AIF1_PB'
amixer -c 0 cset iface=MIXER,name='WSA_RX0 INP0' 'RX0'
amixer -c 0 cset iface=MIXER,name='WSA_COMP1 Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrLeft WSA MODE' '0'
amixer -c 0 cset iface=MIXER,name='SpkrLeft COMP Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrLeft BOOST Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrLeft DAC Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrLeft VISENSE Switch' '0'
amixer -c 0 cset iface=MIXER,name='WSA_RX0 Digital Volume'  '85'
amixer -c 0 cset iface=MIXER,name='SpkrRight WSA MODE' '0'
amixer -c 0 cset iface=MIXER,name='SpkrRight PA Volume' '20'
amixer -c 0 cset iface=MIXER,name='WSA RX1 MUX' 'AIF1_PB'
amixer -c 0 cset iface=MIXER,name='WSA_RX1 INP0' 'RX1'
amixer -c 0 cset iface=MIXER,name='WSA_COMP2 Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrRight WSA MODE' '0'
amixer -c 0 cset iface=MIXER,name='SpkrRight COMP Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrRight BOOST Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrRight DAC Switch' '1'
amixer -c 0 cset iface=MIXER,name='SpkrRight VISENSE Switch' '0'
amixer -c 0 cset iface=MIXER,name='WSA_RX1 Digital Volume'  '85'
amixer -c 0 cset iface=MIXER,name='WSA_CODEC_DMA_RX_0 Audio Mixer MULTIMEDIA0' 1

$ aplay -D plughw:0,0 test.wav

$ file test.wav
RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, stereo 48000 Hz
````