### PR TITLE
linux-yocto-dev: import patches fixing ufs regressions

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -22,6 +22,9 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0001-dts-rb3gen2-soundwire-checkin.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
+    file://workarounds/0001-scsi-ufs-qcom-Check-gear-against-max-gear-in-vop-fre.patch \
+    file://workarounds/0002-scsi-ufs-qcom-Map-devfreq-OPP-freq-to-UniPro-Core-Cl.patch \
+    file://workarounds/0003-scsi-ufs-qcom-Call-ufs_qcom_cfg_timers-in-clock-scal.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \
     file://drivers/0004-PCI-dwc-Add-host_start_link-host_start_link-hooks-fo.patch \
     file://drivers/0005-PCI-dwc-Implement-.start_link-.stop_link-hooks.patch \

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-scsi-ufs-qcom-Check-gear-against-max-gear-in-vop-fre.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-scsi-ufs-qcom-Check-gear-against-max-gear-in-vop-fre.patch
@@ -1,0 +1,47 @@
+From a07b09444da4a1a57e08682cf3adce33d8acf7e3 Mon Sep 17 00:00:00 2001
+From: Ziqi Chen <quic_ziqichen@quicinc.com>
+Date: Fri, 9 May 2025 15:50:27 +0800
+Subject: [PATCH 1/3] scsi: ufs: qcom: Check gear against max gear in vop
+ freq_to_gear()
+
+The vop freq_to_gear() may return a gear greater than the negotiated max
+gear, return the negotiated max gear if the mapped gear is greater than it.
+
+Fixes: c02fe9e222d1 ("scsi: ufs: qcom: Implement the freq_to_gear_speed() vop")
+Signed-off-by: Ziqi Chen <quic_ziqichen@quicinc.com>
+Tested-by: Neil Armstrong <neil.armstrong@linaro.org>
+Reviewed-by: Bean Huo <beanhuo@micron.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250509075029.3776419-2-quic_ziqichen@quicinc.com/]
+---
+ drivers/ufs/host/ufs-qcom.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
+index c0761ccc1381e3..28515f89ce7988 100644
+--- a/drivers/ufs/host/ufs-qcom.c
++++ b/drivers/ufs/host/ufs-qcom.c
+@@ -1924,7 +1924,7 @@ static int ufs_qcom_config_esi(struct ufs_hba *hba)
+ 
+ static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
+ {
+-	u32 gear = 0;
++	u32 gear = UFS_HS_DONT_CHANGE;
+ 
+ 	switch (freq) {
+ 	case 403000000:
+@@ -1946,10 +1946,10 @@ static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
+ 		break;
+ 	default:
+ 		dev_err(hba->dev, "%s: Unsupported clock freq : %lu\n", __func__, freq);
+-		break;
++		return UFS_HS_DONT_CHANGE;
+ 	}
+ 
+-	return gear;
++	return min_t(u32, gear, hba->max_pwr_info.info.gear_rx);
+ }
+ 
+ /*
+-- 
+2.49.0
+

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0002-scsi-ufs-qcom-Map-devfreq-OPP-freq-to-UniPro-Core-Cl.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0002-scsi-ufs-qcom-Map-devfreq-OPP-freq-to-UniPro-Core-Cl.patch
@@ -1,0 +1,172 @@
+From d8442cade1c5f6e6229550c7e94d37625a2be649 Mon Sep 17 00:00:00 2001
+From: Can Guo <quic_cang@quicinc.com>
+Date: Fri, 9 May 2025 15:50:28 +0800
+Subject: [PATCH 2/3] scsi: ufs: qcom: Map devfreq OPP freq to UniPro Core
+ Clock freq
+
+On some platforms, the devfreq OPP freq may be different than the unipro
+core clock freq. Implement ufs_qcom_opp_freq_to_clk_freq() and use it to
+find the unipro core clk freq.
+
+Fixes: c02fe9e222d1 ("scsi: ufs: qcom: Implement the freq_to_gear_speed() vop")
+Signed-off-by: Can Guo <quic_cang@quicinc.com>
+Co-developed-by: Ziqi Chen <quic_ziqichen@quicinc.com>
+Signed-off-by: Ziqi Chen <quic_ziqichen@quicinc.com>
+Tested-by: Luca Weiss <luca.weiss@fairphone.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250509075029.3776419-3-quic_ziqichen@quicinc.com/]
+---
+ drivers/ufs/host/ufs-qcom.c | 81 ++++++++++++++++++++++++++++++++-----
+ 1 file changed, 71 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
+index 28515f89ce7988..2b000c1708ce45 100644
+--- a/drivers/ufs/host/ufs-qcom.c
++++ b/drivers/ufs/host/ufs-qcom.c
+@@ -103,7 +103,9 @@ static const struct __ufs_qcom_bw_table {
+ };
+ 
+ static void ufs_qcom_get_default_testbus_cfg(struct ufs_qcom_host *host);
+-static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, unsigned long freq);
++static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
++						   unsigned long freq, char *name);
++static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, bool is_scale_up, unsigned long freq);
+ 
+ static struct ufs_qcom_host *rcdev_to_ufs_host(struct reset_controller_dev *rcd)
+ {
+@@ -602,7 +604,7 @@ static int ufs_qcom_link_startup_notify(struct ufs_hba *hba,
+ 			return -EINVAL;
+ 		}
+ 
+-		err = ufs_qcom_set_core_clk_ctrl(hba, ULONG_MAX);
++		err = ufs_qcom_set_core_clk_ctrl(hba, true, ULONG_MAX);
+ 		if (err)
+ 			dev_err(hba->dev, "cfg core clk ctrl failed\n");
+ 		/*
+@@ -1360,29 +1362,46 @@ static int ufs_qcom_set_clk_40ns_cycles(struct ufs_hba *hba,
+ 	return ufshcd_dme_set(hba, UIC_ARG_MIB(PA_VS_CORE_CLK_40NS_CYCLES), reg);
+ }
+ 
+-static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, unsigned long freq)
++static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, bool is_scale_up, unsigned long freq)
+ {
+ 	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
+ 	struct list_head *head = &hba->clk_list_head;
+ 	struct ufs_clk_info *clki;
+ 	u32 cycles_in_1us = 0;
+ 	u32 core_clk_ctrl_reg;
++	unsigned long clk_freq;
+ 	int err;
+ 
++	if (hba->use_pm_opp && freq != ULONG_MAX) {
++		clk_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk_unipro");
++		if (clk_freq) {
++			cycles_in_1us = ceil(clk_freq, HZ_PER_MHZ);
++			goto set_core_clk_ctrl;
++		}
++	}
++
+ 	list_for_each_entry(clki, head, list) {
+ 		if (!IS_ERR_OR_NULL(clki->clk) &&
+ 		    !strcmp(clki->name, "core_clk_unipro")) {
+-			if (!clki->max_freq)
++			if (!clki->max_freq) {
+ 				cycles_in_1us = 150; /* default for backwards compatibility */
+-			else if (freq == ULONG_MAX)
++				break;
++			}
++
++			if (freq == ULONG_MAX) {
+ 				cycles_in_1us = ceil(clki->max_freq, HZ_PER_MHZ);
+-			else
+-				cycles_in_1us = ceil(freq, HZ_PER_MHZ);
++				break;
++			}
+ 
++			if (is_scale_up)
++				cycles_in_1us = ceil(clki->max_freq, HZ_PER_MHZ);
++			else
++				cycles_in_1us = ceil(clk_get_rate(clki->clk), HZ_PER_MHZ);
+ 			break;
+ 		}
+ 	}
+ 
++set_core_clk_ctrl:
+ 	err = ufshcd_dme_get(hba,
+ 			    UIC_ARG_MIB(DME_VS_CORE_CLK_CTRL),
+ 			    &core_clk_ctrl_reg);
+@@ -1425,7 +1444,7 @@ static int ufs_qcom_clk_scale_up_pre_change(struct ufs_hba *hba, unsigned long f
+ 		return ret;
+ 	}
+ 	/* set unipro core clock attributes and clear clock divider */
+-	return ufs_qcom_set_core_clk_ctrl(hba, freq);
++	return ufs_qcom_set_core_clk_ctrl(hba, true, freq);
+ }
+ 
+ static int ufs_qcom_clk_scale_up_post_change(struct ufs_hba *hba)
+@@ -1457,7 +1476,7 @@ static int ufs_qcom_clk_scale_down_pre_change(struct ufs_hba *hba)
+ static int ufs_qcom_clk_scale_down_post_change(struct ufs_hba *hba, unsigned long freq)
+ {
+ 	/* set unipro core clock attributes and clear clock divider */
+-	return ufs_qcom_set_core_clk_ctrl(hba, freq);
++	return ufs_qcom_set_core_clk_ctrl(hba, false, freq);
+ }
+ 
+ static int ufs_qcom_clk_scale_notify(struct ufs_hba *hba, bool scale_up,
+@@ -1922,11 +1941,53 @@ static int ufs_qcom_config_esi(struct ufs_hba *hba)
+ 	return ret;
+ }
+ 
++static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
++						   unsigned long freq, char *name)
++{
++	struct ufs_clk_info *clki;
++	struct dev_pm_opp *opp;
++	unsigned long clk_freq;
++	int idx = 0;
++	bool found = false;
++
++	opp = dev_pm_opp_find_freq_exact_indexed(hba->dev, freq, 0, true);
++	if (IS_ERR(opp)) {
++		dev_err(hba->dev, "Failed to find OPP for exact frequency %lu\n", freq);
++		return 0;
++	}
++
++	list_for_each_entry(clki, &hba->clk_list_head, list) {
++		if (!strcmp(clki->name, name)) {
++			found = true;
++			break;
++		}
++
++		idx++;
++	}
++
++	if (!found) {
++		dev_err(hba->dev, "Failed to find clock '%s' in clk list\n", name);
++		dev_pm_opp_put(opp);
++		return 0;
++	}
++
++	clk_freq = dev_pm_opp_get_freq_indexed(opp, idx);
++
++	dev_pm_opp_put(opp);
++
++	return clk_freq;
++}
++
+ static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
+ {
+ 	u32 gear = UFS_HS_DONT_CHANGE;
++	unsigned long unipro_freq;
++
++	if (!hba->use_pm_opp)
++		return gear;
+ 
+-	switch (freq) {
++	unipro_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk_unipro");
++	switch (unipro_freq) {
+ 	case 403000000:
+ 		gear = UFS_HS_G5;
+ 		break;
+-- 
+2.49.0
+

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0003-scsi-ufs-qcom-Call-ufs_qcom_cfg_timers-in-clock-scal.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0003-scsi-ufs-qcom-Call-ufs_qcom_cfg_timers-in-clock-scal.patch
@@ -1,0 +1,135 @@
+From 2df0481e32710f9ba6905cb078522bc85f29783a Mon Sep 17 00:00:00 2001
+From: Can Guo <quic_cang@quicinc.com>
+Date: Fri, 9 May 2025 15:50:29 +0800
+Subject: [PATCH 3/3] scsi: ufs: qcom: Call ufs_qcom_cfg_timers() in clock
+ scaling path
+
+ufs_qcom_cfg_timers() is clock freq dependent like ufs_qcom_set_core_clk_
+ctrl(), hence move ufs_qcom_cfg_timers() call to clock scaling path. In
+addition, do not assume the devfreq OPP freq is always the 'core_clock'
+freq although 'core_clock' is the first clock phandle in device tree, use
+ufs_qcom_opp_freq_to_clk_freq() to find the core clk freq.
+
+Signed-off-by: Can Guo <quic_cang@quicinc.com>
+Co-developed-by: Ziqi Chen <quic_ziqichen@quicinc.com>
+Signed-off-by: Ziqi Chen <quic_ziqichen@quicinc.com>
+Tested-by: Luca Weiss <luca.weiss@fairphone.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-arm-msm/20250509075029.3776419-4-quic_ziqichen@quicinc.com/]
+---
+ drivers/ufs/host/ufs-qcom.c | 49 ++++++++++++++++++++++---------------
+ 1 file changed, 29 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
+index 2b000c1708ce45..48c2244c2d68dc 100644
+--- a/drivers/ufs/host/ufs-qcom.c
++++ b/drivers/ufs/host/ufs-qcom.c
+@@ -545,13 +545,14 @@ static int ufs_qcom_hce_enable_notify(struct ufs_hba *hba,
+  *
+  * @hba: host controller instance
+  * @is_pre_scale_up: flag to check if pre scale up condition.
++ * @freq: target opp freq
+  * Return: zero for success and non-zero in case of a failure.
+  */
+-static int ufs_qcom_cfg_timers(struct ufs_hba *hba, bool is_pre_scale_up)
++static int ufs_qcom_cfg_timers(struct ufs_hba *hba, bool is_pre_scale_up, unsigned long freq)
+ {
+ 	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
+ 	struct ufs_clk_info *clki;
+-	unsigned long core_clk_rate = 0;
++	unsigned long clk_freq = 0;
+ 	u32 core_clk_cycles_per_us;
+ 
+ 	/*
+@@ -563,22 +564,34 @@ static int ufs_qcom_cfg_timers(struct ufs_hba *hba, bool is_pre_scale_up)
+ 	if (host->hw_ver.major < 4 && !ufshcd_is_intr_aggr_allowed(hba))
+ 		return 0;
+ 
++	if (hba->use_pm_opp && freq != ULONG_MAX) {
++		clk_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk");
++		if (clk_freq)
++			goto cfg_timers;
++	}
++
+ 	list_for_each_entry(clki, &hba->clk_list_head, list) {
+ 		if (!strcmp(clki->name, "core_clk")) {
++			if (freq == ULONG_MAX) {
++				clk_freq = clki->max_freq;
++				break;
++			}
++
+ 			if (is_pre_scale_up)
+-				core_clk_rate = clki->max_freq;
++				clk_freq = clki->max_freq;
+ 			else
+-				core_clk_rate = clk_get_rate(clki->clk);
++				clk_freq = clk_get_rate(clki->clk);
+ 			break;
+ 		}
+ 
+ 	}
+ 
++cfg_timers:
+ 	/* If frequency is smaller than 1MHz, set to 1MHz */
+-	if (core_clk_rate < DEFAULT_CLK_RATE_HZ)
+-		core_clk_rate = DEFAULT_CLK_RATE_HZ;
++	if (clk_freq < DEFAULT_CLK_RATE_HZ)
++		clk_freq = DEFAULT_CLK_RATE_HZ;
+ 
+-	core_clk_cycles_per_us = core_clk_rate / USEC_PER_SEC;
++	core_clk_cycles_per_us = clk_freq / USEC_PER_SEC;
+ 	if (ufshcd_readl(hba, REG_UFS_SYS1CLK_1US) != core_clk_cycles_per_us) {
+ 		ufshcd_writel(hba, core_clk_cycles_per_us, REG_UFS_SYS1CLK_1US);
+ 		/*
+@@ -598,7 +611,7 @@ static int ufs_qcom_link_startup_notify(struct ufs_hba *hba,
+ 
+ 	switch (status) {
+ 	case PRE_CHANGE:
+-		if (ufs_qcom_cfg_timers(hba, false)) {
++		if (ufs_qcom_cfg_timers(hba, false, ULONG_MAX)) {
+ 			dev_err(hba->dev, "%s: ufs_qcom_cfg_timers() failed\n",
+ 				__func__);
+ 			return -EINVAL;
+@@ -876,17 +889,6 @@ static int ufs_qcom_pwr_change_notify(struct ufs_hba *hba,
+ 
+ 		break;
+ 	case POST_CHANGE:
+-		if (ufs_qcom_cfg_timers(hba, false)) {
+-			dev_err(hba->dev, "%s: ufs_qcom_cfg_timers() failed\n",
+-				__func__);
+-			/*
+-			 * we return error code at the end of the routine,
+-			 * but continue to configure UFS_PHY_TX_LANE_ENABLE
+-			 * and bus voting as usual
+-			 */
+-			ret = -EINVAL;
+-		}
+-
+ 		/* cache the power mode parameters to use internally */
+ 		memcpy(&host->dev_req_params,
+ 				dev_req_params, sizeof(*dev_req_params));
+@@ -1438,7 +1440,7 @@ static int ufs_qcom_clk_scale_up_pre_change(struct ufs_hba *hba, unsigned long f
+ {
+ 	int ret;
+ 
+-	ret = ufs_qcom_cfg_timers(hba, true);
++	ret = ufs_qcom_cfg_timers(hba, true, freq);
+ 	if (ret) {
+ 		dev_err(hba->dev, "%s ufs cfg timer failed\n", __func__);
+ 		return ret;
+@@ -1475,6 +1477,13 @@ static int ufs_qcom_clk_scale_down_pre_change(struct ufs_hba *hba)
+ 
+ static int ufs_qcom_clk_scale_down_post_change(struct ufs_hba *hba, unsigned long freq)
+ {
++	int ret;
++
++	ret = ufs_qcom_cfg_timers(hba, false, freq);
++	if (ret) {
++		dev_err(hba->dev, "%s: ufs_qcom_cfg_timers() failed\n",	__func__);
++		return ret;
++	}
+ 	/* set unipro core clock attributes and clear clock divider */
+ 	return ufs_qcom_set_core_clk_ctrl(hba, false, freq);
+ }
+-- 
+2.49.0
+


### PR DESCRIPTION
Import patch series to fix UFS multi-frequency scaling regresions caused in 6.15.

v3 series: https://lore.kernel.org/linux-arm-msm/20250509075029.3776419-1-quic_ziqichen@quicinc.com/