### PR TITLE
ci: use git force in pre-fetch

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           for r in $(find ${KAS_REPO_REF_DIR}/* -maxdepth 0 -type d); do
             echo "pre-fetch: $r"
-            git -C $r fetch --prune origin '+refs/*:refs/*'
+            git -C $r fetch --force --prune origin '+refs/*:refs/*'
           done
 
   kas-lock:


### PR DESCRIPTION
If the upstream server get corruped and fixed in some way we need to replicate evething in our mirror so keep exavtly from the server.