### PR TITLE
packagegroup-qcom: use RDEPENDS instead of RRECOMMENDS

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -7,13 +7,13 @@ PACKAGES = " \
     ${PN}-boot-additional \
 "
 
-RRECOMMENDS:${PN}-boot-essential = " \
+RDEPENDS:${PN}-boot-essential = " \
     pd-mapper \
     qrtr \
     rmtfs \
     tqftpserv \
 "
 
-RRECOMMENDS:${PN}-boot-additional = " \
+RDEPENDS:${PN}-boot-additional = " \
     fastrpc \
 "


### PR DESCRIPTION
All initramfs-\*-image recipes use NO_RECOMMENDS to keep the size minimal. The commit ebf3168 ("packagegroups: Define QCOM userspace helper packagegroups") made initramfs-tiny-image to pull     packagegroup-qcom-* packages, which RRECOMMENDs platform packages     instead of RDEPENDing on them, thus all testing initramfs images have     lost corresponding Qualcomm tools.

Make packagegroup-qcom use RDEPENDS instead of RRECOMMENDS in order to     brign tool packages back.