### PR TITLE
ci: reduce the amount of files published for each build

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -160,11 +160,10 @@ jobs:
           # expects file to be relative to our PWD. deploy_dir is outside
           # that, so we move things around:
           deploy_dir=../kas/build/tmp/deploy/images/${{matrix.machine}}
-          uploads_dir=./uploads/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
+          uploads_dir=./uploads/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}/${{ matrix.machine }}
           mkdir -p $uploads_dir
-          find $deploy_dir/ -maxdepth 1 -name "*.rootfs*.qcomflash" -exec rm -rf {} \;
-          cp buildchart.svg kas-build.yml $deploy_dir/
-          mv $deploy_dir $uploads_dir/
+          find $deploy_dir/ -maxdepth 1 -type f -exec cp {} $uploads_dir/ \;
+          cp buildchart.svg kas-build.yml $uploads_dir/
 
       - name: Upload private artifacts
         uses: qualcomm-linux/upload-private-artifact-action@v1


### PR DESCRIPTION
Each build exports close to 590 files, because it was initially decided to 'blindly' publish the deploy_dir folder which is bitbake output directory.

In a typical build, there are 25 symlinks which end up being duplicate files on the file server (1.3GB per platform). The symlinks are convenient/shortened filenames, and don't need to be published.

deploy_dir also contains 'partitions' folder which is an intermediate artifact used to generate the image GPT files, with 490 files.

To clean up the published files, and to avoid growing it by mistake in the future, this commit switches the logic. Instead of publishing the entire deploy_dir folder (with minimal cleanup), the CI job now only publishes real files (no symlinks) located in the root of deploy_dir. Any additional files needed (later) can be manually added.

For a local RB3G2 build, it's 26 files, for 900MB.