### PR TITLE
qcs9100-ride-sx: disable EFI runtime services

### DIFF
--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -36,3 +36,6 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-staging = " \
                       qcom/sa8775p-addons-ride.dtb \
                       qcom/sa8775p-addons-ride-r3.dtb \
                       "
+
+# https://github.com/qualcomm-linux/meta-qcom/issues/856
+KERNEL_CMDLINE_EXTRA:append = " efi=noruntime"


### PR DESCRIPTION
On QCS9100 RIDE SX accessing EFI vars causes kernel oops. Disable RT services until the issue gets resolved.

```
[Firmware Bug]: Unable to handle paging request in EFI runtime service
------------[ cut here ]------------
WARNING: CPU: 2 PID: 161 at drivers/firmware/efi/runtime-wrappers.c:341 __efi_queue_work+0xd4/0x108
Modules linked in:
CPU: 2 UID: 0 PID: 161 Comm: mount Tainted: G          I         6.15.0-rc1-yoctodev-standard-g151abc177ae8 #1 PREEMPT
Tainted: [I]=FIRMWARE_WORKAROUND
Hardware name: Qualcomm QCS9100 Ride Rev3 (DT)
pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
pc : __efi_queue_work+0xd4/0x108
lr : __efi_queue_work+0xc0/0x108
sp : ffff800081c83a80
x29: ffff800081c83a80 x28: ffff7067462e0000 x27: 0000000000000000
x26: ffff7067429dee00 x25: 000000000000000c x24: 0000000000000000
x23: 0000000000000000 x22: ffff70674634bc00 x21: ffff70674634b800
x20: ffff800081c83b30 x19: ffffa2741239bb38 x18: 0000000000000000
x17: 000000040044ffff x16: 0000000000000100 x15: ffff7067462e0090
x14: ffff7067462e0080 x13: 0000000000000001 x12: 0000000000000002
x11: 071c71c71c71c71c x10: 8623b690b2f37923 x9 : 19c5b371d5fccc7a
x8 : ffff7067462e1108 x7 : 0000000000000001 x6 : 0000000000000001
x5 : 0000000000000000 x4 : ffff7067462e0000 x3 : 0000000000000000
x2 : 0000000000000000 x1 : 8000000000000015 x0 : 8000000000000015
Call trace:
 __efi_queue_work+0xd4/0x108 (P)
x29: ffff800080003ec0 x28: ffff706747deb480 x27: 0000000000000010
x26: 0000000000000002 x25: 0000000000100073 x24: ffff706746cb0000
x23: ffff70674133c000 x22: 0000000000000402 x21: ffff706740adf300
x20: ffff70674133ba80 x19: 0000000000000000 x18: ffff70758fc16bc0
x17: ffffce017df23000 x16: ffff800080000000 x15: 0000aaaac4f8ffff
x14: 0000000000000000 x13: ffffa274114a44e8 x12: 0000ffffac9c0fff
x11: 1fffee0ce8fc8541 x10: 0000000000000000 x9 : 0000000000000040
x8 : ffff70674000a228 x7 : 0000000000000000 x6 : 0000000000000000
x5 : ffff706740adf400 x4 : 0000000000000000 x3 : 0000000000000001
x2 : 0000000090880000 x1 : 0000000000000000 x0 : ffff706740adf360
Call trace:
 0xffff706740adf400 (P)
 arm_smmu_context_fault+0xa4/0x140
 __handle_irq_event_percpu+0x48/0x140
 handle_irq_event+0x44/0xb0
 handle_fasteoi_irq+0x98/0x1c0
 handle_irq_desc+0x34/0x58
 generic_handle_domain_irq+0x1c/0x28
 gic_handle_irq+0x4c/0x140
 call_on_irq_stack+0x24/0x64
 do_interrupt_handler+0x80/0x84
 el1_interrupt+0x34/0x68
 el1h_64_irq_handler+0x18/0x24
 el1h_64_irq+0x6c/0x70
 __vmf_anon_prepare+0xc/0xa0 (P)
 handle_mm_fault+0x88/0x2b8
 do_page_fault+0x1a8/0x6bc
 do_translation_fault+0xac/0xc0
 do_mem_abort+0x40/0x90
 el1_abort+0x3c/0x60
 el1h_64_sync_handler+0xf0/0x120
 el1h_64_sync+0x6c/0x70
 __arch_copy_to_user+0x190/0x240 (P)
 copy_page_to_iter+0xfc/0x140
 filemap_read+0x1c0/0x420
 blkdev_read_iter+0x6c/0x184
 vfs_read+0x290/0x340
 ksys_read+0x64/0x100
 __arm64_sys_read+0x18/0x24
 invoke_syscall.constprop.0+0x40/0xf0
 el0_svc_common.constprop.0+0x38/0xd8
 do_el0_svc+0x1c/0x28
 el0_svc+0x30/0xc8
 el0t_64_sync_handler+0x10c/0x138
 el0t_64_sync+0x198/0x19c
Code: 00000000 00000000 00000000 00000000 (00000000)
---[ end trace 0000000000000000 ]---
Kernel panic - not syncing: Oops: Fatal exception in interrupt
SMP: stopping secondary CPUs
Kernel Offset: 0x22738fcb0000 from 0xffff800080000000
PHYS_OFFSET: 0xfff08f99c0000000
CPU features: 0x0800,000002e0,01002650,aa0072ab
Memory Limit: none
---[ end Kernel panic - not syncing: Oops: Fatal exception in interrupt ]---
```