### PR TITLE
Email update for vkraleti

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default reviewers for all changes in entire repository,
 # unless a later match takes precedence
-*  @quic-vkraleti @ricardosalveti @sbanerjee-quic @ndechesne
+*  @vkraleti @ricardosalveti @sbanerjee-quic @ndechesne
 
 # Reviewers to be assigned for any changes in ci/ subdirectory
 ci/*  @quaresmajose @ricardosalveti @sbanerjee-quic @ndechesne
 
 # Reviewers to be assigned for any changes in conf/ subdirectory
-conf/*  @quic-vkraleti @ricardosalveti @sbanerjee-quic @ndechesne
+conf/*  @vkraleti @ricardosalveti @sbanerjee-quic @ndechesne
 
 # Reviewers to be assigned for any changes in recipes-kernel/linux/ subdirectory
-recipes-kernel/linux/*  @NainaMehtaQUIC @quic-vkraleti @sbanerjee-quic @ndechesne
+recipes-kernel/linux/*  @NainaMehtaQUIC @vkraleti @sbanerjee-quic @ndechesne

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ with the suggested change instead.
 
 * Naveen Kumar <quic_kumarn@quicinc.com>
 * Sourabh Banerjee <quic_sbanerje@quicinc.com>
-* Viswanath Kraleti <quic_vkraleti@quicinc.com>
+* Viswanath Kraleti <vkraleti@oss.qualcomm.com>
 * Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
 * Nicolas Dechesne <nicolas.dechesne@oss.qualcomm.com>
 


### PR DESCRIPTION
As an organizational guideline, it is preferred to use the oss.qualcomm.com email ID instead of the quicinc email ID.