### PR TITLE
qcom-partition-conf: qcs9100: fix type argument

### DIFF
--- a/recipes-bsp/partition/files/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/files/qcs9100-partitions.conf
@@ -57,7 +57,7 @@
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
 --partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --lun=4 --name=keymaster_a --size=512KB --type=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf


### PR DESCRIPTION
There is no partition type argument, should be type-guid instead.