### PR TITLE
ci: distro: update distro name and dependencies

### DIFF
--- a/ci/distro.yml
+++ b/ci/distro.yml
@@ -3,9 +3,16 @@
 header:
   version: 14
 
-distro: qcom-wayland
+distro: qcom-distro
 
 repos:
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
+
+  meta-openembedded:
+    url: https://github.com/openembedded/meta-openembedded
+    layers:
+      meta-oe:
+      meta-networking:
+      meta-python:


### PR DESCRIPTION
Default qualcomm distro name was updated from qcom-wayland to
qcom-distro, and the default layer dependency now includes meta-oe,
meta-networking and meta-python.