### PR TITLE
qrb2210-rb1-core-kit: add Hexagon DSP binaries to essential packages

### DIFF
--- a/conf/machine/qrb2210-rb1-core-kit.conf
+++ b/conf/machine/qrb2210-rb1-core-kit.conf
@@ -17,7 +17,10 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qrb2210-rb1.dtb \
                       "
 
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "packagegroup-rb1-firmware"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-rb1-firmware \
+    packagegroup-rb1-hexagon-dsp-binaries \
+"
 
 # Helper util to tell the android bootloader to mark the boot as successfull.
 # The boot firmware will switch to slot B and fail to boot otherwise.


### PR DESCRIPTION
Add packagegroup-rb1-hexagon-dsp-binaries to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS in order to pull DSP binaries into the rootfs.