### PR TITLE
ci: add and build kas configuration file for initramfs images

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -115,6 +115,10 @@ jobs:
           kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml
           ci/yocto-pybootchartgui.sh && mv $KAS_WORK_DIR/build/buildchart.svg .
 
+          if [ "${{ matrix.machine }}" = "qcom-arm8a" ]; then
+            kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml:initramfs-test.yml
+          fi
+
       - uses: actions/upload-artifact@v4
         with:
           name: buildchart-${{ matrix.machine }}

--- a/ci/initramfs-test.yml
+++ b/ci/initramfs-test.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+target:
+  - initramfs-test-image
+  - initramfs-test-full-image
+  - initramfs-firmware-image
+  - initramfs-firmware-rb3gen2-image
+  - initramfs-firmware-qcs8300-ride-image
+  - initramfs-firmware-sa8775p-ride-image


### PR DESCRIPTION
Extend kas build logic to also build a series of initramfs images (test and firmware related), to be used with general kernel validation.