### PR TITLE
fixup! ci: Convert to yet another artifact upload API (#861)

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  security-events: read  # This is required to handle authentication to our artifact publishing API
 
 jobs:
   build-nightly:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  security-events: read  # This is required to handle authentication to our artifact publishing API
 
 jobs:
   build:


### PR DESCRIPTION
We need this permission for merge commits also, so that we can verify the API token is indeed a member of qualcomm-linux that can publish artifacts.