### PR TITLE
initramfs-test-full-image: add openssh-sftp-server

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -13,6 +13,7 @@ PACKAGE_INSTALL += " \
     ncurses-terminfo \
     ncurses-terminfo-base \
     net-tools \
+    openssh-sftp-server \
     rng-tools \
     stress-ng \
     util-linux \


### PR DESCRIPTION
scp switched to using the SFTP protocol by default from openssh 9.0 version.  So in order for scp to work we will need sftp-server on the target.

This will fix [issue](https://github.com/qualcomm-linux/meta-qcom/issues/959)