### PR TITLE
Add graphicsdlkm recipe

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -25,4 +25,5 @@ RDEPENDS:${PN}-miscellaneous = " \
     ${@bb.utils.contains("BBLAYERS", "openembedded-layer", "libssc","", d)} \
     libvmmem-dev \
     libdmabufheap-dev \
+    graphicsdlkm \
 "

--- a/recipes-graphics/graphicsdlkm/files/kgsl.rules
+++ b/recipes-graphics/graphicsdlkm/files/kgsl.rules
@@ -1,0 +1,1 @@
+KERNEL=="kgsl-3d0", GROUP="render", MODE="0660", TAG+="uaccess"

--- a/recipes-graphics/graphicsdlkm/graphicsdlkm_1.0.bb
+++ b/recipes-graphics/graphicsdlkm/graphicsdlkm_1.0.bb
@@ -1,0 +1,15 @@
+inherit module
+
+DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
+
+SRCREV = "e878d0a22e449d92a2ab92f384e4775e6895b7f6"
+SRC_URI = "git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https"
+SRC_URI += "file://kgsl.rules"
+
+do_install:append() {
+      install -m 0644 ${WORKDIR}/sources/kgsl.rules -D ${D}${nonarch_base_libdir}/udev/rules.d/kgsl.rules
+}
+
+FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"


### PR DESCRIPTION
graphicsdlkm recipe introduces the QUALCOMM KGSL driver, which is responsible for managing the Adreno GPU.

Key responsibilities of the driver include:
- GPU memory management
- Command submission to GPU
- GPU Power management
- Providing debug and profiling interface to user-space