### PR TITLE
initramfs-test-full-image: add fastrpc-tests package

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -6,6 +6,7 @@ PACKAGE_INSTALL += " \
     bootrr \
     coreutils \
     expect \
+    fastrpc-tests \
     hdparm \
     igt-gpu-tools-tests \
     kexec \


### PR DESCRIPTION
Add `fastrpc-tests` package in initramfs-test-full-image for fastrpc
testing.

Closes: https://github.com/qualcomm-linux/meta-qcom/issues/1003