### PR TITLE
initramfs-test-full-image: add igt-gpu-tools-tests package

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -7,6 +7,7 @@ PACKAGE_INSTALL += " \
     coreutils \
     expect \
     hdparm \
+    igt-gpu-tools-tests \
     kexec \
     lsof \
     ncurses \


### PR DESCRIPTION
Add the igt-gpu-tools-tests package to initramfs-test-full-image.bb to enable support for DRM driver testing.

Fixes [issue#1000](https://github.com/qualcomm-linux/meta-qcom/issues/1000)