### PR TITLE
SA8775P and QCS8300 initramfs images

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-image.bb
@@ -7,10 +7,12 @@ PACKAGE_INSTALL:qcom-armv8a = " \
     packagegroup-dragonboard410c-firmware \
     packagegroup-dragonboard820c-firmware \
     packagegroup-dragonboard845c-firmware \
+    packagegroup-qcs8300-ride-firmware \
     packagegroup-rb1-firmware \
     packagegroup-rb2-firmware \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb5-firmware \
+    packagegroup-sa8775p-ride-firmware \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "
 

--- a/recipes-bsp/images/initramfs-firmware-qcs8300-ride-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-qcs8300-ride-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with QCS8300 Ride firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-qcs8300-ride-firmware \
+"
+
+require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-sa8775p-ride-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sa8775p-ride-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with SA8775P Ride firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-sa8775p-ride-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Add initramfs images with SA8775P and QCS8300 firmware for the Ride SX boards.