### PR TITLE
qcom-ptool: upgrade revision to fix build flash issue on QCS615

### DIFF
--- a/recipes-devtools/partition-utils/qcom-ptool_git.bb
+++ b/recipes-devtools/partition-utils/qcom-ptool_git.bb
@@ -9,7 +9,7 @@ RDEPENDS:${PN} += "python3-xml"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
 
-SRCREV = "be9d04e7940c777d361f05f0468e260ee493b76e"
+SRCREV = "e71fe81f06e18deb4a25425f8a781d04a0f9cbde"
 
 PV = "0.0+git"
 


### PR DESCRIPTION
Current QCS615 partition table include keymint.mbn and secs2d.mbn that are not present in build, which cause PCAT flash failure. Upgrade ptool to include the fix.