### PR TITLE
qcs9075-iq-9075-evk: fix QCOM_DTB_DEFAULT

### DIFF
--- a/conf/machine/qcs9075-iq-9075-evk.conf
+++ b/conf/machine/qcs9075-iq-9075-evk.conf
@@ -6,7 +6,7 @@ require conf/machine/include/qcom-qcs9100.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "qcs9075-rb8"
+QCOM_DTB_DEFAULT ?= "qcs9075-iq-9075-evk"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs9075-iq-9075-evk.dtb \


### PR DESCRIPTION
Commit d55a42e05d42 ("linux-yocto-dev: refresh qcs9075-iq-9075-evk DT patches") has updated KERNEL_DEVICETREE, but failed to update QCOM_DTB_DEFAULT. Thus dtb.bin isn't being created, which makes tests on the RB8 board fail.

Point QCOM_DTB_DEFAULT to point to the same DTB as KERNEL_DEVICETREE does.
