### PR TITLE
ci: fix meta-qcom-distro builds

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -120,7 +120,7 @@ jobs:
           export KAS_WORK_DIR=$PWD/../kas
           mkdir $KAS_WORK_DIR
           ${KAS_CONTAINER} dump --resolve-env --resolve-local --resolve-refs \
-              ci/mirror.yml:ci/${{ matrix.machine }}.yml > kas-build.yml
+              ci/mirror.yml:ci/${{ matrix.machine }}.yml${{ matrix.distro.yamlfile }} > kas-build.yml
           ${KAS_CONTAINER} build ci/mirror.yml:ci/${{ matrix.machine }}.yml${{ matrix.distro.yamlfile }}
           ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
           mv $KAS_WORK_DIR/build/buildchart.svg .

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run kas lock
         run: |
-          ${KAS_CONTAINER} dump --update --lock --inplace ci/base.yml
+          ${KAS_CONTAINER} lock --update ci/base.yml
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run kas lock
         run: |
-          ${KAS_CONTAINER} lock --update ci/base.yml
+          ${KAS_CONTAINER} lock --update ci/base.yml:ci/distro.yml
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -100,7 +100,7 @@ jobs:
           - name: poky-altcfg
             yamlfile: ""
           - name: qcom
-            yamlfile: 'ci/distro.yml:'
+            yamlfile: ':ci/distro.yml'
     runs-on: [self-hosted, x86]
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}
     steps:
@@ -121,7 +121,7 @@ jobs:
           mkdir $KAS_WORK_DIR
           ${KAS_CONTAINER} dump --resolve-env --resolve-local --resolve-refs \
               ci/mirror.yml:ci/${{ matrix.machine }}.yml > kas-build.yml
-          ${KAS_CONTAINER} build ci/mirror.yml:${{ matrix.distro.yamlfile }}ci/${{ matrix.machine }}.yml
+          ${KAS_CONTAINER} build ci/mirror.yml:ci/${{ matrix.machine }}.yml${{ matrix.distro.yamlfile }}
           ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
           mv $KAS_WORK_DIR/build/buildchart.svg .
 

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -20,7 +20,7 @@ repos:
   bitbake:
     url: https://github.com/openembedded/bitbake
     layers:
-      .: excluded
+      .: disabled
 
   meta-yocto:
     url: https://git.yoctoproject.org/meta-yocto

--- a/ci/distro.yml
+++ b/ci/distro.yml
@@ -19,3 +19,6 @@ repos:
       meta-oe:
       meta-python:
       meta-xfce:
+
+target:
+  - qcom-multimedia-image


### PR DESCRIPTION
Fixes for meta-qcom-distro builds, including extended lockfile, updated kas-build.yml, correct include order of the kas yml fragment and set qcom-multimedia-image as default distro image.

First two changes are general kas clean up fixes (removing deprecated options).