### PR TITLE
ci: pre-fetch KAS_REPO_REF_DIR with just git

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -13,7 +13,19 @@ env:
   BASE_ARTIFACT_URL: "https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${{ github.run_id }}"
 
 jobs:
+  kas-mirror:
+    if: github.repository == 'qualcomm-linux/meta-qcom'
+    runs-on: [self-hosted, x86]
+    steps:
+      - name: Update kas mirrors
+        run: |
+          for r in $(find ${KAS_REPO_REF_DIR}/* -maxdepth 0 -type d); do
+            echo "pre-fetch: $r"
+            git -C $r fetch --prune origin '+refs/*:refs/*'
+          done
+
   kas-lock:
+    needs:  kas-mirror
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
     steps:


### PR DESCRIPTION
We initially used KAS_REPO_REF_DIR to keep a local copy of the repos mirrors,
to avoid fetching projects from scratch in CI. However, it is implemented such
that the mirrors, once created by kas the first time, are never updated by kas,
they are 'read only'.
    
Sometimes the fetch from upstream fails and the KAS ended up falling back
to the old content of the mirrors, silently. To fix this we will pre-fetch
all ref front the origin the repos in KAS_REPO_REF_DIR.
    
We will for each repo retry 3 times sleeping 10 seconds between attempts.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/712