### PR TITLE
 qdl: update source revision to newest master 

### DIFF
--- a/recipes-devtools/qdl/qdl_git.bb
+++ b/recipes-devtools/qdl/qdl_git.bb
@@ -1,4 +1,6 @@
-SUMMARY = "QDL flasing tool"
+SUMMARY = "Qualcomm DownLoader flashing tool"
+DESCRIPTION = "Communicate with Qualcomm SoCs to upload new software or \
+dump memory"
 HOMEPAGE = "https://github.com/linux-msm/qdl.git"
 SECTION = "devel"
 

--- a/recipes-devtools/qdl/qdl_git.bb
+++ b/recipes-devtools/qdl/qdl_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "libxml2 libusb1"
 
 inherit pkgconfig
 
-SRCREV = "fa070e81b4a33a4fa6f33af08ef8cf7245715540"
+SRCREV = "5db7794e9fdb73ed0c45384026cd8a62b5fff786"
 SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.0+${SRCREV}"


### PR DESCRIPTION
There have been 48 commits to the master branch of QDL since we last updated the recipe. Let's point at the current master revision to bring it up to date.

While at it, also flesh out the recipe description a bit.