### PR TITLE
qcom-qcm2290: Add boot essential userspace package groups to image

### DIFF
--- a/conf/machine/include/qcom-qcm2290.inc
+++ b/conf/machine/include/qcom-qcm2290.inc
@@ -8,4 +8,12 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
 KERNEL_CMDLINE_EXTRA ?= "earlycon clk_ignore_unused pd_ignore_unused"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"
+
 EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qrb2210-rb1 qcom-gen-partition-bins"


### PR DESCRIPTION
Add qcom-boot-essential and qcom-boot-additional package groups for qcs9100 devices to ensure basic user space support for booting is present.