### PR TITLE
RB1: add platform-specific modules

### DIFF
--- a/conf/machine/qrb2210-rb1-core-kit.conf
+++ b/conf/machine/qrb2210-rb1-core-kit.conf
@@ -12,6 +12,8 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "packagegroup-rb1-firmware"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "packagegroup-rb1-modules"
+
 ## needed until we fix the EFI boot
 # To build an Android boot image
 KERNEL_CLASSES += "linux-qcom-bootimg"

--- a/recipes-bsp/packagegroups/packagegroup-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb1.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 PACKAGES = " \
     ${PN}-firmware \
     ${PN}-hexagon-dsp-binaries \
+    ${PN}-modules \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -19,4 +20,37 @@ RRECOMMENDS:${PN}-firmware = " \
 
 RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-thundercomm-rb1-adsp \
+"
+
+RRECOMMENDS:${PN}-modules = " \
+    kernel-module-ath10k-snoc \
+    kernel-module-cdc-ncm \
+    kernel-module-dispcc-qcm2290 \
+    kernel-module-display-connector \
+    kernel-module-gpi \
+    kernel-module-gpucc-qcm2290 \
+    kernel-module-i2c-gpio \
+    kernel-module-i2c-qcom-geni \
+    kernel-module-icc-bwmon \
+    kernel-module-lmh \
+    kernel-module-lontium-lt9611uxc \
+    kernel-module-mcp251xfd \
+    kernel-module-msm \
+    kernel-module-phy-qcom-qmp-usbc \
+    kernel-module-phy-qcom-qusb2 \
+    kernel-module-qcom-pmic-tcpm \
+    kernel-module-qcom-pon \
+    kernel-module-qcom-q6v5-pas \
+    kernel-module-qcom-rng \
+    kernel-module-qcom-stats \
+    kernel-module-qcom-usb-vbus-regulator \
+    kernel-module-qcom-wdt \
+    kernel-module-qrtr \
+    kernel-module-qrtr-mhi \
+    kernel-module-qrtr-smd \
+    kernel-module-rmtfs-mem \
+    kernel-module-rpmsg-ctrl \
+    kernel-module-rtc-pm8xxx \
+    kernel-module-socinfo \
+    kernel-module-spi-geni-qcom \
 "


### PR DESCRIPTION
This is a temporal solution until @koenkooi finishes module packagegroups to let other developers test recent kernels on this platform. I do not intend for this to be merged, so marking it as draft.