### PR TITLE
packagegroup-sa8775p-ride-firmware: include sa8775p-qupv3fw

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
@@ -14,6 +14,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sa8775p-audio \
     linux-firmware-qcom-sa8775p-compute \
     linux-firmware-qcom-sa8775p-generalpurpose \
+    linux-firmware-qcom-sa8775p-qupv3fw \
     linux-firmware-qcom-vpu \
 "
 


### PR DESCRIPTION
Available as part of linux-firmware 20250509 from oe-core.