### PR TITLE
linux-yocto-dev: import patches fixing venus probe crashes

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -25,6 +25,9 @@ SRC_URI:append:qcom = " \
     file://workarounds/0001-scsi-ufs-qcom-Check-gear-against-max-gear-in-vop-fre.patch \
     file://workarounds/0002-scsi-ufs-qcom-Map-devfreq-OPP-freq-to-UniPro-Core-Cl.patch \
     file://workarounds/0003-scsi-ufs-qcom-Call-ufs_qcom_cfg_timers-in-clock-scal.patch \
+    file://workarounds/0001-media-venus-protect-against-spurious-interrupts-duri.patch \
+    file://workarounds/0001-media-venus-hfi-explicitly-release-IRQ-during-teardo.patch \
+    file://workarounds/0001-media-venus-Fix-probe-error-handling.patch \
     file://drivers/0003-PCI-Add-new-start_link-stop_link-function-ops.patch \
     file://drivers/0004-PCI-dwc-Add-host_start_link-host_start_link-hooks-fo.patch \
     file://drivers/0005-PCI-dwc-Implement-.start_link-.stop_link-hooks.patch \

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-Fix-probe-error-handling.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-Fix-probe-error-handling.patch
@@ -1,0 +1,80 @@
+From 31f91817a35ddbc2f57327ec8ab9ac0039bf50a7 Mon Sep 17 00:00:00 2001
+From: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Date: Thu, 27 Mar 2025 13:53:04 +0100
+Subject: [PATCH] media: venus: Fix probe error handling
+
+Video device registering has been moved earlier in the probe function,
+but the new order has not been propagated to error handling. This means
+we can end with unreleased resources on error (e.g dangling video device
+on missing firmware probe aborting).
+
+Fixes: 08b1cf474b7f7 ("media: venus: core, venc, vdec: Fix probe dependency error")
+Cc: stable@vger.kernel.org
+Signed-off-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Reviewed-by: Dikshita Agarwal <quic_dikshita@quicinc.com>
+Reviewed-by: Bryan O'Donoghue <bod@kernel.org>
+Signed-off-by: Bryan O'Donoghue <bod@kernel.org>
+Signed-off-by: Hans Verkuil <hverkuil@xs4all.nl>
+Upstream-Status: Backport [https://git.kernel.org/torvalds/linux/c/523cea3a19f0]
+---
+ drivers/media/platform/qcom/venus/core.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 04641a7dcc9832..5bd99d0aafe4d7 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -438,7 +438,7 @@ static int venus_probe(struct platform_device *pdev)
+ 
+ 	ret = v4l2_device_register(dev, &core->v4l2_dev);
+ 	if (ret)
+-		goto err_core_deinit;
++		goto err_hfi_destroy;
+ 
+ 	platform_set_drvdata(pdev, core);
+ 
+@@ -476,24 +476,24 @@ static int venus_probe(struct platform_device *pdev)
+ 
+ 	ret = venus_enumerate_codecs(core, VIDC_SESSION_TYPE_DEC);
+ 	if (ret)
+-		goto err_venus_shutdown;
++		goto err_core_deinit;
+ 
+ 	ret = venus_enumerate_codecs(core, VIDC_SESSION_TYPE_ENC);
+ 	if (ret)
+-		goto err_venus_shutdown;
++		goto err_core_deinit;
+ 
+ 	ret = pm_runtime_put_sync(dev);
+ 	if (ret) {
+ 		pm_runtime_get_noresume(dev);
+-		goto err_dev_unregister;
++		goto err_core_deinit;
+ 	}
+ 
+ 	venus_dbgfs_init(core);
+ 
+ 	return 0;
+ 
+-err_dev_unregister:
+-	v4l2_device_unregister(&core->v4l2_dev);
++err_core_deinit:
++	hfi_core_deinit(core, false);
+ err_venus_shutdown:
+ 	venus_shutdown(core);
+ err_firmware_deinit:
+@@ -506,9 +506,9 @@ static int venus_probe(struct platform_device *pdev)
+ 	pm_runtime_put_noidle(dev);
+ 	pm_runtime_disable(dev);
+ 	pm_runtime_set_suspended(dev);
++	v4l2_device_unregister(&core->v4l2_dev);
++err_hfi_destroy:
+ 	hfi_destroy(core);
+-err_core_deinit:
+-	hfi_core_deinit(core, false);
+ err_core_put:
+ 	if (core->pm_ops->core_put)
+ 		core->pm_ops->core_put(core);
+-- 
+2.49.0
+

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-hfi-explicitly-release-IRQ-during-teardo.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-hfi-explicitly-release-IRQ-during-teardo.patch
@@ -1,0 +1,33 @@
+From 88872ed483b2d0578623320d99e78e7c360f1d8e Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Date: Thu, 12 Jun 2025 10:29:43 +0200
+Subject: [PATCH] media: venus: hfi: explicitly release IRQ during teardown
+
+Ensure the IRQ is released before dismantling the ISR handler and
+clearing related pointers.
+
+This prevents any possibility of the interrupt triggering after the
+handler context has been invalidated.
+
+Fixes: d96d3f30c0f2 ("[media] media: venus: hfi: add Venus HFI files")
+Signed-off-by: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/linux-media/20250612082943.2753676-1-jorge.ramirez@oss.qualcomm.com/]
+---
+ drivers/media/platform/qcom/venus/hfi_venus.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/platform/qcom/venus/hfi_venus.c b/drivers/media/platform/qcom/venus/hfi_venus.c
+index b5f2ea8799507f..d9d62d965bcf02 100644
+--- a/drivers/media/platform/qcom/venus/hfi_venus.c
++++ b/drivers/media/platform/qcom/venus/hfi_venus.c
+@@ -1678,6 +1678,7 @@ void venus_hfi_destroy(struct venus_core *core)
+ 	venus_interface_queues_release(hdev);
+ 	mutex_destroy(&hdev->lock);
+ 	kfree(hdev);
++	devm_free_irq(core->dev, core->irq, core);
+ 	core->ops = NULL;
+ }
+ 
+-- 
+2.49.0
+

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-protect-against-spurious-interrupts-duri.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-media-venus-protect-against-spurious-interrupts-duri.patch
@@ -1,0 +1,47 @@
+From 9c5677b7e2ccae47ba3b588556fe6099cff9223a Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Date: Fri, 6 Jun 2025 17:25:22 +0200
+Subject: [PATCH] media: venus: protect against spurious interrupts during
+ probe
+
+Make sure the interrupt handler is initialized before the interrupt is
+registered.
+
+If the IRQ is registered before hfi_create(), it's possible that an
+interrupt fires before the handler setup is complete, leading to a NULL
+dereference.
+
+This error condition has been observed during system boot on Rb3Gen2.
+
+Fixes: af2c3834c8ca ("[media] media: venus: adding core part and helper functions")
+Signed-off-by: Jorge Ramirez-Ortiz <jorge.ramirez@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/all/20250606152522.4123158-1-jorge.ramirez@oss.qualcomm.com/]
+---
+ drivers/media/platform/qcom/venus/core.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 77d48578ecd288..04641a7dcc9832 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -424,13 +424,13 @@ static int venus_probe(struct platform_device *pdev)
+ 	INIT_DELAYED_WORK(&core->work, venus_sys_error_handler);
+ 	init_waitqueue_head(&core->sys_err_done);
+ 
+-	ret = devm_request_threaded_irq(dev, core->irq, hfi_isr, venus_isr_thread,
+-					IRQF_TRIGGER_HIGH | IRQF_ONESHOT,
+-					"venus", core);
++	ret = hfi_create(core, &venus_core_ops);
+ 	if (ret)
+ 		goto err_core_put;
+ 
+-	ret = hfi_create(core, &venus_core_ops);
++	ret = devm_request_threaded_irq(dev, core->irq, hfi_isr, venus_isr_thread,
++					IRQF_TRIGGER_HIGH | IRQF_ONESHOT,
++					"venus", core);
+ 	if (ret)
+ 		goto err_core_put;
+ 
+-- 
+2.49.0
+


### PR DESCRIPTION
Backport and add fromlist patches required to fix venus probe crashes on rb3gen2, which happens quite often on boot and locks up the kernel completely on reboots.