### PR TITLE
ci/qcom-distro.yml: enable meta-virtualization and its dependencies

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -13,12 +13,21 @@ repos:
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
     layers:
+      meta-filesystems:
       meta-gnome:
       meta-multimedia: 
       meta-networking:
       meta-oe:
       meta-python:
       meta-xfce:
+
+  meta-virtualization:
+    url: https://git.yoctoproject.org/git/meta-virtualization
+    branch: master
+
+local_conf_header:
+  virtualization:
+    SKIP_META_VIRT_SANITY_CHECK = "1"
 
 target:
   - qcom-multimedia-image


### PR DESCRIPTION
This enables recipes like `docker-moby` and `podman`.

Related to https://github.com/qualcomm-linux/meta-qcom-distro/issues/53