### PR TITLE
ci: Convert to yet another artifact upload API

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -121,41 +121,17 @@ jobs:
           path: buildchart.svg
 
       - name: Publish image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          build_dir=${CACHE_DIR}/builds/${BUILD_ID}
-          mkdir -p $build_dir
-          img_dir=$build_dir/${{ matrix.machine }}
-          [ -d $img_dir ] && rm -rf $img_dir
           deploy_dir=../kas/build/tmp/deploy/images/${{matrix.machine}}
           find $deploy_dir/ -maxdepth 1 -name "*.rootfs*.qcomflash" -exec rm -rf {} \;
-          mv $deploy_dir $img_dir
 
           # Instruct our file server to make these files available for download
-          url="${BASE_ARTIFACT_URL}/${BUILD_ID}/${{ matrix.machine }}/"
-
-          retries=8
-          okay=0
-          shopt -s lastpipe  # allows us to capture the value of `okay` in the while loop below
-          for ((i=0; i<retries; i++)); do
-              curl -X POST -H "Accept: text/event-stream" -i --fail-with-body -s -N ${url} | \
-                  while read line; do
-                      echo $line
-                      if [[ $line == STATUS=* ]]; then
-                          if [[ $line == "STATUS=OK" ]]; then
-                              okay=1
-                              break
-                          fi
-                      fi
-                  done
-              [ $okay -eq 1 ] && break
-              echo # new line break in case response doesn't have one
-              echo "Error: unable to publish artifacts, sleep and retry"
-              sleep 2
-          done
-          (( retries == i )) && { echo 'Failed to publish artifacts'; exit 1; }
-
-          echo # new line break in case response doesn't have one
-          echo Image available at: ${url}
+          export URL="${BASE_ARTIFACT_URL}/${BUILD_ID}/${{ matrix.machine }}/"
+          export BUILD_DIR="$(readlink -f $deploy_dir)"
+          .github/workflows/publish_artifacts.py
+          echo Image available at: ${URL}
 
   create-output:
     needs: compile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  security-events: read  # This is required to handle authentication to our artifact publishing API
 
 jobs:
   event-file:

--- a/.github/workflows/publish_artifacts.py
+++ b/.github/workflows/publish_artifacts.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from multiprocessing import Pool
+import os
+import sys
+from typing import List
+
+import requests
+
+gh_token = os.environ["GITHUB_TOKEN"]
+
+
+def upload_file(args):
+    try:
+        url, base, name = args
+
+        headers = {
+            "Authentication": f"Bearer {gh_token}",
+        }
+        r = requests.put(url, headers=headers, allow_redirects=False)
+        if not r.ok:
+            return name, f"Unable to get signed url HTTP_{r.status_code} - {r.text}"
+
+        url = r.headers["location"]
+        path = os.path.join(base, name)
+        r = requests.put(
+            url, data=open(path, "rb"), headers={"Content-type": "application/octet-stream"}
+        )
+        if not r.ok:
+            return name, f"Unable to upload content HTTP_{r.status_code} - {r.text}"
+
+        return name, None
+    except Exception as e:
+        return name, str(e)
+
+
+def get_files_to_publish(path: str) -> List[str]:
+    paths = []
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            paths.append(os.path.join(root, file)[len(path) :])
+    return paths
+
+
+def main(artifacts_dir: str, base_url: str):
+    paths = get_files_to_publish(artifacts_dir)
+    print(f"= Found {len(paths)} files to publish", flush=True)
+
+    failed = False
+    work = [(f"{base_url}{x}", artifacts_dir, x) for x in paths]
+    with Pool(5) as p:
+        results = p.imap_unordered(upload_file, work)
+        for i, res in enumerate(results):
+            name, err = res
+            print(f"= {i+1} of {len(work)} - {name}", flush=True)
+            if err:
+                print(f"|-> ERROR: {err}", flush=True)
+                failed = True
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    BUILD_DIR = os.environ["BUILD_DIR"]
+    if BUILD_DIR[-1] != "/":
+        BUILD_DIR = BUILD_DIR + "/"
+
+    URL = os.environ["URL"]
+    if URL[-1] != "/":
+        URL = URL + "/"
+
+    main(BUILD_DIR, URL)


### PR DESCRIPTION
The current artifact upload logic requires the self-hosted runner and the file-server to share the same NFS volume as a means of uploading artifacts. This change decouples that so that we could use any runner and still upload artifacts.

We do this by leveraging the GITHUB_TOKEN included in every CI job (including PRs from forked repositories). This is an ephemeral token only valid during the lifetime of the workflow. By granting it read access to the "security-events" API, our file-serve can assert the token it gets is a valid qualcomm-linux token before allowing an upload to happen.

The upload logic gets a little hard to maintain with inline yaml and shell script, so I've created a Python helper to do the upload. It has a few handy features:

 * parallel uploads
 * upload progress
 * better logging/info messages