### PR TITLE
weston-init: set default weston backend to drm

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,1 @@
+DEFAULTBACKEND:qcom ?= "drm"


### PR DESCRIPTION
DRM should be the default weston backend on qcom devices.