### PR TITLE
workflows: add build download URL to summary

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -150,6 +150,8 @@ jobs:
           echo "Downloads URL: ${build_url}"
           echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT
           echo "${build_url}" > build_url
+          echo "## Download URL" >> $GITHUB_STEP_SUMMARY
+          echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
       - name: Upload build URL
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Build URL is added to the summary and will be displayed in the workflow presentation page in github.