### PR TITLE
initramfs-mega-image: add SA8775P-RIDE packagegroups

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -15,12 +15,14 @@ PACKAGE_INSTALL += " \
     packagegroup-rb2-firmware \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb5-firmware \
+    packagegroup-sa8775p-ride-firmware \
     packagegroup-dragonboard820c-hexagon-dsp-binaries \
     packagegroup-dragonboard845c-hexagon-dsp-binaries \
     packagegroup-rb1-hexagon-dsp-binaries \
     packagegroup-rb2-hexagon-dsp-binaries \
     packagegroup-rb3gen2-hexagon-dsp-binaries \
     packagegroup-rb5-hexagon-dsp-binaries \
+    packagegroup-sa8775p-ride-hexagon-dsp-binaries \
 "
 
 # Qualcomm HDKs


### PR DESCRIPTION
In order to check for conflicts, add packagegroups for the SA8775P-RIDE board to the mega-image.