### PR TITLE
Drop PCIe-related kernel command line options

### DIFF
--- a/conf/machine/include/qcom-qcs6490.inc
+++ b/conf/machine/include/qcom-qcs6490.inc
@@ -7,7 +7,7 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "pcie_pme=nomsi earlycon"
+KERNEL_CMDLINE_EXTRA ?= "earlycon"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \

--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -7,7 +7,7 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "pci=noaer earlycon"
+KERNEL_CMDLINE_EXTRA ?= "earlycon"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \

--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -7,7 +7,7 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "pci=noaer pcie_pme=nomsi earlycon"
+KERNEL_CMDLINE_EXTRA ?= "pci=noaer earlycon"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \


### PR DESCRIPTION
Several SoC configs include PCIe-specific flags, which are not supposed to be used in production environment. Drop those flags.