### PR TITLE
ci: publish buildchart.svg kas-build.yml on the deploy dir

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -135,8 +135,8 @@ jobs:
           uploads_dir=./uploads
           mkdir $uploads_dir
           find $deploy_dir/ -maxdepth 1 -name "*.rootfs*.qcomflash" -exec rm -rf {} \;
+          cp buildchart.svg kas-build.yml $deploy_dir/
           mv $deploy_dir $uploads_dir/
-          cp buildchart.svg kas-build.yml $uploads_dir/
 
       - name: Upload private artifacts
         uses: qualcomm-linux/upload-private-artifact-action@v1


### PR DESCRIPTION
Make buildchart and kas lock file machine specific
otherwise they collided with previously existing files
on the uploads dir.