### PR TITLE
packagegroup-qcs615-adp-air: packagegroups for QCS615-ADP-Air

### DIFF
--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -12,5 +12,9 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qcs615-ride.dtb \
                       "
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcs615-adp-air-firmware \
+"
+
 QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs615-adp-air"

--- a/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Packages for the QCS615-ADP-Air platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcs615-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
+    linux-firmware-qcom-venus-5.4 \
+"


### PR DESCRIPTION
Add firmware packagegroups for the QCS615-ADP-Air board.