### PR TITLE
Fix bitbake lack of whitespace warnings

### DIFF
--- a/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
+++ b/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
@@ -6,7 +6,7 @@ RDEPENDS:${PN} = "initramfs-framework-base ${VIRTUAL-RUNTIME_base-utils}"
 SRC_URI = "file://copy-modules.sh"
 
 S = "${WORKDIR}/sources"
-UNPACKDIR= "${S}"
+UNPACKDIR = "${S}"
 
 do_install() {
     install -d ${D}/init.d

--- a/recipes-support/rust-android-sparse/rust-android-sparse_0.6.0.bb
+++ b/recipes-support/rust-android-sparse/rust-android-sparse_0.6.0.bb
@@ -4,7 +4,7 @@ inherit cargo cargo-update-recipe-crates
 
 # how to get android-sparse could be as easy as but default to a git checkout:
 SRC_URI += "crate://crates.io/android-sparse/0.6.0"
-S= "${CARGO_VENDORING_DIRECTORY}/android-sparse-${PV}"
+S = "${CARGO_VENDORING_DIRECTORY}/android-sparse-${PV}"
 SRC_URI[android-sparse-0.6.0.sha256sum] = "9c76c5759b0af9dea95a769ff5fe140cec5afb5fa65019817f3731b3232afe44"
 
 require rust-android-sparse-crates.inc


### PR DESCRIPTION
Consequence of https://github.com/openembedded/bitbake/commit/24772dd2ae6c0cd11540a260f15065f906fb0997.