### PR TITLE
ci: correct download URLs for dragonboard 410c/820c

### DIFF
--- a/ci/lava/dragonboard-410c/boot.yaml
+++ b/ci/lava/dragonboard-410c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/boot-apq8016-sbc-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/boot-apq8016-sbc-qcom-armv8a.img"
       rootfs:
         headers:
           Authorization: LAVA_BASIC_AUTH
-        url: "{{BUILD_DOWNLOAD_URL}}/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:

--- a/ci/lava/dragonboard-820c/boot.yaml
+++ b/ci/lava/dragonboard-820c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/boot-apq8096-db820c-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/boot-apq8096-db820c-qcom-armv8a.img"
       rootfs:
         headers:
           Authorization: LAVA_BASIC_AUTH
-        url: "{{BUILD_DOWNLOAD_URL}}/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:


### PR DESCRIPTION
Include machine name into the generated download URLs for db410c / db820c.