### PR TITLE
image-types-qcom: respect the IMAGE_NAME_SUFFIX variable

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -42,7 +42,7 @@ IMAGE_TYPEDEP:qcomflash += "${IMAGE_QCOMFLASH_FS_TYPE}"
 create_qcomflash_pkg() {
     # esp image
     if [ -n "${QCOM_ESP_FILE}" ]; then
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_ESP_IMAGE}-${MACHINE}.rootfs.vfat ${QCOM_ESP_FILE}
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_ESP_IMAGE}-${MACHINE}${IMAGE_NAME_SUFFIX}.vfat ${QCOM_ESP_FILE}
     fi
 
     # dtb image


### PR DESCRIPTION
IMAGE_NAME_SUFFIX [1]: Suffix used for the image output filename defaults to ".rootfs" to distinguish the image file from other files created during image building; however if this suffix is redundant or not desired you can clear the value of this variable (set the value to “”). For example, this is typically cleared in Initramfs image recipes.

[1] https://docs.yoctoproject.org/ref-manual/variables.html#term-IMAGE_NAME_SUFFIX