### PR TITLE
ci/mirror: Switch to new CDN

### DIFF
--- a/ci/mirror.yml
+++ b/ci/mirror.yml
@@ -6,4 +6,4 @@ header:
 local_conf_header:
   mirror: |
     BB_HASHSERVE_UPSTREAM = "wss://hashserv.yoctoproject.org/ws"
-    SSTATE_MIRRORS = "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"
+    SSTATE_MIRRORS = "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"


### PR DESCRIPTION
The project [1] is switching the way handle our CDN provision of sstate objects, update the URL accordingly.

[1] https://git.yoctoproject.org/yocto-docs/commit/?id=406e8a8e30404c0538f5aa46f211540bae2b206b