### PR TITLE
Add LAVA template for qcs8300-ride-sx machine

### DIFF
--- a/ci/lava/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcs8300-ride-sx/boot.yaml
@@ -1,0 +1,63 @@
+actions:
+- deploy:
+    images:
+      image:
+        headers:
+          Authentication: Q_GITHUB_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+    postprocess:
+      docker:
+        image: ghcr.io/foundriesio/lava-lmp-sign:main
+        steps:
+        - export IMAGE_PATH=$PWD
+        - cp overlay*.tar.gz overlay.tar.gz
+        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=qcs8300 >> $IMAGE_PATH/flash.settings
+        - cat $IMAGE_PATH/flash.settings
+    timeout:
+      minutes: 5
+    to: downloads
+- deploy:
+    images:
+      image:
+        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+      settings:
+        url: downloads://flash.settings
+      overlay:
+        url: downloads://overlay.tar.gz
+    timeout:
+      minutes: 5
+    to: flasher
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: root
+    method: minimal
+    prompts:
+    - root@{{DEVICE_TYPE}}
+    timeout:
+      minutes: 3
+- test:
+    definitions:
+    - from: git
+      name: "{{DEVICE_TYPE}}-smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a, dmesg"
+- command:
+    name: network_turn_on
+context:
+  lava_test_results_dir: /home/lava-%s
+  test_character_delay: 10
+device_type: {{DEVICE_TYPE}}
+job_name: boot test ({{DEVICE_TYPE}}) {{GITHUB_RUN_ID}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+timeouts:
+  job:
+    minutes: 15
+visibility: public


### PR DESCRIPTION
This is a clone of the template for qcs9100-ride-sx with the
device-type changed as the LAVA deployment method is the same.
I have tested with a manual job
https://lava.infra.foundries.io/scheduler/job/86608