### PR TITLE
ci: add yocto-pybootchartgui

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -111,6 +111,12 @@ jobs:
           export KAS_WORK_DIR=$PWD/../kas
           mkdir $KAS_WORK_DIR
           kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml
+          ci/yocto-pybootchartgui.sh && mv $KAS_WORK_DIR/build/buildchart.svg .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: buildchart-${{ matrix.machine }}
+          path: buildchart.svg
 
       - name: Publish image
         run: |

--- a/ci/yocto-pybootchartgui.sh
+++ b/ci/yocto-pybootchartgui.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
+
+if [ -z $KAS_WORK_DIR ]; then
+    echo "KAS_WORK_DIR is empty and it needs to point to populated work dir"
+fi
+
+# pybootchartgui tool
+CMD="$CMD $KAS_WORK_DIR/oe-core/scripts/pybootchartgui/pybootchartgui.py"
+# display time in minutes instead of seconds
+CMD="$CMD --minutes"
+# image format (png, svg, pdf); default format png
+CMD="$CMD --format=svg"
+# output path (file or directory) where charts are stored
+CMD="$CMD --output=buildchart"
+# /path/to/tmp/buildstats/<recipe-machine>/<BUILDNAME>/
+CMD="$CMD $KAS_WORK_DIR/build/tmp/buildstats"
+
+exec kas shell $TOPDIR/ci/base.yml --command "$CMD"


### PR DESCRIPTION
Create buildchart.svg with the buildstats collected data. We have the buildstats enabled but the output is hard to read and understand. The openembedded-core pybootchartgui scripts can process this logs and generates some pretty charts.

For each Yocto build, this will generate a github artifact by machine like `buildchart-qcm6490-idp.zip` with an svg image inside https://github.com/qualcomm-linux/meta-qcom/actions/runs/14362539141/artifacts/2916117283
![buildchart](https://github.com/user-attachments/assets/ae39df6d-76a9-484e-b629-a993f52bd375)
