### PR TITLE
recipe-bsp: modification to include qcom-iris in final image.

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
+++ b/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
@@ -42,6 +42,7 @@ RRECOMMENDS:${PN}-qcom-generic += " \
     kernel-module-phy-qcom-qmp-usbc \
     kernel-module-phy-qcom-qusb2 \
     kernel-module-phy-qcom-snps-femto-v \
+    kernel-module-qcom-iris \
     kernel-module-qcom-pmic-tcpm \
     kernel-module-qcom-pon \
     kernel-module-qcom-q6v5-mss \


### PR DESCRIPTION
adding kernel module qcom-iris in machine essential package group,
so that it is present in device as part of final image.

Change-Id: I3597529a6ba81e883deb9c8c5e5807e72e733cda