### PR TITLE
CI: disable fail-fast for CI job submission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
     needs: prepare-job-list
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare-job-list.outputs.jobmatrix) }}
     steps:
       - name: Clone repository


### PR DESCRIPTION
It is usually important to get the image tested on all boards rather than stopping on the first failure. Specifi fail-fast:false to the submit-job in order to let all image tests finish if one of them fails.