### PR TITLE
ci: include symlink for files used by LAVA tests

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -163,6 +163,7 @@ jobs:
           uploads_dir=./uploads/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}/${{ matrix.machine }}
           mkdir -p $uploads_dir
           find $deploy_dir/ -maxdepth 1 -type f -exec cp {} $uploads_dir/ \;
+          find $deploy_dir/ -maxdepth 1 -type l -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz -exec cp -d {} $uploads_dir/ \;
           cp buildchart.svg kas-build.yml $uploads_dir/
 
       - name: Upload private artifacts


### PR DESCRIPTION
In 918119a8a546 (ci: reduce the amount of files published for each build), we reduced the amount of files published by the job. However some of the files removed are actually used by LAVA job template (see ci/lava/*/boot.yaml).

Bitbake typically artifacts with full, unique name that includes a timestamp, such as
core-image-base-qcs6490-rb3gen2-core-kit.rootfs-20250728160211.qcomflash.tar.gz, and it also creates a convenient, shorter symlink, such as core-image-base-qcs6490-rb3gen2-core-kit.rootfs.qcomflash.tar.gz.

LAVA uses the shorter link, because at this stage of the pipeline the timestamp is not known. When we removed the symlink, it broke the LAVA tests. The right thing to do is most likely to export the timestamp from the build job, and use the full name with the timestamp in the LAVA test template. In order to unblock the CI, this patch implements a workaround and we keep the symlinks for all artifacts used by LAVA jobs.