### PR TITLE
linux-yocto-dev: fix Kconfig dependency

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev/drivers/0008-PCI-pwrctrl-Add-power-control-driver-for-tc9563.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/drivers/0008-PCI-pwrctrl-Add-power-control-driver-for-tc9563.patch
@@ -42,7 +42,7 @@ index 990cab67d41332..d14ef2b0ffd84f 100644
  
 +config PCI_PWRCTRL_TC9563
 +	tristate "PCI Power Control driver for TC9563 PCIe switch"
-+	select PCI_PWRCTL
++	select PCI_PWRCTRL
 +	help
 +	  Say Y here to enable the PCI Power Control driver of TC9563 PCIe
 +	  switch.


### PR DESCRIPTION
While refreshing TC9563 patchset I didn't notice that one of Kconfig symbols was also renamed in the upstream kernel. This e.g. causes failures on qcom-armv7a machines with the linux-yocto-dev kernels. Correct the Kconfig symbol in the patch.

Fixes: a489721ca174 ("linux-yocto-dev: refresh")