### PR TITLE
firmware-qcom-boot-qcs6490: update to 00075.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00075.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00075.0.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \
     "
-SRC_URI[bootbinaries.sha256sum] = "08c0798f1ab9f380c94b54141847c7b365c87f2a072a2461779cf282809aeeb4"
+SRC_URI[bootbinaries.sha256sum] = "38e6f424e02a8f99b9edf953e9d62b02489cb936426c58c48daf399ec6d5b60c"
 SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"
 
 QCOM_BOOT_IMG_SUBDIR = "qcm6490"


### PR DESCRIPTION
Firmware available as part of the Qualcomm Linux 1.4 release.

Known changes:
 - Boot KPI optimizations
 - Update memmap holes dynamically as conventional memory
 - Minor bug fixes
 - Supporting 32-bit OEM ID