### PR TITLE
Add back graphicsdlkm recipe

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
+++ b/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
@@ -35,6 +35,7 @@ RRECOMMENDS:${PN}-board-generic += " \
 # This packagegroup lists 'generic' qcom modules that are shared between
 # the SoCs we support
 RRECOMMENDS:${PN}-qcom-generic += " \
+    graphicsdlkm \
     kernel-module-fastrpc \
     kernel-module-gpi \
     kernel-module-i2c-qcom-geni \

--- a/recipes-graphics/graphicsdlkm/files/kgsl.rules
+++ b/recipes-graphics/graphicsdlkm/files/kgsl.rules
@@ -1,0 +1,1 @@
+KERNEL=="kgsl-3d0", GROUP="render", MODE="0660", TAG+="uaccess"

--- a/recipes-graphics/graphicsdlkm/graphicsdlkm_1.0.bb
+++ b/recipes-graphics/graphicsdlkm/graphicsdlkm_1.0.bb
@@ -1,0 +1,18 @@
+inherit module
+
+DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
+
+SRCREV = "56d7a36e6b95d3e311fe22f93be98d9d5943036d"
+SRC_URI = "git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https"
+SRC_URI += "file://kgsl.rules"
+
+KERNEL_MODULE_PROBECONF += "msm_kgsl"
+module_conf_msm_kgsl = "blacklist msm_kgsl"
+
+do_install:append() {
+      install -m 0644 ${WORKDIR}/sources/kgsl.rules -D ${D}${nonarch_base_libdir}/udev/rules.d/kgsl.rules
+}
+
+FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"


### PR DESCRIPTION
Add a recipe for `graphicsdlkm` to support the Qualcomm KGSL driver. Module is blacklisted by default. The user space recipe would bring in a mechanism to load the module.