### PR TITLE
ci: build-yocto: cleanup sstate-cache after the build

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -123,41 +123,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download kas lockfile
-        uses: actions/download-artifact@v7
-        with:
-          name: kas-lockfile
-          path: ci
-
-      - name: Download kas-container
-        uses: actions/download-artifact@v7
-        with:
-          name: kas-container
-          path: ${{ runner.temp }}
-
-      - name: Setting up kas-container
-        run: |
-          KAS_CONTAINER=$RUNNER_TEMP/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
-          chmod +x $KAS_CONTAINER
-
-      - name: Setup cache variables (used by oe-selftest)
-        run: |
-          echo "DL_DIR=${CACHE_DIR}/downloads" >> $GITHUB_ENV
-          echo "SSTATE_DIR=${CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
-
-      - name: Run Yocto patchreview
-        run: |
-          ci/kas-container-shell-helper.sh ci/yocto-patchreview.sh
-
-      - name: Run yocto-check-layer
-        run: |
-          ci/kas-container-shell-helper.sh ci/yocto-check-layer.sh
-
-      - name: Run oe-selftest
-        run: |
-          ci/kas-container-shell-helper.sh ci/oe-selftest.sh
-
   compile-env:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: ubuntu-latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -108,6 +108,24 @@ jobs:
           mkdir $KAS_WORK_DIR
           $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
 
+      - name: Sstate-cache cleanup
+        run: |
+          set -x
+          SSTATE_CACHE_MANAGEMENT="/work/oe-core/scripts/sstate-cache-management.py"
+          SSTATE_CACHE_MANAGEMENT+=" --jobs $(nproc) --cache-dir \\\$(bitbake-getvar --value SSTATE_DIR) --yes --debug"
+          SSTATE_CACHE_MANAGEMENT+=" --dry-run"
+
+          flock ${SSTATE_DIR}-lock --command " \
+            ${KAS_CONTAINER} shell ${KAS_YAMLS} --command \"$SSTATE_CACHE_MANAGEMENT --remove-duplicated \
+            | tee sstate-cache-management-duplicated.log \" \
+            "
+          flock ${SSTATE_DIR}-lock --command " \
+            ${KAS_CONTAINER} shell ${KAS_YAMLS} --command \"$SSTATE_CACHE_MANAGEMENT --remove-orphans \
+            | tee sstate-cache-management-orphans.log \" \
+            "
+          mv $KAS_WORK_DIR/build/sstate-cache-management* .
+          exit 1
+
       - name: Kas build world
         if:  inputs.world
         shell: bash
@@ -175,7 +193,7 @@ jobs:
             # Copy *.efi, *.efi and *.vfat as they are useful for debugging
             find $images_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp -v {} $uploads_dir/ \;
           fi
-          cp -v buildstats* kas-build.yml $uploads_dir/
+          cp -v buildstats* kas-build.yml sstate-cache-management* $uploads_dir/
           if [ -d $sdk_dir ]; then
             cp -v $sdk_dir/* $uploads_dir/
           fi


### PR DESCRIPTION
We need to clean up the ci local sstate-cache that is not used, otherwise it will grow infinitely.
This will take up significant space that will not be used by anyone since invalid sstate-cache
artefacts will no longer be needed.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/715