### PR TITLE
Deploy vmlinux for kernel debugging

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -48,6 +48,11 @@ create_qcomflash_pkg() {
         done
     fi
 
+    # vmlinux
+    [ -e "${DEPLOY_DIR_IMAGE}/vmlinux" -a \
+        ! -e "vmlinux" ] && \
+        install -m 0644 "${DEPLOY_DIR_IMAGE}/vmlinux" vmlinux
+
     # Legacy boot images
     if [ -n "${QCOM_DTB_DEFAULT}" ]; then
         [ -e "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" -a \

--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -4,6 +4,8 @@
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 
 KERNEL_IMAGETYPE ?= "Image"
+KERNEL_ALT_IMAGETYPE ?= "vmlinux"
+
 KERNEL_IMAGETYPES ?= "Image.gz"
 
 # For dtb.bin generation


### PR DESCRIPTION
"Having a handy 'vmlinux' would be helpful for debugging kernel issues. Start generating vmlinux and make it available along with the kernel image."