### PR TITLE
Fix qcomflash dir for RB1 board

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -43,6 +43,19 @@ create_qcomflash_pkg() {
         done
     fi
 
+    # Legacy boot images
+    if [ -n "${QCOM_DTB_DEFAULT}" ]; then
+        [ -e "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" -a \
+            ! -e "boot.img" ] && \
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" boot.img
+        [ -e "${DEPLOY_DIR_IMAGE}/boot-${QCOM_DTB_DEFAULT}-${MACHINE}.img" -a \
+            ! -e "boot.img" ] && \
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${QCOM_DTB_DEFAULT}-${MACHINE}.img" boot.img
+    fi
+    [ -e "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" -a \
+        ! -e "boot.img" ] && \
+        install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" boot.img
+
     # rootfs image
     install -m 0644 ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} ${QCOM_ROOTFS_FILE}
 

--- a/conf/machine/qrb2210-rb1-core-kit.conf
+++ b/conf/machine/qrb2210-rb1-core-kit.conf
@@ -6,6 +6,8 @@ require conf/machine/include/qcom-qcm2290.inc
 
 MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
 
+QCOM_DTB_DEFAULT ?= "qrb2210-rb1"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/qrb2210-rb1.dtb \
                       "

--- a/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
@@ -43,16 +43,16 @@
 --partition --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --name=modem_a --size=184320KB --type-guid=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 --filename=NON-HLOS.bin
---partition --name=modem_b --size=184320KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=NON-HLOS.bin
---partition --name=dsp_a --size=65536KB --type-guid=7EFE5010-2A1A-4A1A-B8BC-990257813512 --filename=dspso.bin
---partition --name=dsp_b --size=65536KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=dspso.bin
+--partition --name=modem_a --size=184320KB --type-guid=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+--partition --name=modem_b --size=184320KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=dsp_a --size=65536KB --type-guid=7EFE5010-2A1A-4A1A-B8BC-990257813512
+--partition --name=dsp_b --size=65536KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
 --partition --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=abl.elf
 --partition --name=abl_r --size=1024KB --type-guid=4ED7A78D-9BB0-478A-B0B8-9349BCB2D934 --filename=abl.elf
 --partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
---partition --name=bluetooth_a --size=1024KB --type-guid=6cb747f1-c2ef-4092-add0-ca39f79c7af4 --filename=BTFM.bin
---partition --name=bluetooth_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=BTFM.bin
+--partition --name=bluetooth_a --size=1024KB --type-guid=6cb747f1-c2ef-4092-add0-ca39f79c7af4
+--partition --name=bluetooth_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
 --partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
 --partition --name=imagefv_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf

--- a/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
@@ -35,8 +35,8 @@
 --partition --name=hyp_a --size=512KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
 --partition --name=hyp_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hyp.mbn
 --partition --name=hyp_r --size=512KB --type-guid=4BACB256-C6E9-46F5-A3B6-A245080A9727 --filename=hyp.mbn
---partition --name=boot_a --size=98304KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot-erase.img
---partition --name=boot_b --size=98304KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot-erase.img
+--partition --name=boot_a --size=98304KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
+--partition --name=boot_b --size=98304KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
 --partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
 --partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=km4.mbn
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6

--- a/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
@@ -58,7 +58,7 @@
 --partition --name=imagefv_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf
 --partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
 --partition --name=uefisecapp_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=uefi_sec.mbn
---partition --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B --filename=persist.img --sparse=true
+--partition --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 --partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
 --partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
@@ -78,7 +78,7 @@
 --partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
 --partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
 --partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C
---partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=logfs_ufs_8mb.bin
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
 --partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
 --partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA --filename=storsec.mbn

--- a/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm2290-partitions.conf
@@ -60,7 +60,7 @@
 --partition --name=uefisecapp_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=uefi_sec.mbn
 --partition --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 --partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
---partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19
+--partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19 --filename=zeros_33sectors.bin
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
 --partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
 --partition --name=devcfg_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=devcfg.mbn


### PR DESCRIPTION
As noted in #806 the qcomflash dir for the RB1 board misses several files, which can cause errors during flashing.
- Install boot image into the qcomflash dir and use it for `boot_a`/`boot_b` partitions
- Don't flash `persist` and `logfs`, they are unused by Linux
- Don't flash firmware and DSP partitions, they are unused with meta-qcom


Closes #806 