### PR TITLE
ci: fix two issues breaking testing on dragonboard boards

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -163,7 +163,7 @@ jobs:
           uploads_dir=./uploads/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}/${{ matrix.machine }}
           mkdir -p $uploads_dir
           find $deploy_dir/ -maxdepth 1 -type f -exec cp {} $uploads_dir/ \;
-          find $deploy_dir/ -maxdepth 1 -type l -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz -exec cp -d {} $uploads_dir/ \;
+          find $deploy_dir/ -maxdepth 1 -type l \( -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz \) -exec cp -d {} $uploads_dir/ \;
           cp buildchart.svg kas-build.yml $uploads_dir/
 
       - name: Upload private artifacts

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -141,7 +141,7 @@ jobs:
           mv $KAS_WORK_DIR/build/buildchart.svg .
 
           if [ "${{ matrix.machine }}" = "qcom-armv8a" ]; then
-            ${KAS_CONTAINER} build ci/mirror.yml:ci/${{ matrix.machine }}.yml${{ matrix.kernel.yamlfile }}:ci/initramfs-test.yml
+            ${KAS_CONTAINER} build ci/mirror.yml:ci/${{ matrix.machine }}.yml${{ matrix.distro.yamlfile }}${{ matrix.kernel.yamlfile }}:ci/initramfs-test.yml
           fi
 
       - uses: actions/upload-artifact@v4

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -36,10 +36,10 @@ QCOM_VFAT_SECTOR_SIZE ??= "4096"
 # Default serial console for QCOM devices
 SERIAL_CONSOLES ?= "115200;ttyMSM0"
 
-# Increase INITRAMFS_MAXSIZE to 384 MiB to cover initramfs-kerneltest-full
+# Increase INITRAMFS_MAXSIZE to 640 MiB to cover initramfs-kerneltest-full
 # image.  All our boards (except db410c) have 2GiB and db410c has 1GiB of RAM,
 # so this image would fit.
-INITRAMFS_MAXSIZE = "393216"
+INITRAMFS_MAXSIZE = "655360"
 
 # Use systemd-boot as the EFI bootloader
 EFI_PROVIDER = "systemd-boot"


### PR DESCRIPTION
Fix two issues with CI:
- don't remove built artifacts for qcom-armv8a builds
- copy all symlinks as expected