### PR TITLE
ci: base: enable pni-names in DISTRO_FEATURES

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -39,7 +39,7 @@ local_conf_header:
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
-    DISTRO_FEATURES:append = " efi"
+    DISTRO_FEATURES:append = " efi pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
 


### PR DESCRIPTION
Enable Predictable Network Interface Names by default in order to have a stable interface naming in our testing infrastructure.