### PR TITLE
linux-qcom-next: use 'nobranch=1' in SRC_URI to support retagged commits

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -15,7 +15,10 @@ PV = "${LINUX_VERSION}+git"
 # tag: qcom-next-6.16-rc3-20250701
 SRCREV ?= "54f158d766ac86c95e97a17c9e51db880d2d30dd"
 
-SRC_URI = "git://github.com/qualcomm-linux/kernel.git;branch=qcom-next;protocol=https"
+SRCBRANCH ?= "nobranch=1"
+SRCBRANCH:class-devupstream ?= "branch=qcom-next"
+
+SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
 
 # Additional kernel configs.
 SRC_URI += " \


### PR DESCRIPTION
To avoid fetcher issues caused by the retargeting of the `qcom-next` branch on every tag upmerge, use `nobranch=1` in `SRC_URI`. This allows BitBake to search for the specified `SRCREV` across the entire repository, including commits that are no longer associated with the current branch tip but are still preserved by tag.

The `branch` parameter should be used only in cases like `devupstream`, where a stable and consistent branch reference is expected.