### PR TITLE
initramfs-test-full-image: add more utilities

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -15,11 +15,13 @@ PACKAGE_INSTALL += " \
     ncurses-terminfo-base \
     net-tools \
     openssh-sftp-server \
+    pulseaudio-misc \
     rng-tools \
     stress-ng \
     util-linux \
     util-linux-chrt \
     util-linux-lsblk \
+    weston-examples \
 "
 
 PACKAGE_INSTALL:append:libc-glibc = " \
@@ -44,6 +46,7 @@ PACKAGE_INSTALL_openembedded-layer += " \
     makedumpfile \
     mbw \
     ncurses-terminfo-base \
+    pipewire-tools \
     sysbench \
     tinymembench \
     tiobench \


### PR DESCRIPTION
Add the following utilities in 'initramfs-test-full-image.bb'

- pulseaudio-misc and pipewire-tools (used for validating audio functionality)
- weston-examples (used for validating graphics functionality)

Fixes [issue#1001](https://github.com/qualcomm-linux/meta-qcom/issues/1001) 
Fixes [issue#1002](https://github.com/qualcomm-linux/meta-qcom/issues/1002) 
Fixes [issue#1005](https://github.com/qualcomm-linux/meta-qcom/issues/1005)