### PR TITLE
meta-qcom:partition: Add persist partition for security function

### DIFF
--- a/recipes-bsp/partition/files/qcm6490-partitions.conf
+++ b/recipes-bsp/partition/files/qcm6490-partitions.conf
@@ -21,7 +21,6 @@
 #This is LUN 0 - HLOS LUN
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=23099392KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
---partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 #This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
@@ -115,4 +114,5 @@
 --partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
 --partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
 --partition --lun=5 --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
+--partition --lun=5 --name=persist --size=51200KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 --partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/recipes-bsp/partition/files/qcm6490-partitions.conf
+++ b/recipes-bsp/partition/files/qcm6490-partitions.conf
@@ -21,6 +21,7 @@
 #This is LUN 0 - HLOS LUN
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=23099392KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 #This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf

--- a/recipes-bsp/partition/files/qcs8300-partitions.conf
+++ b/recipes-bsp/partition/files/qcs8300-partitions.conf
@@ -22,7 +22,6 @@
 # This is LUN 0 - HLOS LUN"
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
---partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
@@ -106,3 +105,8 @@
 --partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
 --partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 5 - Protected Read-write LUN
+#QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
+--partition --lun=5 --name=persist --size=51200KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/recipes-bsp/partition/files/qcs8300-partitions.conf
+++ b/recipes-bsp/partition/files/qcs8300-partitions.conf
@@ -22,6 +22,7 @@
 # This is LUN 0 - HLOS LUN"
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf

--- a/recipes-bsp/partition/files/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/files/qcs9100-partitions.conf
@@ -22,7 +22,6 @@
 # This is LUN 0 - HLOS LUN"
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=29390848KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
---partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
@@ -106,3 +105,8 @@
 --partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
 --partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 5 - Protected Read-write LUN
+#QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
+--partition --lun=5 --name=persist --size=51200KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/recipes-bsp/partition/files/qcs9100-partitions.conf
+++ b/recipes-bsp/partition/files/qcs9100-partitions.conf
@@ -22,6 +22,7 @@
 # This is LUN 0 - HLOS LUN"
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=rootfs --size=29390848KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --lun=0 --name=persist --size=32768KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 
 # This is LUN 1 - Boot LUN A
 --partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf


### PR DESCRIPTION
Add persist partition to save the encrypted files for the security function.