### PR TITLE
qcs9100-ride-sx: set QCOM_DTB_DEFAULT to qcs9100-ride-r3

### DIFF
--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -6,6 +6,8 @@ require conf/machine/include/qcom-qcs9100.inc
 
 MACHINE_FEATURES += "efi pci"
 
+QCOM_DTB_DEFAULT ?= "qcs9100-ride-r3"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs9100-ride.dtb \
                       qcom/qcs9100-ride-r3.dtb \


### PR DESCRIPTION
Set QCOM_DTB_DEFAULT to qcs9100-ride-r3 as it is the most common and more widely available ride sx development target.

Revision 3 of the board uses a different PHY for the two ethernet ports and supports 2.5G speed.

Both development targets we use in our lab are R3.