### PR TITLE
enable graphicsdlkm module only for linux-yocto-dev

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -25,5 +25,5 @@ RDEPENDS:${PN}-miscellaneous = " \
     ${@bb.utils.contains("BBLAYERS", "openembedded-layer", "libssc","", d)} \
     libvmmem-dev \
     libdmabufheap-dev \
-    graphicsdlkm \
+    ${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-yocto-dev", "graphicsdlkm", "", d)} \
 "


### PR DESCRIPTION
The graphicsdlkm kernel module can only be compiled with the linux-yocto-dev kernel. To avoid build failures when using other kernel providers, enable this module conditionally based on the current kernel provider.