### PR TITLE
initramfs-test-full: Add more utils

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -11,6 +11,8 @@ PACKAGE_INSTALL += " \
     ncurses \
     ncurses-terminfo \
     ncurses-terminfo-base \
+    net-tools \
+    rng-tools \
     stress-ng \
     util-linux \
     util-linux-chrt \


### PR DESCRIPTION
Adding the utilities net-tools and rng-tools in 'initramfs-test-full-image.bb'

- net-tools is required by the [scripts](https://github.com/qualcomm-linux/qcom-linux-testkit/pull/35/) in PR#35 in qcom-linux-testkit
- rng-tools is required by the [script](https://github.com/qualcomm-linux/qcom-linux-testkit/blob/main/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh) to run rngtest