### PR TITLE
firmware-qcom-boot: update to 00095.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00075.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00075.0.bb
@@ -1,3 +1,0 @@
-require recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "38e6f424e02a8f99b9edf953e9d62b02489cb936426c58c48daf399ec6d5b60c"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00095.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "9c100d7b184ecf0ab9c4be71a8bb7c243fdc79a64380ca3025024dd2b14c5078"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00075.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00075.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "826599d4ef60337f38de935f3049134489e3f703b874dd592996b013f8e9e40a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00095.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "463ffd7f20d243a5673ac49d744c8a35a3ab2067c3588be2741c2e6551f5a8f5"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00075.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00075.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "c8042ef4668761f75021886b931d678339ca9cbab936a20f951a6ba747a77303"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00095.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "c201c9e966a706c9e76685ff4298f0940958c4d4877299eee1248ef26b809aa0"


### PR DESCRIPTION
A new firmware drop 00095.0 is available. Migrate to it for qcs6490, qcs9100, qcs8300 based machines. 