### PR TITLE
Add support for QCS615-adp-air machine

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -82,6 +82,7 @@ jobs:
       matrix:
         machine:
           - qcm6490-idp
+          - qcs615-adp-air
           - qcs6490-rb3gen2-core-kit
           - qcs8300-ride-sx
           - qcs9075-iq-9075-evk

--- a/ci/qcs615-adp-air.yml
+++ b/ci/qcs615-adp-air.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: qcs615-adp-air

--- a/conf/machine/include/qcom-qcs615.inc
+++ b/conf/machine/include/qcom-qcs615.inc
@@ -1,0 +1,18 @@
+# Configuration and variables for QCS615 family.
+
+SOC_FAMILY = "qcs615"
+require conf/machine/include/qcom-base.inc
+require conf/machine/include/qcom-common.inc
+
+DEFAULTTUNE = "armv8-2a-crypto"
+require conf/machine/include/arm/arch-armv8-2a.inc
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"
+
+EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qcs615"

--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -1,0 +1,16 @@
+#@TYPE: Machine
+#@NAME: Qualcomm QCS615 ADP Air Beta Evaluation Kit (EVK)
+#@DESCRIPTION: Machine configuration for Qualcomm ADP Air Beta Evaluation Kit (EVK), with QCS615.
+
+require conf/machine/include/qcom-qcs615.inc
+
+MACHINE_FEATURES += "efi pci"
+
+QCOM_DTB_DEFAULT ?= "qcs615-ride"
+
+KERNEL_DEVICETREE ?= " \
+                      qcom/qcs615-ride.dtb \
+                      "
+
+QCOM_BOOT_FILES_SUBDIR = "qcs615"
+QCOM_PARTITION_CONF = "qcom-partition-conf-qcs615-adp-air"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -1,0 +1,16 @@
+DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS615 platform"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
+FW_BUILD_ID = "r1.0_${PV}/qcs615-le-1-0"
+FW_BIN_PATH = "common/build/common/bin"
+BOOTBINARIES = "QCS615_bootbinaries"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    "
+
+QCOM_BOOT_IMG_SUBDIR = "qcs615"
+
+include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00095.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "c9b0332873feda447b32491dcbbc96255c3cf88da1868d89ac5113b01cb42f75"

--- a/recipes-bsp/partition/files/qcs615-partitions.conf
+++ b/recipes-bsp/partition/files/qcs615-partitions.conf
@@ -1,0 +1,80 @@
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# options if not explicitly provide
+
+--disk --type=emmc --size=76841669632 --write-protect-boundary=65536 --sector-size-in-bytes=512 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --lun (mandatory for UFS, emmc no need this)
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --attributes  1000000000000004
+#   --filename    ""
+#   --readonly    true
+#   --sparse      false
+
+# This is LUN 0 - HLOS LUN"
+--partition --name=xbl_a --size=3584KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=xbl_b --size=3584KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98
+--partition --name=xbl_config_b --size=512KB --type-guid=A4CDBB5A-5A73-436E-B129-689EC01DBFE3
+--partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
+--partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
+--partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=keymint.mbn
+--partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=secs2d.mbn
+--partition --name=cmnlib_a --size=512KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5
+--partition --name=cmnlib64_a --size=512KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=qupfw_a --size=64KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
+--partition --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
+--partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=rawdump --size=131072KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428
+--partition --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
+--partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA
+--partition --name=multiimgoem --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8
+--partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
+--partition --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
+--partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=hyp_b --size=8192KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
+--partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2
+--partition --name=qupfw_b --size=64KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=secs2d.mbn
+--partition --name=cmnlib_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=cmnlib64_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
+--partition --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E
+--partition --name=core_nhlos_a --size=174080KB --type-guid=6690b4ce-70e9-4817-b9f1-25d64d888357
+--partition --name=core_nhlos_b --size=174080KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=quantumfv --size=512KB --type-guid=80c23c26-c3f9-4a19-bb38-1e457daceb09
+--partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=persist --size=131072KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+--partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img

--- a/recipes-bsp/partition/qcom-partition-conf-qcs615-adp-air.bb
+++ b/recipes-bsp/partition/qcom-partition-conf-qcs615-adp-air.bb
@@ -1,0 +1,7 @@
+MACHINE_DESC = "Qualcomm QCS615 ADP AIR"
+
+PARTCONF = "qcs615-partitions.conf"
+
+QCOM_PARTCONF_SUBDIR = "qcs615"
+
+include qcom-partition-conf.inc

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -42,6 +42,7 @@ SRC_URI:append:qcom = " \
     file://qcs9075-board-dts/0003-arm64-dts-qcom-qcs9075-Introduce-QCS9075M-SOM.patch \
     file://qcs9075-board-dts/0004-arm64-dts-qcom-Add-support-for-qcs9075-IQ-9075-EVK.patch \
     file://qcs9075-board-dts/0001-arm64-dts-qcom-qcs9075-iq-9075-evk-enable-UFS.patch \
+    file://qcs615-board-dts/0001-arm64-dts-qcom-qcs615-Add-Command-DB-support.patch \
 "
 
 # Include additional kernel configs.

--- a/recipes-kernel/linux/linux-yocto-dev/qcs615-board-dts/0001-arm64-dts-qcom-qcs615-Add-Command-DB-support.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcs615-board-dts/0001-arm64-dts-qcom-qcs615-Add-Command-DB-support.patch
@@ -1,0 +1,38 @@
+From 63b53fc23be01c7b34690f7dded0c144ae4412ac Mon Sep 17 00:00:00 2001
+From: Lijuan Gao <quic_lijuang@quicinc.com>
+Date: Thu, 27 Mar 2025 15:29:49 +0800
+Subject: [PATCH 1/3] arm64: dts: qcom: qcs615: Add Command DB support
+
+Command DB is a database in the shared memory of QCOM SoCs, that
+provides a mapping between resource key and the resource address for a
+system resource managed by a remote processor. The data is stored in a
+shared memory region and is loaded by the remote processor. Therefore,
+enabling Command DB ensures that those resources function properly.
+
+Signed-off-by: Lijuan Gao <quic_lijuang@quicinc.com>
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://lore.kernel.org/r/20250221-add_command_db_support-v1-1-d60acbf913aa@quicinc.com]
+---
+ arch/arm64/boot/dts/qcom/qcs615.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs615.dtsi b/arch/arm64/boot/dts/qcom/qcs615.dtsi
+index 3e9922e69536..4a96202aea99 100644
+--- a/arch/arm64/boot/dts/qcom/qcs615.dtsi
++++ b/arch/arm64/boot/dts/qcom/qcs615.dtsi
+@@ -417,6 +417,12 @@ reserved-memory {
+ 		#size-cells = <2>;
+ 		ranges;
+ 
++		aop_cmd_db_mem: aop-cmd-db@85f20000 {
++			compatible = "qcom,cmd-db";
++			reg = <0x0 0x85f20000 0x0 0x20000>;
++			no-map;
++		};
++
+ 		smem_region: smem@86000000 {
+ 			compatible = "qcom,smem";
+ 			reg = <0x0 0x86000000 0x0 0x200000>;
+-- 
+2.34.1
+


### PR DESCRIPTION
Enable QCS615 support, include:
1. dts patches for kernel
2. partition conf for qcs615
3. firmware recipe to take care deploy boot non-hlos.
4. machine conf
5. github CI enablement for qcs615