### PR TITLE
qcom-common: drop GL / EGL / GL ES providers

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -16,11 +16,6 @@ XSERVER ?= " \
     xf86-input-evdev \
 "
 
-PREFERRED_PROVIDER_virtual/egl ?= "mesa"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
-PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-yocto"
 
 PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"


### PR DESCRIPTION
Stop setting DEFAULT_PROVIDER in the qcom-common.inc. The default-providers.inc already sets them correctly and overriding those values in this file conflicts with the GLVND being enabled.