### PR TITLE
WIP ci: Move to IT managed AWS self-hosted runners

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -8,14 +8,14 @@ on:
         value: ${{ jobs.create-output.outputs.url }}
 
 env:
-  CACHE_DIR: /srv/gh-runners/quic-yocto
-  KAS_REPO_REF_DIR: /srv/gh-runners/quic-yocto/kas-mirrors
-  KAS_CONTAINER: /srv/gh-runners/quic-yocto/kas-mirrors/kas-container
+  CACHE_DIR: /efs/qli/meta-qcom/
+  KAS_REPO_REF_DIR: /efs/qli/meta-qcom/kas-mirrors
+  KAS_CONTAINER: /efs/qli/meta-qcom/kas-mirrors/kas-container
 
 jobs:
   kas-setup:
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64-dev]
     steps:
       - name: Update kas-container
         run: |
@@ -46,7 +46,7 @@ jobs:
   yocto-check-layer:
     needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64-dev]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,7 +64,7 @@ jobs:
   yocto-patchreview:
     needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64-dev]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,7 +102,7 @@ jobs:
             yamlfile: ""
           - name: qcom
             yamlfile: ':ci/distro.yml'
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64-dev]
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}
     steps:
       - uses: actions/checkout@v4
@@ -162,7 +162,7 @@ jobs:
     needs: compile
     outputs:
       url: ${{ steps.print-output.outputs.url }}
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64-dev]
     steps:
       - name: "Print output"
         id: print-output


### PR DESCRIPTION
These runners should be equivalent to the currently used in GCP.

IT provides two types of runners that are just like what is been used in in GCP:
During UAT, the label will be named with "*-dev"

 * `runs-on: [self-hosted, qcom-u2404, amd64-dev]`
 * `runs-on: [self-hosted, qcom-u2404, arm64-dev]`