### PR TITLE
audio: Add QCM6490 topology file and include it in packagegroup-qcom

### DIFF
--- a/recipes-support/audio/alsa-ucm-conf/0001-ucm2-Qualcomm-Update-the-QCM6490-and-QCS6490-hifi-co.patch
+++ b/recipes-support/audio/alsa-ucm-conf/0001-ucm2-Qualcomm-Update-the-QCM6490-and-QCS6490-hifi-co.patch
@@ -1,0 +1,44 @@
+From e7ec0f1ac3eebfa04e18a944d511bbb5fa57239d Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Tue, 10 Jun 2025 16:46:59 +0530
+Subject: [PATCH 1/2] ucm2: Qualcomm: Update the QCM6490 and QCS6490 hifi conf
+ files
+
+Rename the HiFi conf files for QCM6490-IDP and QCS6490-RB3Gen2 boards
+to match with soundcard name.
+
+Closes: https://github.com/alsa-project/alsa-ucm-conf/pull/577
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+
+Upstream-Status: Backport [https://github.com/alsa-project/alsa-ucm-conf/commit/e7ec0f1ac3eebfa04e18a944d511bbb5fa57239d]
+---
+ .../QCM6490-IDP/{QCM6490-IDP.conf => qcm6490-idp-snd-card.conf}   | 0
+ .../{QCS6490-RB3Gen2.conf => qcs6490-rb3gen2-snd-card.conf}       | 0
+ .../qcm6490/{QCM6490-IDP.conf => qcm6490-idp-snd-card.conf}       | 0
+ .../{QCS6490-RB3Gen2.conf => qcs6490-rb3gen2-snd-card.conf}       | 0
+ 4 files changed, 0 insertions(+), 0 deletions(-)
+ rename ucm2/Qualcomm/qcm6490/QCM6490-IDP/{QCM6490-IDP.conf => qcm6490-idp-snd-card.conf} (100%)
+ rename ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/{QCS6490-RB3Gen2.conf => qcs6490-rb3gen2-snd-card.conf} (100%)
+ rename ucm2/conf.d/qcm6490/{QCM6490-IDP.conf => qcm6490-idp-snd-card.conf} (100%)
+ rename ucm2/conf.d/qcs6490/{QCS6490-RB3Gen2.conf => qcs6490-rb3gen2-snd-card.conf} (100%)
+
+diff --git a/ucm2/Qualcomm/qcm6490/QCM6490-IDP/QCM6490-IDP.conf b/ucm2/Qualcomm/qcm6490/QCM6490-IDP/qcm6490-idp-snd-card.conf
+similarity index 100%
+rename from ucm2/Qualcomm/qcm6490/QCM6490-IDP/QCM6490-IDP.conf
+rename to ucm2/Qualcomm/qcm6490/QCM6490-IDP/qcm6490-idp-snd-card.conf
+diff --git a/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/QCS6490-RB3Gen2.conf b/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/qcs6490-rb3gen2-snd-card.conf
+similarity index 100%
+rename from ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/QCS6490-RB3Gen2.conf
+rename to ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/qcs6490-rb3gen2-snd-card.conf
+diff --git a/ucm2/conf.d/qcm6490/QCM6490-IDP.conf b/ucm2/conf.d/qcm6490/qcm6490-idp-snd-card.conf
+similarity index 100%
+rename from ucm2/conf.d/qcm6490/QCM6490-IDP.conf
+rename to ucm2/conf.d/qcm6490/qcm6490-idp-snd-card.conf
+diff --git a/ucm2/conf.d/qcs6490/QCS6490-RB3Gen2.conf b/ucm2/conf.d/qcs6490/qcs6490-rb3gen2-snd-card.conf
+similarity index 100%
+rename from ucm2/conf.d/qcs6490/QCS6490-RB3Gen2.conf
+rename to ucm2/conf.d/qcs6490/qcs6490-rb3gen2-snd-card.conf
+-- 
+2.34.1
+

--- a/recipes-support/audio/alsa-ucm-conf/0002-ucm2-Qualcomm-Update-the-HIFI-enable-mixer-commands-.patch
+++ b/recipes-support/audio/alsa-ucm-conf/0002-ucm2-Qualcomm-Update-the-HIFI-enable-mixer-commands-.patch
@@ -1,0 +1,53 @@
+From a98b12220989e2187a47b0e06ac9145c92232a8e Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Wed, 18 Jun 2025 16:46:18 +0530
+Subject: [PATCH 2/2] ucm2: Qualcomm: Update the HIFI enable mixer commands for
+ qcm6490-idp and qcs6490-rb3gen2
+
+Closes: https://github.com/alsa-project/alsa-ucm-conf/pull/577
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+
+Upstream-Status: Backport [https://github.com/alsa-project/alsa-ucm-conf/commit/a98b12220989e2187a47b0e06ac9145c92232a8e]
+---
+ ucm2/Qualcomm/qcm6490/QCM6490-IDP/HiFi.conf     | 8 ++++----
+ ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/HiFi.conf | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/ucm2/Qualcomm/qcm6490/QCM6490-IDP/HiFi.conf b/ucm2/Qualcomm/qcm6490/QCM6490-IDP/HiFi.conf
+index 0d6497e..0a0d331 100644
+--- a/ucm2/Qualcomm/qcm6490/QCM6490-IDP/HiFi.conf
++++ b/ucm2/Qualcomm/qcm6490/QCM6490-IDP/HiFi.conf
+@@ -3,10 +3,10 @@ SectionVerb {
+ 		TQ "HiFi"
+ 	}
+ 	EnableSequence [
+-		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MULTIMEDIA0' 1"
+-		cset "name='MULTIMEDIA1 Audio Mixer VA_CODEC_DMA_TX_0' 1"
+-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MULTIMEDIA2' 1"
+-		cset "name='MULTIMEDIA3 Audio Mixer TX_CODEC_DMA_TX_3' 1"
++		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
++		cset "name='MultiMedia2 Mixer VA_CODEC_DMA_TX_0' 1"
++		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia3' 1"
++		cset "name='MultiMedia4 Mixer TX_CODEC_DMA_TX_3' 1"
+ 	]
+ 
+ 	Include.wsae.File "/codecs/wsa883x/DefaultEnableSeq.conf"
+diff --git a/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/HiFi.conf b/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/HiFi.conf
+index 954dbfa..2488523 100644
+--- a/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/HiFi.conf
++++ b/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/HiFi.conf
+@@ -3,8 +3,8 @@ SectionVerb {
+ 		TQ "HiFi"
+ 	}
+ 	EnableSequence [
+-		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MULTIMEDIA0' 1"
+-		cset "name='MULTIMEDIA1 Audio Mixer VA_CODEC_DMA_TX_0' 1"
++		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
++		cset "name='MultiMedia2 Mixer VA_CODEC_DMA_TX_0' 1"
+ 	]
+ 
+ 	Include.wsae.File "/codecs/wsa883x/DefaultEnableSeq.conf"
+-- 
+2.34.1
+

--- a/recipes-support/audio/alsa-ucm-conf_%.bbappend
+++ b/recipes-support/audio/alsa-ucm-conf_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-ucm2-Qualcomm-Update-the-QCM6490-and-QCS6490-hifi-co.patch \
+            file://0002-ucm2-Qualcomm-Update-the-HIFI-enable-mixer-commands-.patch \
+           "


### PR DESCRIPTION
Added the audio topology file for QCM6490 to support ASOC firmware loading. Integrated the topology file into the packagegroup-qcom package for deployment.