### PR TITLE
ci: upload build artifacts to S3 bucket

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -172,6 +172,13 @@ jobs:
         with:
           path: ./uploads
 
+      - name: Upload artifacts to S3 bucket
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v1
+        with:
+          path: ./uploads
+          destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
+          s3_bucket: qcom-prd-gh-artifacts
+
   create-output:
     needs: compile
     outputs:


### PR DESCRIPTION
Upload the build artifacts to the specified S3 bucket. This step is
essential to enable Axiom testing, as it relies on these artifacts
being available. Ensure the upload is completed before initiating tests