### PR TITLE
Deploy contents.xml to enable automatic image flashing in Axiom

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -7,6 +7,8 @@ IMAGE_TYPES += "qcomflash"
 
 QCOM_BOOT_FIRMWARE ?= ""
 
+QCOM_CONTENTS_XML ?= ""
+
 QCOM_ESP_IMAGE ?= "esp-qcom-image"
 QCOM_ESP_FILE ?= "${@'efi.bin' if d.getVar('QCOM_ESP_IMAGE') else ''}"
 
@@ -34,6 +36,7 @@ do_image_qcomflash[dirs] = "${QCOMFLASH_DIR}"
 do_image_qcomflash[cleandirs] = "${QCOMFLASH_DIR}"
 do_image_qcomflash[depends] += "${@ ['', '${QCOM_PARTITION_CONF}:do_deploy'][d.getVar('QCOM_PARTITION_CONF') != '']} \
                                 ${@ ['', '${QCOM_BOOT_FIRMWARE}:do_deploy'][d.getVar('QCOM_BOOT_FIRMWARE') != '']} \
+                                ${@ ['', '${QCOM_CONTENTS_XML}:do_deploy'][d.getVar('QCOM_CONTENTS_XML') != '']} \
                                 virtual/kernel:do_deploy \
 				${@'virtual/bootloader:do_deploy' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader') else  ''} \
 				${@'${QCOM_ESP_IMAGE}:do_image_complete' if d.getVar('QCOM_ESP_IMAGE') != '' else  ''}"
@@ -107,6 +110,7 @@ create_qcomflash_pkg() {
             -name '*.elf' -o \
             -name '*.mbn*' -o \
             -name '*.fv' -o \
+            -name 'contents.xml' -o \
             -name 'sec.dat'` ; do
         install -m 0644 ${bfw} .
     done

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -21,3 +21,5 @@ QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcm6490-idp"
+
+QCOM_CONTENTS_XML = "contentsxml-qcom-boot-qcs6490"

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -23,3 +23,5 @@ QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs6490-rb3gen2"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
+
+QCOM_CONTENTS_XML = "contentsxml-qcom-boot-qcs6490"

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -22,3 +22,5 @@ QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs8300-ride-sx"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"
+
+QCOM_CONTENTS_XML = "contentsxml-qcom-boot-qcs8300"

--- a/conf/machine/qcs9075-iq-9075-evk.conf
+++ b/conf/machine/qcs9075-iq-9075-evk.conf
@@ -24,3 +24,5 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs9100-ride-sx"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+
+QCOM_CONTENTS_XML = "contentsxml-qcom-boot-qcs9100"

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -25,3 +25,5 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs9100-ride-sx"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+
+QCOM_CONTENTS_XML = "contentsxml-qcom-boot-qcs9100"

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-common.inc
@@ -1,0 +1,21 @@
+# Install contents.xml in DEPLOY_DIR
+
+S = "${UNPACKDIR}"
+
+QCOM_BOOT_IMG_SUBDIR ?= ""
+CONTENTS_XML_FILE ?= ""
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}
+    find "${S}" -maxdepth 1 -name "${CONTENTS_XML_FILE}" -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/contents.xml \;
+}
+addtask deploy before do_build after do_install
+
+inherit allarch

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs6490.inc
@@ -1,0 +1,16 @@
+DESCRIPTION = "Contents file for invoking Axiom on Qualcomm QCS6490 platforms"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://contents-qcm6490-LICENSE.txt;md5=6e1bae7ef13289c332a27b917fb49764"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
+FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/contents.xml;downloadfilename=contents-qcm6490_${PV}.xml;name=cxml-qcm6490 \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=contents-qcm6490-LICENSE.txt;name=cxml-license-qcm6490 \
+    "
+
+QCOM_BOOT_IMG_SUBDIR = "qcm6490"
+CONTENTS_XML_FILE = "contents-qcm6490_${PV}.xml"
+
+include contentsxml-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs6490_00095.0.bb
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs6490_00095.0.bb
@@ -1,0 +1,4 @@
+require contentsxml-qcom-boot-qcs6490.inc
+
+SRC_URI[cxml-qcm6490.sha256sum] = "42b384c0a82ffc294ffd690294b0261aadb2aa7bb6d85dd3eea522b50f90e7a3"
+SRC_URI[cxml-license-qcm6490.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs8300.inc
@@ -1,0 +1,16 @@
+DESCRIPTION = "Contents file for invoking Axiom on Qualcomm QCS8300 platforms"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://contents-qcs8300-LICENSE.txt;md5=6e1bae7ef13289c332a27b917fb49764"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
+FW_BUILD_ID = "r1.0_${PV}/qcs8300-le-1-0"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/contents.xml;downloadfilename=contents-qcs8300_${PV}.xml;name=cxml-qcs8300 \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=contents-qcs8300-LICENSE.txt;name=cxml-license-qcs8300 \
+    "
+
+QCOM_BOOT_IMG_SUBDIR = "qcs8300"
+CONTENTS_XML_FILE = "contents-qcs8300_${PV}.xml"
+
+include contentsxml-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs8300_00095.0.bb
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs8300_00095.0.bb
@@ -1,0 +1,4 @@
+require contentsxml-qcom-boot-qcs8300.inc
+
+SRC_URI[cxml-qcs8300.sha256sum] = "75fe177a10592fd6d076a8d5373e42c2c2d807436f420f527a8bf6df2d137a7c"
+SRC_URI[cxml-license-qcs8300.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs9100.inc
@@ -1,0 +1,16 @@
+DESCRIPTION = "Contents file for invoking Axiom on Qualcomm QCS9100 platforms"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://contents-qcm9100-LICENSE.txt;md5=6e1bae7ef13289c332a27b917fb49764"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
+FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/contents.xml;downloadfilename=contents-qcs9100_${PV}.xml;name=cxml-qcs9100 \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=contents-qcm9100-LICENSE.txt;name=cxml-license-qcs9100 \
+    "
+
+QCOM_BOOT_IMG_SUBDIR = "qcs9100"
+CONTENTS_XML_FILE = "contents-qcs9100_${PV}.xml"
+
+include contentsxml-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs9100_00095.0.bb
+++ b/recipes-bsp/firmware-boot/contentsxml-qcom-boot-qcs9100_00095.0.bb
@@ -1,0 +1,4 @@
+require contentsxml-qcom-boot-qcs9100.inc
+
+SRC_URI[cxml-qcs9100.sha256sum] = "357cce722dad4551c7ae229dde8eae5c7218f0c8d97380e46bf3a35236b0aa9b"
+SRC_URI[cxml-license-qcs9100.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"


### PR DESCRIPTION
The 'contents.xml' file maps images to their respective partitions in a format understood by Axiom. Deploy the same to enable Axiom automatic image flashing on supported boards.