### PR TITLE
WIP: Add support for building in containers

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -17,6 +17,11 @@ jobs:
   kas-mirror:
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
+    container:
+      image: ghcr.io/siemens/kas/kas:4.7
+      volumes:
+        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+      options: --privileged --user=builder
     steps:
       - name: Update kas mirrors
         run: |
@@ -29,6 +34,11 @@ jobs:
     needs:  kas-mirror
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
+    container:
+      image: ghcr.io/siemens/kas/kas:4.7
+      volumes:
+        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+      options: --privileged --user=builder
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +57,10 @@ jobs:
     needs: kas-lock
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
+    container:
+      image: ghcr.io/siemens/kas/kas:4.7
+      volumes:
+        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,6 +79,10 @@ jobs:
     needs: kas-lock
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
+    container:
+      image: ghcr.io/siemens/kas/kas:4.7
+      volumes:
+        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,6 +101,10 @@ jobs:
     needs: kas-lock
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
+    container:
+      image: ghcr.io/siemens/kas/kas:4.7
+      volumes:
+        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
     strategy:
       fail-fast: true
       matrix:
@@ -103,6 +125,12 @@ jobs:
         with:
           name: kas-lock
           path: ci/
+
+      - name: Install build deps
+        run: |
+          sudo apt update -y
+          sudo apt install -y libcairo-dev meson python3-dev
+          sudo pip install -U pycairo==1.26.1 --break-system-packages
 
       - name: Kas build
         run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -157,9 +157,9 @@ jobs:
 
   create-output:
     needs: compile
+    runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.print-output.outputs.url }}
-    runs-on: [self-hosted, x86]
     steps:
       - name: "Print output"
         id: print-output

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -10,7 +10,7 @@ on:
 env:
   BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
   CACHE_DIR: /srv/gh-runners/quic-yocto
-  KAS_REPO_REF_DIR: /srv/gh-runners/quic-yocto/kas-mirrors
+  KAS_REPO_REF_DIR: ${CACHE_DIR}/kas-mirrors
   BASE_ARTIFACT_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
     container:
       image: ghcr.io/siemens/kas/kas:4.7
       volumes:
-        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+        - /srv/gh-runners/quic-yocto:/srv/gh-runners/quic-yocto
       options: --privileged --user=builder
     steps:
       - name: Update kas mirrors
@@ -37,7 +37,7 @@ jobs:
     container:
       image: ghcr.io/siemens/kas/kas:4.7
       volumes:
-        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+        - /srv/gh-runners/quic-yocto:/srv/gh-runners/quic-yocto
       options: --privileged --user=builder
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     container:
       image: ghcr.io/siemens/kas/kas:4.7
       volumes:
-        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+        - /srv/gh-runners/quic-yocto:/srv/gh-runners/quic-yocto
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
     container:
       image: ghcr.io/siemens/kas/kas:4.7
       volumes:
-        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+        - /srv/gh-runners/quic-yocto:/srv/gh-runners/quic-yocto
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
     container:
       image: ghcr.io/siemens/kas/kas:4.7
       volumes:
-        - ${KAS_REPO_REF_DIR}:${KAS_REPO_REF_DIR}
+        - /srv/gh-runners/quic-yocto:/srv/gh-runners/quic-yocto
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -82,6 +82,7 @@ jobs:
   compile:
     needs: kas-lock
     if: github.repository == 'qualcomm-linux/meta-qcom'
+    runs-on: [self-hosted, x86]
     strategy:
       fail-fast: true
       matrix:
@@ -92,7 +93,6 @@ jobs:
           - qrb2210-rb1-core-kit
           - qcom-armv8a
           - qcom-armv7a
-    runs-on: [self-hosted, x86]
     name: ${{ matrix.machine }}/poky/systemd
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As per issue #840, this PR moves our workflows to use the kas container where appropriate, allowing us have more control of the project build dependencies.