### PR TITLE
partition: fix rootfs GUID in the RB1 partition conf file

### DIFF
--- a/recipes-bsp/partition/files/qcm2290-partitions.conf
+++ b/recipes-bsp/partition/files/qcm2290-partitions.conf
@@ -94,4 +94,4 @@
 --partition --name=fsg --size=2048KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
 --partition --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
 --partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
---partition --name=rootfs --size=9960572KB --type-guid=1B81E7E6-F50D-419B-A739-2AEEF8DA3335 --filename=rootfs.img
+--partition --name=rootfs --size=9960572KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img


### PR DESCRIPTION
As reported on https://github.com/qualcomm-linux/qcom-ptool/issues/9, the GUID used for rootfs is incorrectly. It was wrongly inherited from the original partition XML file of an Android build, and the GUID which was used corresponds to what Android uses for userdata partition.

This changes sets the correct GUID
(b921b045-1df0-41c3-af44-4c6f280d3fae) for Root Partition (64-bit ARM/AArch64).

Reported-by: Loic Minier <loic.minier@oss.qualcomm.com>