### PR TITLE
workflows: update LAVA schema check to 2025.04

### DIFF
--- a/.github/workflows/lava-schema-check.yml
+++ b/.github/workflows/lava-schema-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   schema-check:
     runs-on: ubuntu-latest
-    container: lavasoftware/lava-server:2024.09
+    container: lavasoftware/lava-server:2025.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Use LAVA release 2025.04 to check job templates schema. LAVA instance where the test jobs are run were recently upgraded to the same version.