### PR TITLE
initramfs-firmware-rb3gen2-image: add firmware image

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-rb3gen2-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-rb3gen2-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with RB3-Gen2 firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-rb3gen2-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Add initramfs image with the firmware for the RB3 Gen2 board.