### PR TITLE
Use new SoC-specific essential packagegroups

### DIFF
--- a/conf/machine/include/qcom-qcm2290.inc
+++ b/conf/machine/include/qcom-qcm2290.inc
@@ -10,6 +10,7 @@ KERNEL_CMDLINE_EXTRA ?= "earlycon clk_ignore_unused pd_ignore_unused"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
+    packagegroup-machine-essential-qcom-qcm2290-soc \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/include/qcom-qcs6490.inc
+++ b/conf/machine/include/qcom-qcs6490.inc
@@ -11,6 +11,7 @@ KERNEL_CMDLINE_EXTRA ?= "earlycon"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
+    packagegroup-machine-essential-qcom-qcs6490-soc \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Use `packagegroup-machine-essential-qcom-qcs6490-soc` and `packagegroup-machine-essential-qcom-qcm2290-soc` to pull SoC-specific packages into images.