### PR TITLE
ci: use KAS_CLONE_DEPTH instead of KAS mirrors

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CACHE_DIR: /srv/gh-runners/quic-yocto
-  KAS_REPO_REF_DIR: /srv/gh-runners/quic-yocto/kas-mirrors
+  KAS_CLONE_DEPTH: 1
   BASE_ARTIFACT_URL: "https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${{ github.run_id }}"
 
 jobs:


### PR DESCRIPTION
We initially used KAS_REPO_REF_DIR to keep a local copy of the repos mirrors, to avoid fetching projects from scratch in CI. However, it is implemented such that the mirrors, once created by kas the *first* time, are never updated by kas, they are 'read only'.

Some others (such as meta-arm) have implemented a script to update the repos manually, however KAS has a variable called KAS_CLONE_DEPTH, which as the documentation says "This is useful in case CI always starts with empty work directory and this directory is always discarded after the CI run". Which is exactly what we need here.

Lately, the Yocto git servers have been flaky, which caused KAS to fail to fetch from upstream, and the KAS ended up falling back to the old content of the mirrors, silently. e.g. doing CI with old refs for oe-core, bitbake, .. which is very much undesirable.