### PR TITLE
Deploy QCS9100 SAIL firmware

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -100,6 +100,12 @@ create_qcomflash_pkg() {
         install -m 0644 ${bfw} .
     done
 
+    # sail nor firmware
+    if [ -d "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/sail_nor" ]; then
+        install -d sail_nor
+        find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/sail_nor" -maxdepth 1 -type f -exec install -m 0644 {} sail_nor \;
+    fi
+
     # Create symlink to ${QCOMFLASH_DIR} dir
     ln -rsf ${QCOMFLASH_DIR} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -14,13 +14,13 @@ inherit deploy
 
 do_deploy() {
     install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name 'gpt_*.bin' -delete
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name 'zeros_*.bin' -delete
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.elf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.fv' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name 'gpt_*.bin' -delete
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name 'zeros_*.bin' -delete
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name '*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name '*.elf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name '*.fv' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${UNPACKDIR}/${BOOTBINARIES}" -maxdepth 1 -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
 
     find "${UNPACKDIR}" -name 'cdt*bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
 }

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00075.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00075.0.bb
@@ -19,3 +19,14 @@ SRC_URI[qcs9100-ride-sx.sha256sum] = "377a8405899ac82199deaf70bca3648c15b924a3fc
 QCOM_BOOT_IMG_SUBDIR = "qcs9100"
 
 include firmware-qcom-boot-common.inc
+
+do_deploy:append() {
+    if [ -d "${UNPACKDIR}/${BOOTBINARIES}/sail_nor" ]; then
+        SAIL_FILES="gpt_backup0.bin gpt_main0.bin prog_firehose_ddr.elf patch0.xml rawprogram0.xml sailfreertos.elf"
+
+        install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/sail_nor
+        for sail_file in ${SAIL_FILES}; do
+            install -m 0644 ${UNPACKDIR}/${BOOTBINARIES}/sail_nor/${sail_file} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/sail_nor
+        done
+    fi
+}


### PR DESCRIPTION
SAIL firmware is available as part of the boot firmware r1.0_00075.0 release, and required by QCS9100.