### PR TITLE
qdl: replace 0.0 in recipe PV with latest release

### DIFF
--- a/recipes-devtools/qdl/qdl_git.bb
+++ b/recipes-devtools/qdl/qdl_git.bb
@@ -14,7 +14,7 @@ inherit pkgconfig
 SRCREV = "5db7794e9fdb73ed0c45384026cd8a62b5fff786"
 SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
 
-PV = "0.0+${SRCREV}"
+PV = "2.1+${SRCREV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The most recent qdl release is 2.1, which is 6 months old and we are referencing a newer revision from git instead.

Still, that git revision is based off a release, so it makes more sense for PV to start with the revision, so when there is an actual newer release, possible consumers of the package feed see that there is an actual update. There is no loss of information, because the source revision appended after the '+' remains as is.