### PR TITLE
uki: add back support for console and KERNEL_CMDLINE_EXTRA in the kernel cmdline

### DIFF
--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -12,7 +12,7 @@ inherit image uki uki-esp-image
 
 UKI_FILENAME = "${EFI_LINUX_IMG}"
 
-UKI_CMDLINE = "root=${QCOM_BOOTIMG_ROOTFS} rw rootwait"
+UKI_CMDLINE = "root=${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${KERNEL_CONSOLE}"
 
 # Remove 'upstream' dtb, rely on EFI provided one
 KERNEL_DEVICETREE = ""

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -13,6 +13,7 @@ inherit image uki uki-esp-image
 UKI_FILENAME = "${EFI_LINUX_IMG}"
 
 UKI_CMDLINE = "root=${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${KERNEL_CONSOLE}"
+UKI_CMDLINE += "${@d.getVar('KERNEL_CMDLINE_EXTRA') or ''}"
 
 # Remove 'upstream' dtb, rely on EFI provided one
 KERNEL_DEVICETREE = ""
@@ -34,3 +35,5 @@ remove_unused_files() {
     find ${IMAGE_ROOTFS} -mindepth 1 ! -path "${IMAGE_ROOTFS}/EFI*" -exec rm -rf {} +
 }
 IMAGE_PREPROCESS_COMMAND:append = " remove_unused_files"
+
+do_uki[vardeps] += "KERNEL_CMDLINE_EXTRA"


### PR DESCRIPTION
Both were removed as a side effect of https://github.com/qualcomm-linux/meta-qcom/pull/722