### PR TITLE
ci: qcs8300-ride-sx: hardcode LAVA device type

### DIFF
--- a/ci/lava/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcs8300-ride-sx/boot.yaml
@@ -52,7 +52,7 @@ actions:
 context:
   lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
-device_type: {{DEVICE_TYPE}}
+device_type: qcs8300-ride
 job_name: boot test ({{DEVICE_TYPE}}) {{GITHUB_RUN_ID}}
 metadata:
   build-commit: '{{GITHUB_SHA}}'


### PR DESCRIPTION
The lava instance doesn't define an expected 'qcs8300-ride-sx' device type for QCS8300 boards. Until that gets fixed, hardcode device type to be 'qcs8300-ride'.

Fixes: ad7e526b8fff ("ci: Add LAVA template for qcs8300-ride-sx machine")