### PR TITLE
update meta-qcom url to generate kas lock file with commit sha

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -11,6 +11,7 @@ defaults:
 
 repos:
   meta-qcom:
+    url: https://github.com/qualcomm-linux/meta-qcom
 
   oe-core:
     url: https://github.com/openembedded/openembedded-core


### PR DESCRIPTION
Unless the url is added for meta-qcom the generated kas lock file is missing entry for meta-qcom commit.

Adding the 'url:' generates an additional commit sha for meta-qcom as follows in the lock.yml file.

`
        meta-qcom:
            commit: 11bc71051e2d486977a51cf7fc1a0143fec01109
`

