### PR TITLE
Use KERNEL_CLASSES to pull in image-related classes

### DIFF
--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -20,6 +20,10 @@ QCOM_BOOTIMG_PAGE_SIZE = "2048"
 MACHINE_FEATURES += "screen ext2 ext3 opengl usb"
 
 KERNEL_IMAGETYPE ?= "zImage"
+
+# To build an Android boot image
+KERNEL_CLASSES += "linux-qcom-bootimg"
+
 KERNEL_DEVICETREE ?= " \
     qcom/qcom-apq8064-asus-nexus7-flo.dtb \
     qcom/qcom-apq8064-ifc6410.dtb \

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -23,6 +23,9 @@ KERNEL_IMAGETYPES = "Image"
 # To build an Android boot image
 KERNEL_CLASSES += "linux-qcom-bootimg"
 
+# For dtb.bin generation
+KERNEL_CLASSES += "linux-qcom-dtbbin"
+
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 KERNEL_DEVICETREE ?= " \
     qcom/apq8016-sbc.dtb \

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -20,6 +20,9 @@ KERNEL_IMAGETYPE ?= "Image.gz"
 # UKI generation needs uncompressed Kernel image
 KERNEL_IMAGETYPES = "Image"
 
+# To build an Android boot image
+KERNEL_CLASSES += "linux-qcom-bootimg"
+
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 KERNEL_DEVICETREE ?= " \
     qcom/apq8016-sbc.dtb \

--- a/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -9,13 +9,3 @@ FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}-${BASEVER}:"
 SRC_URI:append:qcom = " \
     file://qcom.scc \
 "
-
-# For boot.img
-QCOM_BOOTIMG = ""
-QCOM_BOOTIMG:qcom = "linux-qcom-bootimg"
-inherit ${QCOM_BOOTIMG}
-
-# For dtb.bin
-QCOM_DTBBIN = ""
-QCOM_DTBBIN:qcom = "linux-qcom-dtbbin"
-inherit ${QCOM_DTBBIN}


### PR DESCRIPTION
Rather than clobbering linux-yocto (and linux-yocto-dev) with machine-specific inherits, specify required classes using the KERNEL_CLASSES variable.