### PR TITLE
ci: qcs8300-ride-sx: Fix quotation in LAVA template

### DIFF
--- a/ci/lava/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcs8300-ride-sx/boot.yaml
@@ -13,7 +13,7 @@ actions:
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
         - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=qcs8300 >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=qcs8300" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
       minutes: 5


### PR DESCRIPTION
Small typo change to add a missing quote in the qcs8300 LAVA job template.