### PR TITLE
linux-yocto-dev: enable UFS on the RB8 board

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -43,6 +43,7 @@ SRC_URI:append:qcom = " \
     file://qcs9075-board-dts/0002-arm64-dts-qcom-Add-support-for-QCS9075-RB8.patch \
     file://qcs9075-board-dts/0003-arm64-dts-qcom-Add-support-for-QCS9075-Ride-Ride-r3.patch \
     file://qcs9075-board-dts/0004-arm64-dts-qcom-Enable-cpu-cooling-devices-for-QCS907.patch \
+    file://qcs9075-board-dts/0001-arm64-dts-qcom-qcs9075-rb8-enable-UFS.patch \
 "
 
 # Include additional kernel configs.

--- a/recipes-kernel/linux/linux-yocto-dev/qcs9075-board-dts/0001-arm64-dts-qcom-qcs9075-rb8-enable-UFS.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcs9075-board-dts/0001-arm64-dts-qcom-qcs9075-rb8-enable-UFS.patch
@@ -1,0 +1,52 @@
+From 41be3ebea7e2542b5828fd0b2adaa3d72920b686 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Tue, 6 May 2025 14:13:42 +0300
+Subject: [PATCH] arm64: dts: qcom: qcs9075-rb8: enable UFS
+
+Enable the UFS storage module on the Qualcomm RB8 board.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Pending [Waiting for RB8 patches to be resubmitted]
+---
+ arch/arm64/boot/dts/qcom/qcs9075-rb8.dts | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs9075-rb8.dts b/arch/arm64/boot/dts/qcom/qcs9075-rb8.dts
+index 3ab6deeaacf1..3750d9de6d3a 100644
+--- a/arch/arm64/boot/dts/qcom/qcs9075-rb8.dts
++++ b/arch/arm64/boot/dts/qcom/qcs9075-rb8.dts
+@@ -17,6 +17,7 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart10;
++		ufshc1 = &ufs_mem_hc;
+ 	};
+ 
+ 	chosen {
+@@ -277,6 +278,23 @@ &uart10 {
+ 	status = "okay";
+ };
+ 
++&ufs_mem_hc {
++	reset-gpios = <&tlmm 149 GPIO_ACTIVE_LOW>;
++	vcc-supply = <&vreg_l8a>;
++	vcc-max-microamp = <1100000>;
++	vccq-supply = <&vreg_l4c>;
++	vccq-max-microamp = <1200000>;
++
++	status = "okay";
++};
++
++&ufs_mem_phy {
++	vdda-phy-supply = <&vreg_l4a>;
++	vdda-pll-supply = <&vreg_l1c>;
++
++	status = "okay";
++};
++
+ &xo_board_clk {
+ 	clock-frequency = <38400000>;
+ };
+-- 
+2.39.5
+


### PR DESCRIPTION
Enable the UFS storage on the RB8 board in order to make it able to pass the tests.