### PR TITLE
OpenCV: enable tests

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:append:qcom = " fastcv"
+PACKAGECONFIG:append:qcom = " tests fastcv"


### PR DESCRIPTION
Enable test and sample application binaries to be built by
setting the feature flag. This will allow build verification
of the test and sample binaries.