### PR TITLE
alsa-ucm-conf: Add QCS9075 HiFi config and rename QCS6490 UCM files

### DIFF
--- a/recipes-support/audio/alsa-ucm-conf/0001-Qualcomm-Add-QCS9075-IQ-EVK-HiFi-config.patch
+++ b/recipes-support/audio/alsa-ucm-conf/0001-Qualcomm-Add-QCS9075-IQ-EVK-HiFi-config.patch
@@ -1,0 +1,85 @@
+From bd5cf3839f902b67a355669fdf1bd3231e0cb4c1 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Mon, 9 Jun 2025 20:52:42 +0530
+Subject: [PATCH] Qualcomm: Add QCS9075-IQ-EVK HiFi config
+
+Add UCM2 configs for the Qualcomm QCS9075-IQ-EVK Board to handle:
+	- I2S Speaker Amplifier
+	- I2S Mic
+
+Closes: https://github.com/alsa-project/alsa-ucm-conf/pull/576
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+
+Upstream-Status: Backport [https://github.com/alsa-project/alsa-ucm-conf/commit/bd5cf3839f902b67a355669fdf1bd3231e0cb4c1]
+---
+ .../qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf | 29 +++++++++++++++++++
+ .../qcs9075-iq-evk-snd-card.conf              |  6 ++++
+ .../qcs9075/qcs9075-iq-evk-snd-card.conf      |  6 ++++
+ 3 files changed, 41 insertions(+)
+ create mode 100644 ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
+ create mode 100644 ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
+ create mode 100644 ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
+
+diff --git a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
+new file mode 100644
+index 0000000..6673324
+--- /dev/null
++++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
+@@ -0,0 +1,29 @@
++SectionVerb {
++	Value {
++		TQ "HiFi"
++	}
++	EnableSequence [
++		cset "name='PRIMARY_SDR_MI2S_RX Audio Mixer MULTIMEDIA0' 1"
++		cset "name='MULTIMEDIA1 Audio Mixer TERTIARY_SDR_MI2S_TX' 1"
++	]
++}
++
++SectionDevice."Speaker" {
++	Comment "Speaker playback"
++
++	Value {
++		PlaybackPriority 100
++		PlaybackPCM "hw:${CardId},0"
++		PlaybackMixer "default:${CardId}"
++		PlaybackMixerElem "Speakers"
++	}
++}
++
++SectionDevice."Mic" {
++	Comment "Mic"
++
++	Value {
++		CapturePriority 100
++		CapturePCM "hw:${CardId},1"
++	}
++}
+diff --git a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
+new file mode 100644
+index 0000000..669ba6b
+--- /dev/null
++++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
+@@ -0,0 +1,6 @@
++Syntax 4
++
++SectionUseCase."HiFi" {
++	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
++	Comment "HiFi quality Music"
++}
+diff --git a/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf b/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
+new file mode 100644
+index 0000000..1e49d38
+--- /dev/null
++++ b/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
+@@ -0,0 +1,6 @@
++Syntax 4
++
++SectionUseCase."HiFi" {
++	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
++	Comment "HiFi quality Music."
++}
+-- 
+2.34.1
+

--- a/recipes-support/audio/alsa-ucm-conf/0001-ucm2-Qualcomm-Rename-qcs6490-rb3gen2-and-qcs9075-iq-.patch
+++ b/recipes-support/audio/alsa-ucm-conf/0001-ucm2-Qualcomm-Rename-qcs6490-rb3gen2-and-qcs9075-iq-.patch
@@ -1,0 +1,88 @@
+From 78fca8273bcaa6785cdce2dab8c36b9294afbe66 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Sun, 20 Jul 2025 21:28:44 +0530
+Subject: [PATCH] FROMLIST: ucm2: Qualcomm: Rename qcs6490-rb3gen2 and
+ qcs9075-iq-evk ucm2 conf
+
+Rename the ucm2 conf for Qualcomm qcs6490-rb3gen2 and qcs9075-iq-evk.
+
+qcs6490-rb3gen2-snd-card.conf -> QCS6490-RB3Gen2.conf
+qcs9075-iq-evk-snd-card.conf -> QCS9075-IQ-EVK.conf
+
+Removed snd-card tags from conf files and update the
+mixer settings for QCS9075-IQ-EVK.
+
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Upstream-Status: Submitted [https://github.com/alsa-project/alsa-ucm-conf/pull/596]
+---
+ .../{qcs6490-rb3gen2-snd-card.conf => QCS6490-RB3Gen2.conf}   | 0
+ .../{qcs9075-iq-evk-snd-card => qcs9075-iq-evk}/HiFi.conf     | 4 ++--
+ .../QCS9075-IQ-EVK.conf}                                      | 2 +-
+ .../{qcs6490-rb3gen2-snd-card.conf => QCS6490-RB3Gen2.conf}   | 0
+ .../{qcs9075-iq-evk-snd-card.conf => QCS9075-IQ-EVK.conf}     | 2 +-
+ 5 files changed, 4 insertions(+), 4 deletions(-)
+ rename ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/{qcs6490-rb3gen2-snd-card.conf => QCS6490-RB3Gen2.conf} (100%)
+ rename ucm2/Qualcomm/qcs9075/{qcs9075-iq-evk-snd-card => qcs9075-iq-evk}/HiFi.conf (74%)
+ rename ucm2/Qualcomm/qcs9075/{qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf => qcs9075-iq-evk/QCS9075-IQ-EVK.conf} (52%)
+ rename ucm2/conf.d/qcs6490/{qcs6490-rb3gen2-snd-card.conf => QCS6490-RB3Gen2.conf} (100%)
+ rename ucm2/conf.d/qcs9075/{qcs9075-iq-evk-snd-card.conf => QCS9075-IQ-EVK.conf} (52%)
+
+diff --git a/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/qcs6490-rb3gen2-snd-card.conf b/ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/QCS6490-RB3Gen2.conf
+similarity index 100%
+rename from ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/qcs6490-rb3gen2-snd-card.conf
+rename to ucm2/Qualcomm/qcs6490/QCS6490-RB3Gen2/QCS6490-RB3Gen2.conf
+diff --git a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/HiFi.conf
+similarity index 74%
+rename from ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
+rename to ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/HiFi.conf
+index 6673324..f2be928 100644
+--- a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
++++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/HiFi.conf
+@@ -3,8 +3,8 @@ SectionVerb {
+ 		TQ "HiFi"
+ 	}
+ 	EnableSequence [
+-		cset "name='PRIMARY_SDR_MI2S_RX Audio Mixer MULTIMEDIA0' 1"
+-		cset "name='MULTIMEDIA1 Audio Mixer TERTIARY_SDR_MI2S_TX' 1"
++		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 1"
++		cset "name='MultiMedia2 Mixer TERTIARY_MI2S_TX' 1"
+ 	]
+ }
+ 
+diff --git a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/QCS9075-IQ-EVK.conf
+similarity index 52%
+rename from ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
+rename to ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/QCS9075-IQ-EVK.conf
+index 669ba6b..a45bc27 100644
+--- a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
++++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk/QCS9075-IQ-EVK.conf
+@@ -1,6 +1,6 @@
+ Syntax 4
+ 
+ SectionUseCase."HiFi" {
+-	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
++	File "/Qualcomm/qcs9075/qcs9075-iq-evk/HiFi.conf"
+ 	Comment "HiFi quality Music"
+ }
+diff --git a/ucm2/conf.d/qcs6490/qcs6490-rb3gen2-snd-card.conf b/ucm2/conf.d/qcs6490/QCS6490-RB3Gen2.conf
+similarity index 100%
+rename from ucm2/conf.d/qcs6490/qcs6490-rb3gen2-snd-card.conf
+rename to ucm2/conf.d/qcs6490/QCS6490-RB3Gen2.conf
+diff --git a/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf b/ucm2/conf.d/qcs9075/QCS9075-IQ-EVK.conf
+similarity index 52%
+rename from ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
+rename to ucm2/conf.d/qcs9075/QCS9075-IQ-EVK.conf
+index 1e49d38..42d4a64 100644
+--- a/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
++++ b/ucm2/conf.d/qcs9075/QCS9075-IQ-EVK.conf
+@@ -1,6 +1,6 @@
+ Syntax 4
+ 
+ SectionUseCase."HiFi" {
+-	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
++	File "/Qualcomm/qcs9075/qcs9075-iq-evk/HiFi.conf"
+ 	Comment "HiFi quality Music."
+ }
+-- 
+2.34.1
+

--- a/recipes-support/audio/alsa-ucm-conf_%.bbappend
+++ b/recipes-support/audio/alsa-ucm-conf_%.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom = " \
+    file://0001-Qualcomm-Add-QCS9075-IQ-EVK-HiFi-config.patch \
     file://0001-ucm2-Qualcomm-Update-the-QCM6490-and-QCS6490-hifi-co.patch \
     file://0002-ucm2-Qualcomm-Update-the-HIFI-enable-mixer-commands-.patch \
+    file://0001-ucm2-Qualcomm-Rename-qcs6490-rb3gen2-and-qcs9075-iq-.patch \
 "


### PR DESCRIPTION
Added patch to support QCS9075 IQ EVK HiFi UCM configuration, renamed UCM files for QCS6490 RB3Gen2 and QCS9075 IQ EVK for consistency