### PR TITLE
workflow: stales: stop marking issues as stale automatically

### DIFF
--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -19,6 +19,7 @@ jobs:
         exempt-pr-labels: bug,enhancement
         days-before-stale: 30
         days-before-close: 5
+        days-before-issue-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
While it's a good idea to automatically mark PR as stale when inactive, we probably can live with inactive issues, or we can do a manual triage from time to time. An issue can still be marked as 'stalled' by adding the label manually, and will in turn be closed if no update is made until the 'close' idle delay is reached.