### PR TITLE
Build add-on DTBs with linux-qcom-staging kernel 

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -14,3 +14,14 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \
 "
+
+#
+# Configuration variables for linux-qcom-staging kernel
+#
+
+# These addon DTs are not yet upstreamed. Build them only in staging kernel
+# to avoid conflicts with other kernel providers like linux-yocto-dev.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcm6490-addons-idp.dtb \
+                      qcom/qcm6490-addons-idp-amoled.dtb \
+                      "

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -21,3 +21,14 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_CDT_FILE = "cdt_core_kit"
 QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 QCOM_PARTITION_CONF = "qcom-partition-conf-qcs6490-rb3gen2"
+
+#
+# Configuration variables for linux-qcom-staging kernel
+#
+
+# These addon DTs are not yet upstreamed. Build them only in staging kernel
+# to avoid conflicts with other kernel providers like linux-yocto-dev.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcs6490-addons-rb3gen2.dtb \
+                      qcom/qcs6490-addons-rb3gen2-vision-mezz.dtb \
+                      "

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -23,3 +23,16 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_CDT_FILE = "cdt_ride_sx"
 QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_CONF = "qcom-partition-conf-qcs9100-ride-sx"
+
+#
+# Configuration variables for linux-qcom-staging kernel
+#
+
+# These addon DTs are not yet upstreamed. Build them only in staging kernel
+# to avoid conflicts with other kernel providers like linux-yocto-dev.
+KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
+                      qcom/qcs9100-addons-ride.dtb \
+                      qcom/qcs9100-addons-ride-r3.dtb \
+                      qcom/sa8775p-addons-ride.dtb \
+                      qcom/sa8775p-addons-ride-r3.dtb \
+                      "


### PR DESCRIPTION
The linux-qcom-staging kernel can produce an additional set of DTB files called 'addons DTB' files with downstream additions. Build them along with upstream DTB files to allow users to use downstream features.