### PR TITLE
opencv: add opencv to ci pkg group

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
@@ -1,1 +1,3 @@
-PACKAGECONFIG:append:qcom = " fastcv"
+PACKAGECONFIG:append:qcom = " tests fastcv"
+
+RDEPENDS_${PN}-apps = "${PN}"

--- a/recipes-bsp/packagegroups/packagegroup-qcom-ci.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-ci.bb
@@ -10,4 +10,6 @@ RDEPENDS:${PN} = " \
     ${@bb.utils.contains("BBLAYERS", "openembedded-layer", "libssc","", d)} \
     libvmmem-dev \
     libdmabufheap-dev \
+    opencv-apps \
+    opencv \
 "


### PR DESCRIPTION
Opencv needs build verification
of its libs, tests and samples.
Enable tests for opencv.