### PR TITLE
ci/base.yml+workflows: switch to 'poky-altcfg'

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -90,7 +90,7 @@ jobs:
           - qcom-armv8a
           - qcom-armv7a
     runs-on: [self-hosted, x86]
-    name: ${{ matrix.machine }}/poky/systemd
+    name: ${{ matrix.machine }}/poky-altcfg
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -3,7 +3,7 @@
 header:
   version: 14
 
-distro: poky
+distro: poky-altcfg
 
 defaults:
   repos:
@@ -30,8 +30,6 @@ repos:
 local_conf_header:
   base: |
     CONF_VERSION = "2"
-    INIT_MANAGER = "systemd"
-    PACKAGE_CLASSES = "package_ipk"
     INHERIT += "buildstats buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"


### PR DESCRIPTION
Testing meta-qcom* layers against upstream DISTROs is only useful if the CI doesn't fundamentally change the upstream policies and configuration. Since systemd is virtually indispensable for meta-qcom* machines, switch form `poky` to `poky-altcfg` and remove the initmanager changes from the KAS snippet.

This change will make CI result stop being misleading about how well an upstream DISTRO works with these layers.