### PR TITLE
ci: fix LAVA templates for dragonboard-410c and 820c

### DIFF
--- a/ci/lava/dragonboard-410c/boot.yaml
+++ b/ci/lava/dragonboard-410c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/boot-apq8016-sbc-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/boot-apq8016-sbc-qcom-armv8a.img"
       rootfs:
         headers:
-          Authorization: LAVA_BASIC_AUTH
-        url: "{{BUILD_DOWNLOAD_URL}}/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+          Authentication: Q_GITHUB_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:

--- a/ci/lava/dragonboard-820c/boot.yaml
+++ b/ci/lava/dragonboard-820c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/boot-apq8096-db820c-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/boot-apq8096-db820c-qcom-armv8a.img"
       rootfs:
         headers:
-          Authorization: LAVA_BASIC_AUTH
-        url: "{{BUILD_DOWNLOAD_URL}}/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+          Authentication: Q_GITHUB_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:
@@ -25,7 +25,7 @@ actions:
     to: fastboot
     images:
       boot:
-        url: downloads://boot-apq8016-sbc-qcom-armv8a.img
+        url: downloads://boot-apq8096-db820c-qcom-armv8a.img
       rootfs:
         url: downloads://core-image-base-qcom-armv8a.rootfs.img
         apply-overlay: true


### PR DESCRIPTION
The templates had wrong passwords for downloading rootfs. Boot image name for db820c was copied from 410c and not changed. Download path was missing "qcom-armv8a". These issues caused the jobs to fail. This patch fixes all mentioned problems.