### PR TITLE
Github workflow: build both Poky and Qcom DISTRO configs

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -89,8 +89,13 @@ jobs:
           - qrb2210-rb1-core-kit
           - qcom-armv8a
           - qcom-armv7a
+        distro:
+          - name: poky-systemd
+            yamlfile: ""
+          - name: qcom
+            yamlfile: 'ci/distro.yml:'
     runs-on: [self-hosted, x86]
-    name: ${{ matrix.machine }}/poky/systemd
+    name: ${{ matrix.machine }}/${{ matrix.distro.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,7 +114,7 @@ jobs:
           mkdir $KAS_WORK_DIR
           kas dump --resolve-env --resolve-local --resolve-refs \
               ci/mirror.yml:ci/${{ matrix.machine }}.yml > kas-build.yml
-          kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml
+          kas build ci/mirror.yml:${{ matrix.distro.yamlfile }}ci/${{ matrix.machine }}.yml
           ci/yocto-pybootchartgui.sh && mv $KAS_WORK_DIR/build/buildchart.svg .
 
           if [ "${{ matrix.machine }}" = "qcom-armv8a" ]; then
@@ -118,12 +123,12 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: buildchart-${{ matrix.machine }}
+          name: buildchart-${{ matrix.distro.name }}-${{ matrix.machine }}
           path: buildchart.svg
 
       - uses: actions/upload-artifact@v4
         with:
-          name: kas-build-${{ matrix.machine }}
+          name: kas-build-${{ matrix.distro.name }}-${{ matrix.machine }}
           path: kas-build.yml
 
       - name: Stage build artifacts for publishing
@@ -132,8 +137,8 @@ jobs:
           # expects file to be relative to our PWD. deploy_dir is outside
           # that, so we move things around:
           deploy_dir=../kas/build/tmp/deploy/images/${{matrix.machine}}
-          uploads_dir=./uploads
-          mkdir $uploads_dir
+          uploads_dir=./uploads/${{ matrix.distro.name }}
+          mkdir -p $uploads_dir
           find $deploy_dir/ -maxdepth 1 -name "*.rootfs*.qcomflash" -exec rm -rf {} \;
           cp buildchart.svg kas-build.yml $deploy_dir/
           mv $deploy_dir $uploads_dir/

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -22,35 +22,15 @@ jobs:
       url: ${{ steps.set-build-url.outputs.url }}
     steps:
       - name: 'Download build URL'
-        uses: actions/github-script@v6
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v11
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "build_url"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
-            if (!fs.existsSync(temp)){
-              fs.mkdirSync(temp);
-            }
-            fs.writeFileSync(path.join(temp, 'build_url.zip'), Buffer.from(download.data));
+          run_id: ${{ github.event.workflow_run.id }}
+          name: build_url
 
       - name: 'Setup build URL'
         id: set-build-url
         run: |
-          unzip "${{ runner.temp }}/artifacts/build_url.zip"
           BUILD_URL=$(cat build_url)
           echo "Build URL: ${BUILD_URL}"
           echo "url=${BUILD_URL}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add another axis to the CI matrix: distro.name and have a companion variable to add optional extra yaml files. The DISTRO in meta-qcom-distro needs `distro.yml`, while the default Poky-that-isn't-poky-anymore does not need an extra yaml.