### PR TITLE
Use RDEPENDS instead of RRECOMMENDS in packagegroup-qcom

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -20,7 +20,7 @@ RDEPENDS:${PN}-boot-additional = " \
 "
 
 # libssc depends on libqmi and protobuf which are part of meta-oe
-RRECOMMENDS:${PN}-miscellaneous = " \
+RDEPENDS:${PN}-miscellaneous = " \
     hexagonrpc \
     ${@bb.utils.contains("BBLAYERS", "openembedded-layer", "libssc","", d)} \
     libvmmem-dev \


### PR DESCRIPTION
Switch to using RDEPENDS for including miscellaneous packages in packagegroup-qcom to ensure they are built by default.