### PR TITLE
Drop initramfs-firmware-image from initramfs-test.yml

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -115,8 +115,8 @@ jobs:
           kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml
           ci/yocto-pybootchartgui.sh && mv $KAS_WORK_DIR/build/buildchart.svg .
 
-          if [ "${{ matrix.machine }}" = "qcom-arm8a" ]; then
-            kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml:initramfs-test.yml
+          if [ "${{ matrix.machine }}" = "qcom-armv8a" ]; then
+            kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml:ci/initramfs-test.yml
           fi
 
       - uses: actions/upload-artifact@v4

--- a/ci/initramfs-test.yml
+++ b/ci/initramfs-test.yml
@@ -6,7 +6,6 @@ header:
 target:
   - initramfs-test-image
   - initramfs-test-full-image
-  - initramfs-firmware-image
   - initramfs-firmware-rb3gen2-image
   - initramfs-firmware-qcs8300-ride-image
   - initramfs-firmware-sa8775p-ride-image

--- a/ci/initramfs-test.yml
+++ b/ci/initramfs-test.yml
@@ -4,8 +4,24 @@ header:
   version: 14
 
 target:
-  - initramfs-test-image
-  - initramfs-test-full-image
-  - initramfs-firmware-rb3gen2-image
+  - initramfs-firmware-db8074-image
+  - initramfs-firmware-dragonboard410c-image
+  - initramfs-firmware-dragonboard820c-image
+  - initramfs-firmware-dragonboard845c-image
+  - initramfs-firmware-qar2130p-image
   - initramfs-firmware-qcs8300-ride-image
+  - initramfs-firmware-rb1-image
+  - initramfs-firmware-rb2-image
+  - initramfs-firmware-rb3gen2-image
+  - initramfs-firmware-rb5-image
   - initramfs-firmware-sa8775p-ride-image
+  - initramfs-firmware-sm8150-hdk-image
+  - initramfs-firmware-sm8350-hdk-image
+  - initramfs-firmware-sm8450-hdk-image
+  - initramfs-firmware-sm8550-hdk-image
+  - initramfs-firmware-sm8650-hdk-image
+  - initramfs-kerneltest-full-image
+  - initramfs-kerneltest-image
+  - initramfs-test-full-image
+  - initramfs-test-image
+  - initramfs-tiny-image


### PR DESCRIPTION
initramfs-firmware-image recipe has been dropped with PR #889 ,  remove it from the list of initrd test images as well.