### PR TITLE
ci: build-yocto: join kas-lock and kas-mirror in kas-setup job

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -14,7 +14,7 @@ env:
   BASE_ARTIFACT_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
 
 jobs:
-  kas-mirror:
+  kas-setup:
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
     steps:
@@ -25,11 +25,6 @@ jobs:
             git -C $r fetch --prune origin '+refs/*:refs/*'
           done
 
-  kas-lock:
-    needs:  kas-mirror
-    if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, x86]
-    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -44,7 +39,7 @@ jobs:
           path: ci/*.lock.yml
 
   yocto-check-layer:
-    needs: kas-lock
+    needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
     steps:
@@ -62,7 +57,7 @@ jobs:
           ci/yocto-check-layer.sh
 
   yocto-patchreview:
-    needs: kas-lock
+    needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, x86]
     steps:
@@ -80,7 +75,7 @@ jobs:
           ci/yocto-patchreview.sh
 
   compile:
-    needs: kas-lock
+    needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
     strategy:
       fail-fast: true


### PR DESCRIPTION
Join the jobs kas-lock and kas-mirror in a new kas-setup job. This will improve the efficiency and both jobs has no dependencies and can be easily done in one.