### PR TITLE
enable kernel debug features by default in CI

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -33,6 +33,8 @@ local_conf_header:
     INHERIT += "buildstats buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+  cmdline: |
+    KERNEL_CMDLINE_EXTRA:append = " page_owner=on qcom_scm.download_mode=1"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
CI images are primarily used for testing, and enabling ramdump collection, page owner tracking is helpful for debugging kernel oops issues. Update the kernel command line via `local.conf` to include the necessary options to support these features.