### PR TITLE
Disable earlycon for all machines

### DIFF
--- a/conf/machine/include/qcom-qcm2290.inc
+++ b/conf/machine/include/qcom-qcm2290.inc
@@ -8,7 +8,7 @@ QCOM_VFAT_SECTOR_SIZE = "512"
 
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
-KERNEL_CMDLINE_EXTRA ?= "earlycon clk_ignore_unused pd_ignore_unused"
+KERNEL_CMDLINE_EXTRA ?= "clk_ignore_unused pd_ignore_unused"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \

--- a/conf/machine/include/qcom-qcs6490.inc
+++ b/conf/machine/include/qcom-qcs6490.inc
@@ -7,8 +7,6 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "earlycon"
-
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs6490-soc \

--- a/conf/machine/include/qcom-qcs8300.inc
+++ b/conf/machine/include/qcom-qcs8300.inc
@@ -7,8 +7,6 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "earlycon"
-
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
 "

--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -7,8 +7,6 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
-KERNEL_CMDLINE_EXTRA ?= "earlycon"
-
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
 "


### PR DESCRIPTION
Use of earlycon makes it harder to debug issues (see [RB8 boot logs](https://github.com/qualcomm-linux/meta-qcom/actions/runs/14848561348/job/41689454218) for example). Disable earlycon in order to make it possible to get the full boot log.