### PR TITLE
ci: add dmesg to boot test

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -46,7 +46,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
-        TESTS: "pwd, uname -a, ip a"
+        TESTS: "pwd, uname -a, ip a, dmesg"
 - command:
     name: network_turn_on
 context:

--- a/ci/lava/qcs9075-iq-9075-evk/boot.yaml
+++ b/ci/lava/qcs9075-iq-9075-evk/boot.yaml
@@ -46,7 +46,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
-        TESTS: "pwd, uname -a, ip a"
+        TESTS: "pwd, uname -a, ip a, dmesg"
 - command:
     name: network_turn_on
 context:

--- a/ci/lava/qcs9100-ride-sx/boot.yaml
+++ b/ci/lava/qcs9100-ride-sx/boot.yaml
@@ -46,7 +46,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
-        TESTS: "pwd, uname -a, ip a"
+        TESTS: "pwd, uname -a, ip a, dmesg"
 - command:
     name: network_turn_on
 context:

--- a/ci/lava/qrb2210-rb1-core-kit/boot.yaml
+++ b/ci/lava/qrb2210-rb1-core-kit/boot.yaml
@@ -46,7 +46,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
-        TESTS: "pwd, uname -a, ip a"
+        TESTS: "pwd, uname -a, ip a, dmesg"
 - command:
     name: network_turn_on
 context:


### PR DESCRIPTION
Run dmesg as a part of boot testing on the hardware. dmesg command is only executed. No filtering is done for warning or errors.