### PR TITLE
mesa: add 25.2.0-rc2 version of the recipe

### DIFF
--- a/recipes-graphics/mesa/mesa-git/0001-freedreno-don-t-encode-build-path-into-binaries.patch
+++ b/recipes-graphics/mesa/mesa-git/0001-freedreno-don-t-encode-build-path-into-binaries.patch
@@ -1,0 +1,110 @@
+From 027ac36756cc75eea9ed4fee135a351af30b35fd Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Tue, 16 Jul 2024 12:32:47 +0300
+Subject: [PATCH] freedreno: don't encode build path into binaries
+
+Encoding build-specific path into installed binaries is generally
+frowned upon. It harms the reproducibility of the build and e.g.
+OpenEmbedded now considers that to be an error.
+
+Instead of hardcoding rnn_src_path into the RNN_DEF_PATH define specify
+it manually when running the tests.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30206]
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ src/freedreno/afuc/meson.build   | 4 ++++
+ src/freedreno/decode/meson.build | 4 +++-
+ src/freedreno/meson.build        | 2 +-
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/freedreno/afuc/meson.build b/src/freedreno/afuc/meson.build
+index bb7cebf5a748..351cc31ef2de 100644
+--- a/src/freedreno/afuc/meson.build
++++ b/src/freedreno/afuc/meson.build
+@@ -56,10 +56,12 @@ if with_tests
+   asm_fw = custom_target('afuc_test.fw',
+     output: 'afuc_test.fw',
+     command: [asm, files('../tests/traces/afuc_test.asm'), '@OUTPUT@'],
++    env: {'RNN_PATH': rnn_src_path},
+   )
+   asm_fw_a7xx = custom_target('afuc_test_a7xx.fw',
+     output: 'afuc_test_a7xx.fw',
+     command: [asm, files('../tests/traces/afuc_test_a7xx.asm'), '@OUTPUT@'],
++    env: {'RNN_PATH': rnn_src_path},
+   )
+   test('afuc-asm',
+     diff,
+@@ -120,11 +122,13 @@ if cc.sizeof('size_t') > 4
+     disasm_fw = custom_target('afuc_test.asm',
+       output: 'afuc_test.asm',
+       command: [disasm, '-u', files('../tests/reference/afuc_test.fw')],
++      env: {'RNN_PATH': rnn_src_path},
+       capture: true
+     )
+     disasm_fw_a7xx = custom_target('afuc_test_a7xx.asm',
+       output: 'afuc_test_a7xx.asm',
+       command: [disasm, '-u', files('../tests/reference/afuc_test_a7xx.fw')],
++      env: {'RNN_PATH': rnn_src_path},
+       capture: true
+     )
+     test('afuc-disasm',
+diff --git a/src/freedreno/decode/meson.build b/src/freedreno/decode/meson.build
+index 469eeb4eb597..dfa1c12d0d9f 100644
+--- a/src/freedreno/decode/meson.build
++++ b/src/freedreno/decode/meson.build
+@@ -194,6 +194,7 @@ if dep_lua.found() and dep_libarchive.found()
+       log = custom_target(name + '.log',
+         output: name + '.log',
+         command: [cffdump, '--unit-test', args, files('../tests/traces/' + name + '.rd.gz')],
++        env: {'RNN_PATH': rnn_src_path},
+         capture: true,
+       )
+       test('cffdump-' + name,
+@@ -247,7 +248,8 @@ if with_tests
+       output: name + '.log',
+       command: [crashdec, args, files('../tests/traces/' + name + '.devcore')],
+       capture: true,
+-      env: {'GALLIUM_DUMP_CPU': 'false'},
++      env: {'GALLIUM_DUMP_CPU': 'false',
++            'RNN_PATH': rnn_src_path},
+     )
+ 
+     test('crashdec-' + name,
+diff --git a/src/freedreno/meson.build b/src/freedreno/meson.build
+index 98e49b8fcf0e..145e72597eb9 100644
+--- a/src/freedreno/meson.build
++++ b/src/freedreno/meson.build
+@@ -6,7 +6,7 @@ inc_freedreno_rnn = include_directories('rnn')
+ 
+ rnn_src_path = dir_source_root + '/src/freedreno/registers'
+ rnn_install_path = get_option('datadir') + '/freedreno/registers'
+-rnn_path = rnn_src_path + ':' + get_option('prefix') + '/' + rnn_install_path
++rnn_path = get_option('prefix') + '/' + rnn_install_path
+ 
+ dep_libarchive = dependency('libarchive', allow_fallback: true, required: false)
+ dep_libxml2 = dependency('libxml-2.0', allow_fallback: true, required: false)
+diff --git a/src/freedreno/registers/gen_header.py b/src/freedreno/registers/gen_header.py
+--- a/src/freedreno/registers/gen_header.py
++++ b/src/freedreno/registers/gen_header.py
+@@ -885,13 +885,14 @@ The rules-ng-ng source files this header
+ """)
+ 	maxlen = 0
+ 	for filepath in p.xml_files:
+-		maxlen = max(maxlen, len(filepath))
++		maxlen = max(maxlen, len(os.path.basename(filepath)))
+ 	for filepath in p.xml_files:
+-		pad = " " * (maxlen - len(filepath))
++		filename = os.path.basename(filepath)
++		pad = " " * (maxlen - len(filename))
+ 		filesize = str(os.path.getsize(filepath))
+ 		filesize = " " * (7 - len(filesize)) + filesize
+ 		filetime = time.ctime(os.path.getmtime(filepath))
+-		print("- " + filepath + pad + " (" + filesize + " bytes, from " + filetime + ")")
++		print("- " + filename + pad + " (" + filesize + " bytes, from " + filetime + ")")
+ 	if p.copyright_year:
+ 		current_year = str(datetime.date.today().year)
+ 		print()
+---
+2.39.2
+

--- a/recipes-graphics/mesa/mesa-git/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
+++ b/recipes-graphics/mesa/mesa-git/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
@@ -1,0 +1,24 @@
+From 02cc21800fe29f566add525e63f619c0536d6e7b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Jan 2020 15:23:47 -0800
+Subject: [PATCH] meson misdetects 64bit atomics on mips/clang
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/util/u_atomic.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/util/u_atomic.c b/src/util/u_atomic.c
+index 5a5eab4..e499516 100644
+--- a/src/util/u_atomic.c
++++ b/src/util/u_atomic.c
+@@ -21,7 +21,7 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-#if defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
++#if !defined(__clang__) && defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
+ 
+ #include <stdint.h>
+ #include <pthread.h>

--- a/recipes-graphics/mesa/mesa_25.2.0-rc2.bb
+++ b/recipes-graphics/mesa/mesa_25.2.0-rc2.bb
@@ -1,0 +1,26 @@
+require recipes-graphics/mesa/mesa.inc
+
+SRC_URI = " \
+    git://gitlab.freedesktop.org/mesa/mesa;branch=25.2;protocol=https \
+    file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+    file://0001-freedreno-don-t-encode-build-path-into-binaries.patch \
+"
+SRCREV ?= "85abdb86d377c0e14a9bf73e8023c1845caf98e9"
+PV = "25.1+25.2.0-rc2"
+
+PACKAGECONFIG[opencl] = " \
+    -Dgallium-rusticl=true, \
+    -Dgallium-rusticl=false, \
+    bindgen-cli-native \
+"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/mesa-git:"
+
+# Enable freedreno driver
+PACKAGECONFIG_FREEDRENO = "\
+    freedreno \
+    tools \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'freedreno-fdperf', '', d)} \
+"
+
+PACKAGECONFIG:append:qcom = " ${PACKAGECONFIG_FREEDRENO}"


### PR DESCRIPTION
In order to be able to test upcoming features of the 25.2 branch, which includes A702 support, OpenCL improvements and RGB888 support, add recipe for RC version of the Mesa library. It will be dropped as soon as OE-core switches to the 25.2.0 (probably soon after the release)