### PR TITLE
uki-esp-image: fix order of tasks

### DIFF
--- a/classes/uki-esp-image.bbclass
+++ b/classes/uki-esp-image.bbclass
@@ -16,4 +16,4 @@ do_ukiesp() {
 	install -m 0755 ${DEPLOY_DIR_IMAGE}/${UKI_FILENAME} ${IMAGE_ROOTFS}${ESPFOLDER}/EFI/Linux
 }
 
-addtask ukiesp after do_deploy uki before do_image_complete do_image_wic
+addtask ukiesp after do_rootfs uki before do_image


### PR DESCRIPTION
Fix the order of tasks in uki-esp-image class so that the Linux UKI file has a chance to land in the generated VFAT image.