### PR TITLE
mesa: add support for QCM2290

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -10,4 +10,8 @@ PACKAGECONFIG_FREEDRENO = "\
 PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"
 
 SRC_URI:append:qcom = " \
-    file://0001-freedreno-check-if-GPU-supported-in-fd_pipe_new2.patch;patch=1"
+    file://0001-freedreno-check-if-GPU-supported-in-fd_pipe_new2.patch;patch=1 \
+    file://0001-freedreno-Add-initial-A702-support.patch \
+    file://0002-freedreno-A702-fixes-for-deqp-vk.patch \
+    file://0003-freedreno-fix-compilation.patch \
+"

--- a/recipes-graphics/mesa/mesa/0001-freedreno-Add-initial-A702-support.patch
+++ b/recipes-graphics/mesa/mesa/0001-freedreno-Add-initial-A702-support.patch
@@ -1,0 +1,267 @@
+From 502a42545f015f547546af52475e279602b7db26 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 16 Feb 2024 20:50:59 +0100
+Subject: [PATCH] freedreno: Add initial A702 support
+
+Can we forget this SKU exists?
+
+Turns out, not really.. But at least we can get GPU accel on watches!
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/27665]
+---
+ src/freedreno/common/freedreno_dev_info.h     |  3 ++
+ src/freedreno/common/freedreno_devices.py     | 52 +++++++++++++++++++
+ src/freedreno/registers/adreno/a6xx.xml       |  2 +-
+ src/freedreno/vulkan/tu_cmd_buffer.cc         |  5 +-
+ src/freedreno/vulkan/tu_device.cc             | 12 ++---
+ src/freedreno/vulkan/tu_image.cc              |  2 +-
+ src/freedreno/vulkan/tu_pipeline.cc           |  8 +--
+ .../drivers/freedreno/a6xx/fd6_emit.cc        |  2 +-
+ .../drivers/freedreno/a6xx/fd6_gmem.cc        |  3 +-
+ .../drivers/freedreno/freedreno_resource.c    |  2 +-
+ 10 files changed, 75 insertions(+), 16 deletions(-)
+
+diff --git a/src/freedreno/common/freedreno_dev_info.h b/src/freedreno/common/freedreno_dev_info.h
+index c8b7884ee8ae..03d3368f018a 100644
+--- a/src/freedreno/common/freedreno_dev_info.h
++++ b/src/freedreno/common/freedreno_dev_info.h
+@@ -207,6 +207,9 @@ struct fd_dev_info {
+       /* Whether the sad instruction (iadd3) is supported. */
+       bool has_sad;
+ 
++      /* A702 cuts A LOT of things.. */
++      bool is_a702;
++
+       struct {
+          uint32_t PC_POWER_CNTL;
+          uint32_t TPL1_DBG_ECO_CNTL;
+diff --git a/src/freedreno/common/freedreno_devices.py b/src/freedreno/common/freedreno_devices.py
+index 0e7e74c6a141..c5d28cf34bcc 100644
+--- a/src/freedreno/common/freedreno_devices.py
++++ b/src/freedreno/common/freedreno_devices.py
+@@ -819,6 +819,58 @@ add_gpus([
+         ],
+     ))
+ 
++add_gpus([
++        GPUId(702), # KGSL
++        GPUId(chip_id=0x00b207002000, name="FD702"), # QRB2210 RB1
++        GPUId(chip_id=0xffff07002000, name="FD702"), # Default no-speedbin fallback
++    ], A6xxGPUInfo(
++        CHIP.A6XX, # NOT a mistake!
++        [a6xx_base, A6XXProps(
++            reg_size_vec4 = 48,
++            instr_cache_size = 64,
++            indirect_draw_wfm_quirk = True,
++            has_cp_reg_write = False,
++            depth_bounds_require_depth_test_quirk = True,
++            has_gmem_fast_clear = True,
++            has_hw_multiview = False,
++            has_sampler_minmax = False,
++            has_lpac = False,
++            has_fs_tex_prefetch = False,
++            sysmem_per_ccu_depth_cache_size = 128 * 1024, # ??????
++            sysmem_per_ccu_color_cache_size = 128 * 1024, # ??????
++            gmem_ccu_color_cache_fraction = CCUColorCacheFraction.FULL.value,
++            vs_max_inputs_count = 16,
++            prim_alloc_threshold = 0x1,
++            storage_16bit = True,
++            is_a702 = True,
++            )
++        ],
++        num_ccu = 1,
++        tile_align_w = 32,
++        tile_align_h = 16,
++        num_vsc_pipes = 16,
++        cs_shared_mem_size = 16 * 1024,
++        wave_granularity = 1,
++        fibers_per_sp = 128 * 16,
++        threadsize_base = 16,
++        max_waves = 32,
++        magic_regs = dict(
++            PC_POWER_CNTL = 0,
++            TPL1_DBG_ECO_CNTL = 0x8000,
++            GRAS_DBG_ECO_CNTL = 0,
++            SP_CHICKEN_BITS = 0x1400,
++            UCHE_CLIENT_PF = 0x84,
++            PC_MODE_CNTL = 0xf,
++            SP_DBG_ECO_CNTL = 0x0,
++            RB_DBG_ECO_CNTL = 0x100000,
++            RB_DBG_ECO_CNTL_blit = 0x100000,
++            HLSQ_DBG_ECO_CNTL = 0,
++            RB_UNKNOWN_8E01 = 0x1,
++            VPC_DBG_ECO_CNTL = 0x0,
++            UCHE_UNKNOWN_0E12 = 0x1,
++        ),
++    ))
++
+ # Based on a6xx_base + a6xx_gen4
+ a7xx_base = A6XXProps(
+         has_gmem_fast_clear = True,
+diff --git a/src/freedreno/registers/adreno/a6xx.xml b/src/freedreno/registers/adreno/a6xx.xml
+index d49919f6344c..dbf94dbaefab 100644
+--- a/src/freedreno/registers/adreno/a6xx.xml
++++ b/src/freedreno/registers/adreno/a6xx.xml
+@@ -4353,7 +4353,7 @@ to upconvert to 32b float internally?
+ 	<reg32 offset="0x9306" name="VPC_SO_DISABLE" usage="rp_blit">
+ 		<bitfield name="DISABLE" pos="0" type="boolean"/>
+ 	</reg32>
+-	<reg32 offset="0x9307" name="VPC_POLYGON_MODE2" variants="A7XX-" usage="rp_blit">
++	<reg32 offset="0x9307" name="VPC_POLYGON_MODE2" variants="A6XX-" usage="rp_blit"> <!-- A702 + A7xx -->
+ 		<bitfield name="MODE" low="0" high="1" type="a6xx_polygon_mode"/>
+ 	</reg32>
+ 	<reg32 offset="0x9308" name="VPC_ATTR_BUF_SIZE_GMEM" variants="A7XX-" usage="rp_blit">
+diff --git a/src/freedreno/vulkan/tu_cmd_buffer.cc b/src/freedreno/vulkan/tu_cmd_buffer.cc
+index 3e3a9f5f1e95..92965586c16e 100644
+--- a/src/freedreno/vulkan/tu_cmd_buffer.cc
++++ b/src/freedreno/vulkan/tu_cmd_buffer.cc
+@@ -1094,7 +1094,8 @@ tu6_emit_tile_select(struct tu_cmd_buffer *cmd,
+ 
+       tu_cs_emit_pkt7(cs, CP_SET_BIN_DATA5_OFFSET, 4);
+       tu_cs_emit(cs, tiling->pipe_sizes[pipe] |
+-                     CP_SET_BIN_DATA5_0_VSC_N(slot));
++                     CP_SET_BIN_DATA5_0_VSC_N(slot)
++                     /* A702 also sets BIT(0) but that hangchecks */);
+       tu_cs_emit(cs, pipe * cmd->vsc_draw_strm_pitch);
+       tu_cs_emit(cs, pipe * 4);
+       tu_cs_emit(cs, pipe * cmd->vsc_prim_strm_pitch);
+@@ -1373,7 +1374,7 @@ tu6_init_static_regs(struct tu_device *dev, struct tu_cs *cs)
+    tu_cs_emit_write_reg(cs, REG_A6XX_SP_DBG_ECO_CNTL,
+                         phys_dev->info->a6xx.magic.SP_DBG_ECO_CNTL);
+    tu_cs_emit_write_reg(cs, REG_A6XX_SP_PERFCTR_ENABLE, 0x3f);
+-   if (CHIP == A6XX)
++   if (CHIP == A6XX && !cs->device->physical_device->info->a6xx.is_a702)
+       tu_cs_emit_write_reg(cs, REG_A6XX_TPL1_UNKNOWN_B605, 0x44);
+    tu_cs_emit_write_reg(cs, REG_A6XX_TPL1_DBG_ECO_CNTL,
+                         phys_dev->info->a6xx.magic.TPL1_DBG_ECO_CNTL);
+diff --git a/src/freedreno/vulkan/tu_device.cc b/src/freedreno/vulkan/tu_device.cc
+index 7b18dcf24f9f..c5874808535b 100644
+--- a/src/freedreno/vulkan/tu_device.cc
++++ b/src/freedreno/vulkan/tu_device.cc
+@@ -318,7 +318,7 @@ get_device_extensions(const struct tu_physical_device *device,
+ #endif
+       .EXT_texel_buffer_alignment = true,
+       .EXT_tooling_info = true,
+-      .EXT_transform_feedback = true,
++      .EXT_transform_feedback = !device->info->a6xx.is_a702,
+       .EXT_vertex_attribute_divisor = true,
+       .EXT_vertex_input_dynamic_state = true,
+ 
+@@ -352,15 +352,15 @@ tu_get_features(struct tu_physical_device *pdevice,
+    features->fullDrawIndexUint32 = true;
+    features->imageCubeArray = true;
+    features->independentBlend = true;
+-   features->geometryShader = true;
+-   features->tessellationShader = true;
++   features->geometryShader = !pdevice->info->a6xx.is_a702;
++   features->tessellationShader = !pdevice->info->a6xx.is_a702;
+    features->sampleRateShading = true;
+    features->dualSrcBlend = true;
+    features->logicOp = true;
+    features->multiDrawIndirect = true;
+    features->drawIndirectFirstInstance = true;
+    features->depthClamp = true;
+-   features->depthBiasClamp = true;
++   features->depthBiasClamp = !pdevice->info->a6xx.is_a702;
+    features->fillModeNonSolid = true;
+    features->depthBounds = true;
+    features->wideLines = pdevice->info->a6xx.line_width_max > 1.0;
+@@ -502,7 +502,7 @@ tu_get_features(struct tu_physical_device *pdevice,
+    features->indexTypeUint8 = true;
+ 
+    /* VK_KHR_line_rasterization */
+-   features->rectangularLines = true;
++   features->rectangularLines = !pdevice->info->a6xx.is_a702;
+    features->bresenhamLines = true;
+    features->smoothLines = false;
+    features->stippledRectangularLines = false;
+@@ -1039,7 +1039,7 @@ tu_get_properties(struct tu_physical_device *pdevice,
+    props->subPixelInterpolationOffsetBits = 4;
+    props->maxFramebufferWidth = (1 << 14);
+    props->maxFramebufferHeight = (1 << 14);
+-   props->maxFramebufferLayers = (1 << 10);
++   props->maxFramebufferLayers = (1 << (pdevice->info->a6xx.is_a702 ? 8 : 10));
+    props->framebufferColorSampleCounts = sample_counts;
+    props->framebufferDepthSampleCounts = sample_counts;
+    props->framebufferStencilSampleCounts = sample_counts;
+diff --git a/src/freedreno/vulkan/tu_image.cc b/src/freedreno/vulkan/tu_image.cc
+index da5e1e520a4c..10ed35a25c9e 100644
+--- a/src/freedreno/vulkan/tu_image.cc
++++ b/src/freedreno/vulkan/tu_image.cc
+@@ -739,7 +739,7 @@ tu_image_init(struct tu_device *device, struct tu_image *image,
+       }
+    }
+ 
+-   if (TU_DEBUG(NOUBWC)) {
++   if (TU_DEBUG(NOUBWC) || device->physical_device->info->a6xx.is_a702) {
+       image->ubwc_enabled = false;
+    }
+ 
+diff --git a/src/freedreno/vulkan/tu_pipeline.cc b/src/freedreno/vulkan/tu_pipeline.cc
+index a9dc691bfa19..308830797656 100644
+--- a/src/freedreno/vulkan/tu_pipeline.cc
++++ b/src/freedreno/vulkan/tu_pipeline.cc
+@@ -3106,7 +3106,9 @@ tu6_rast_size(struct tu_device *dev,
+               bool multiview,
+               bool per_view_viewport)
+ {
+-   if (CHIP == A6XX) {
++   if (CHIP == A6XX && dev->physical_device->info->a6xx.is_a702) {
++      return 17;
++   } else if (CHIP == A6XX) {
+       return 15 + (dev->physical_device->info->a6xx.has_legacy_pipeline_shading_rate ? 8 : 0);
+    } else {
+       return 25;
+@@ -3155,9 +3157,9 @@ tu6_emit_rast(struct tu_cs *cs,
+    tu_cs_emit_regs(cs,
+                    PC_POLYGON_MODE(CHIP, polygon_mode));
+ 
+-   if (CHIP == A7XX) {
++   if (CHIP == A7XX || cs->device->physical_device->info->a6xx.is_a702) {
+       tu_cs_emit_regs(cs,
+-                     A7XX_VPC_POLYGON_MODE2(polygon_mode));
++                     A6XX_VPC_POLYGON_MODE2(polygon_mode));
+    }
+ 
+    tu_cs_emit_regs(cs, PC_RASTER_CNTL(CHIP,
+diff --git a/src/gallium/drivers/freedreno/a6xx/fd6_emit.cc b/src/gallium/drivers/freedreno/a6xx/fd6_emit.cc
+index 89ed01437d40..2a36c3fcdf9d 100644
+--- a/src/gallium/drivers/freedreno/a6xx/fd6_emit.cc
++++ b/src/gallium/drivers/freedreno/a6xx/fd6_emit.cc
+@@ -900,7 +900,7 @@ fd6_emit_static_regs(struct fd_context *ctx, struct fd_ringbuffer *ring)
+    WRITE(REG_A6XX_SP_FLOAT_CNTL, A6XX_SP_FLOAT_CNTL_F16_NO_INF);
+    WRITE(REG_A6XX_SP_DBG_ECO_CNTL, screen->info->a6xx.magic.SP_DBG_ECO_CNTL);
+    WRITE(REG_A6XX_SP_PERFCTR_ENABLE, 0x3f);
+-   if (CHIP == A6XX)
++   if (CHIP == A6XX && !screen->info->a6xx.is_a702)
+       WRITE(REG_A6XX_TPL1_UNKNOWN_B605, 0x44);
+    WRITE(REG_A6XX_TPL1_DBG_ECO_CNTL, screen->info->a6xx.magic.TPL1_DBG_ECO_CNTL);
+    if (CHIP == A6XX) {
+diff --git a/src/gallium/drivers/freedreno/a6xx/fd6_gmem.cc b/src/gallium/drivers/freedreno/a6xx/fd6_gmem.cc
+index 309ac5006b91..d346caf6e328 100644
+--- a/src/gallium/drivers/freedreno/a6xx/fd6_gmem.cc
++++ b/src/gallium/drivers/freedreno/a6xx/fd6_gmem.cc
+@@ -1278,7 +1278,8 @@ fd6_emit_tile_prep(struct fd_batch *batch, const struct fd_tile *tile)
+ 
+       OUT_PKT7(ring, CP_SET_BIN_DATA5, 7);
+       OUT_RING(ring, CP_SET_BIN_DATA5_0_VSC_SIZE(pipe->w * pipe->h) |
+-                        CP_SET_BIN_DATA5_0_VSC_N(tile->n));
++                        CP_SET_BIN_DATA5_0_VSC_N(tile->n)
++                        /* A702 also sets BIT(0) but that hangchecks */);
+       OUT_RELOC(ring, fd6_ctx->vsc_draw_strm, /* per-pipe draw-stream address */
+                 (tile->p * fd6_ctx->vsc_draw_strm_pitch), 0, 0);
+       OUT_RELOC(
+diff --git a/src/gallium/drivers/freedreno/freedreno_resource.c b/src/gallium/drivers/freedreno/freedreno_resource.c
+index 4a1dc734d3c5..f91964ad97e8 100644
+--- a/src/gallium/drivers/freedreno/freedreno_resource.c
++++ b/src/gallium/drivers/freedreno/freedreno_resource.c
+@@ -1302,7 +1302,7 @@ get_best_layout(struct fd_screen *screen,
+       return LINEAR;
+    }
+ 
+-   bool ubwc_ok = is_a6xx(screen);
++   bool ubwc_ok = is_a6xx(screen) && !screen->info->a6xx.is_a702;
+    if (FD_DBG(NOUBWC))
+       ubwc_ok = false;
+ 

--- a/recipes-graphics/mesa/mesa/0002-freedreno-A702-fixes-for-deqp-vk.patch
+++ b/recipes-graphics/mesa/mesa/0002-freedreno-A702-fixes-for-deqp-vk.patch
@@ -1,0 +1,209 @@
+From 895966befa17707e5fe89385c8eda7426e8e6dfd Mon Sep 17 00:00:00 2001
+From: C Stout <cstout@google.com>
+Date: Thu, 17 Oct 2024 06:06:15 -0700
+Subject: [PATCH] freedreno: A702 fixes for deqp-vk
+
+Tested on Pixel Watch 2 (Android, KGSL).
+Running only the subset of tests that fail from vulkan-cts-1.3.9:
+
+10-31 15:11:17.996  4471  4489 I dEQP    : Test run totals:
+10-31 15:11:17.996  4471  4489 I dEQP    :   Passed:        19/3470 (0.5%)
+10-31 15:11:17.996  4471  4489 I dEQP    :   Failed:        515/3470 (14.8%)
+10-31 15:11:17.996  4471  4489 I dEQP    :   Not supported: 2936/3470 (84.6%)
+10-31 15:11:17.996  4471  4489 I dEQP    :   Warnings:      0/3470 (0.0%)
+10-31 15:11:17.996  4471  4489 I dEQP    :   Waived:        0/3470 (0.0%)
+
+Change-Id: I895ff33e758cb45e44ce61c7e1963308424ebde5
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/27665]
+---
+ src/freedreno/vulkan/tu_device.cc             |  2 +-
+ src/freedreno/vulkan/tu_formats.cc            | 87 ++++++++++++++++++-
+ src/freedreno/vulkan/tu_image.cc              |  6 +-
+ .../drivers/freedreno/freedreno_screen.c      |  2 +
+ .../drivers/freedreno/freedreno_screen.h      |  6 ++
+ 5 files changed, 98 insertions(+), 5 deletions(-)
+
+diff --git a/src/freedreno/vulkan/tu_device.cc b/src/freedreno/vulkan/tu_device.cc
+index c5874808535b..5115ed4be4ce 100644
+--- a/src/freedreno/vulkan/tu_device.cc
++++ b/src/freedreno/vulkan/tu_device.cc
+@@ -232,7 +232,7 @@ get_device_extensions(const struct tu_physical_device *device,
+       .KHR_shader_subgroup_rotate = true,
+       .KHR_shader_subgroup_uniform_control_flow = true,
+       .KHR_shader_terminate_invocation = true,
+-      .KHR_spirv_1_4 = true,
++      .KHR_spirv_1_4 = device->info->a6xx.has_hw_multiview || TU_DEBUG(NOCONFORM),
+       .KHR_storage_buffer_storage_class = true,
+ #ifdef TU_USE_WSI_PLATFORM
+       .KHR_swapchain = true,
+diff --git a/src/freedreno/vulkan/tu_formats.cc b/src/freedreno/vulkan/tu_formats.cc
+index cb134a979c60..56508f228342 100644
+--- a/src/freedreno/vulkan/tu_formats.cc
++++ b/src/freedreno/vulkan/tu_formats.cc
+@@ -57,11 +57,92 @@ tu6_format_color(enum pipe_format format, enum a6xx_tile_mode tile_mode,
+ }
+ 
+ static bool
+-tu6_format_texture_supported(enum pipe_format format)
++tu6_format_texture_supported(struct tu_physical_device *physical_device, enum pipe_format format)
+ {
++   if (physical_device->info->a6xx.is_a702) {
++      switch (format) {
++         case PIPE_FORMAT_RGTC1_UNORM:
++         case PIPE_FORMAT_RGTC1_SNORM:
++         case PIPE_FORMAT_RGTC2_UNORM:
++         case PIPE_FORMAT_RGTC2_SNORM:
++         case PIPE_FORMAT_BPTC_RGBA_UNORM:
++         case PIPE_FORMAT_BPTC_SRGBA:
++         case PIPE_FORMAT_BPTC_RGB_FLOAT:
++         case PIPE_FORMAT_BPTC_RGB_UFLOAT:
++            return false;
++      }
++   }
+    return fd6_texture_format(format, TILE6_LINEAR, false) != FMT6_NONE;
+ }
+ 
++static bool
++tu_format_texture_linear_filtering_supported(struct tu_physical_device *physical_device, VkFormat vk_format)
++{
++   if (physical_device->info->a6xx.is_a702) {
++      switch (vk_format) {
++         case VK_FORMAT_D16_UNORM:
++         case VK_FORMAT_D24_UNORM_S8_UINT:
++         case VK_FORMAT_X8_D24_UNORM_PACK32:
++         case VK_FORMAT_D32_SFLOAT:
++         case VK_FORMAT_D32_SFLOAT_S8_UINT:
++         case VK_FORMAT_R16_UNORM:
++         case VK_FORMAT_R16_SNORM:
++         case VK_FORMAT_R16_USCALED:
++         case VK_FORMAT_R16_SSCALED:
++         case VK_FORMAT_R16_UINT:
++         case VK_FORMAT_R16_SINT:
++         case VK_FORMAT_R16_SFLOAT:
++         case VK_FORMAT_R16G16_UNORM:
++         case VK_FORMAT_R16G16_SNORM:
++         case VK_FORMAT_R16G16_USCALED:
++         case VK_FORMAT_R16G16_SSCALED:
++         case VK_FORMAT_R16G16_UINT:
++         case VK_FORMAT_R16G16_SINT:
++         case VK_FORMAT_R16G16_SFLOAT:
++         case VK_FORMAT_R16G16B16_UNORM:
++         case VK_FORMAT_R16G16B16_SNORM:
++         case VK_FORMAT_R16G16B16_USCALED:
++         case VK_FORMAT_R16G16B16_SSCALED:
++         case VK_FORMAT_R16G16B16_UINT:
++         case VK_FORMAT_R16G16B16_SINT:
++         case VK_FORMAT_R16G16B16_SFLOAT:
++         case VK_FORMAT_R16G16B16A16_UNORM:
++         case VK_FORMAT_R16G16B16A16_SNORM:
++         case VK_FORMAT_R16G16B16A16_USCALED:
++         case VK_FORMAT_R16G16B16A16_SSCALED:
++         case VK_FORMAT_R16G16B16A16_UINT:
++         case VK_FORMAT_R16G16B16A16_SINT:
++         case VK_FORMAT_R16G16B16A16_SFLOAT:
++         case VK_FORMAT_R32_UINT:
++         case VK_FORMAT_R32_SINT:
++         case VK_FORMAT_R32_SFLOAT:
++         case VK_FORMAT_R32G32_UINT:
++         case VK_FORMAT_R32G32_SINT:
++         case VK_FORMAT_R32G32_SFLOAT:
++         case VK_FORMAT_R32G32B32_UINT:
++         case VK_FORMAT_R32G32B32_SINT:
++         case VK_FORMAT_R32G32B32_SFLOAT:
++         case VK_FORMAT_R32G32B32A32_UINT:
++         case VK_FORMAT_R32G32B32A32_SINT:
++         case VK_FORMAT_R32G32B32A32_SFLOAT:
++         case VK_FORMAT_R64_UINT:
++         case VK_FORMAT_R64_SINT:
++         case VK_FORMAT_R64_SFLOAT:
++         case VK_FORMAT_R64G64_UINT:
++         case VK_FORMAT_R64G64_SINT:
++         case VK_FORMAT_R64G64_SFLOAT:
++         case VK_FORMAT_R64G64B64_UINT:
++         case VK_FORMAT_R64G64B64_SINT:
++         case VK_FORMAT_R64G64B64_SFLOAT:
++         case VK_FORMAT_R64G64B64A64_UINT:
++         case VK_FORMAT_R64G64B64A64_SINT:
++         case VK_FORMAT_R64G64B64A64_SFLOAT:
++            return false;
++      }
++   }
++   return !vk_format_is_int(vk_format);
++}
++
+ struct tu_native_format
+ tu6_format_texture(enum pipe_format format, enum a6xx_tile_mode tile_mode,
+                    bool is_mutable)
+@@ -119,7 +200,7 @@ tu_physical_device_get_format_properties(
+ 
+    bool supported_vtx = tu6_format_vtx_supported(format);
+    bool supported_color = tu6_format_color_supported(format);
+-   bool supported_tex = tu6_format_texture_supported(format);
++   bool supported_tex = tu6_format_texture_supported(physical_device, format);
+    bool is_npot = !util_is_power_of_two_or_zero(desc->block.bits);
+ 
+    if (format == PIPE_FORMAT_NONE ||
+@@ -169,7 +250,7 @@ tu_physical_device_get_format_properties(
+          optimal |= VK_FORMAT_FEATURE_2_BLIT_SRC_BIT;
+       }
+ 
+-      if (!vk_format_is_int(vk_format)) {
++      if (tu_format_texture_linear_filtering_supported(physical_device, vk_format)) {
+          optimal |= VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+ 
+          if (physical_device->vk.supported_extensions.EXT_filter_cubic)
+diff --git a/src/freedreno/vulkan/tu_image.cc b/src/freedreno/vulkan/tu_image.cc
+index 10ed35a25c9e..70693bc942c6 100644
+--- a/src/freedreno/vulkan/tu_image.cc
++++ b/src/freedreno/vulkan/tu_image.cc
+@@ -341,6 +341,10 @@ ubwc_possible(struct tu_device *device,
+               uint32_t mip_levels,
+               bool use_z24uint_s8uint)
+ {
++   /* TODO: enable for a702 */
++   if (info->a6xx.is_a702)
++      return false;
++
+    /* no UBWC with compressed formats, E5B9G9R9, S8_UINT
+     * (S8_UINT because separate stencil doesn't have UBWC-enable bit)
+     */
+@@ -739,7 +743,7 @@ tu_image_init(struct tu_device *device, struct tu_image *image,
+       }
+    }
+ 
+-   if (TU_DEBUG(NOUBWC) || device->physical_device->info->a6xx.is_a702) {
++   if (TU_DEBUG(NOUBWC)) {
+       image->ubwc_enabled = false;
+    }
+ 
+diff --git a/src/gallium/drivers/freedreno/freedreno_screen.c b/src/gallium/drivers/freedreno/freedreno_screen.c
+index e41699ab86cc..68cc141172c5 100644
+--- a/src/gallium/drivers/freedreno/freedreno_screen.c
++++ b/src/gallium/drivers/freedreno/freedreno_screen.c
+@@ -214,6 +214,8 @@ fd_screen_get_shader_param(struct pipe_screen *pscreen,
+    case PIPE_SHADER_TESS_CTRL:
+    case PIPE_SHADER_TESS_EVAL:
+    case PIPE_SHADER_GEOMETRY:
++      if (is_a702(screen))
++         return 0;
+       if (is_a6xx(screen))
+          break;
+       return 0;
+diff --git a/src/gallium/drivers/freedreno/freedreno_screen.h b/src/gallium/drivers/freedreno/freedreno_screen.h
+index bdd446b06c15..3355044c2e93 100644
+--- a/src/gallium/drivers/freedreno/freedreno_screen.h
++++ b/src/gallium/drivers/freedreno/freedreno_screen.h
+@@ -259,6 +259,12 @@ is_a6xx(struct fd_screen *screen)
+    return screen->gen >= 6;
+ }
+ 
++static inline bool
++is_a702(struct fd_screen *screen)
++{
++   return screen->gpu_id == 702;
++}
++
+ /* is it using the ir3 compiler (shader isa introduced with a3xx)? */
+ static inline bool
+ is_ir3(struct fd_screen *screen)

--- a/recipes-graphics/mesa/mesa/0003-freedreno-fix-compilation.patch
+++ b/recipes-graphics/mesa/mesa/0003-freedreno-fix-compilation.patch
@@ -1,0 +1,27 @@
+From d6ef4c989fedf5cb7a8e63fcaa6402b2da7a533a Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 19 Mar 2025 20:45:56 +0200
+Subject: [PATCH] freedreno: fix compilation
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Pending
+---
+ src/gallium/drivers/freedreno/a6xx/fd6_rasterizer.cc | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/gallium/drivers/freedreno/a6xx/fd6_rasterizer.cc b/src/gallium/drivers/freedreno/a6xx/fd6_rasterizer.cc
+index 1da50349f657..925ee7e84c67 100644
+--- a/src/gallium/drivers/freedreno/a6xx/fd6_rasterizer.cc
++++ b/src/gallium/drivers/freedreno/a6xx/fd6_rasterizer.cc
+@@ -99,8 +99,9 @@ __fd6_setup_rasterizer_stateobj(struct fd_context *ctx,
+    OUT_REG(ring, A6XX_VPC_POLYGON_MODE(mode));
+    OUT_REG(ring, PC_POLYGON_MODE(CHIP, mode));
+ 
+-   if (CHIP == A7XX) {
+-      OUT_REG(ring, A7XX_VPC_POLYGON_MODE2(mode));
++   if (CHIP == A7XX ||
++       CHIP == A6XX && ctx->screen->info->a6xx.is_a702) {
++      OUT_REG(ring, A6XX_VPC_POLYGON_MODE2(mode));
+    }
+ 
+    /* With a7xx the hw doesn't do the clamping for us.  When depth clamp


### PR DESCRIPTION
The QRB2210 / QCM2290 SoC uses A702, which is not currently supported by Mesa. Import patches from the MR ([0]) and add a patch on top that fixes build issues.

[0] https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/27665