### PR TITLE
linux: add qcom include file with common definitions

### DIFF
--- a/recipes-kernel/linux/linux-qcom-staging_6.14.bb
+++ b/recipes-kernel/linux/linux-qcom-staging_6.14.bb
@@ -5,6 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 inherit kernel
+require recipes-kernel/linux/linux-qcom.inc
 
 COMPATIBLE_MACHINE = "(qcom)"
 

--- a/recipes-kernel/linux/linux-qcom.inc
+++ b/recipes-kernel/linux/linux-qcom.inc
@@ -1,0 +1,9 @@
+# Kernel config
+KERNEL_CONFIG_NAME ?= "${KERNEL_PACKAGE_NAME}-config-${KERNEL_ARTIFACT_NAME}"
+KERNEL_CONFIG_LINK_NAME ?= "${KERNEL_PACKAGE_NAME}-config"
+
+do_deploy:append:qcom() {
+    # Publish final kernel config with a proper datetime-based link
+    cp -a ${B}/.config ${DEPLOYDIR}/${KERNEL_CONFIG_NAME}
+    ln -sf ${KERNEL_CONFIG_NAME} ${DEPLOYDIR}/${KERNEL_CONFIG_LINK_NAME}
+}

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -1,6 +1,8 @@
 # do not override KBRANCH and SRCREV_machine, use default ones.
 COMPATIBLE_MACHINE:qcom = "(qcom)"
 
+require recipes-kernel/linux/linux-qcom.inc
+
 FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom = " \

--- a/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -5,6 +5,8 @@ BASEVER = "${@ d.getVar('LINUX_VERSION').rpartition('.')[0]}"
 
 FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}-${BASEVER}:"
 
+require recipes-kernel/linux/linux-qcom.inc
+
 # include all Qualcomm-specific files
 SRC_URI:append:qcom = " \
     file://qcom.scc \


### PR DESCRIPTION
This include file was intendend to contains definitions shared by all qcom kernels.
Initially it will deploy the kernel .config to facilitate debugging of the configuration used.