### PR TITLE
ci/base.yml: switch to github.com/openembedded mirrors where possible

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -13,12 +13,12 @@ repos:
   meta-qcom:
 
   oe-core:
-    url: https://git.openembedded.org/openembedded-core
+    url: https://github.com/openembedded/openembedded-core
     layers:
       meta:
 
   bitbake:
-    url: https://git.openembedded.org/bitbake
+    url: https://github.com/openembedded/bitbake
     layers:
       .: excluded
 


### PR DESCRIPTION
The Yocto Project infrastructure has been mostly unreachable for the past week, so switch to more reliable mirrors where possible.

Since meta-yocto is, well, a Yocto Project project, this isn't mirrored by OE.