### PR TITLE
Build both multimedia-image and multimedia-proprietary-image in CI

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -76,6 +76,8 @@ jobs:
             yamlfile: ""
           - name: qcom-distro
             yamlfile: ':ci/qcom-distro.yml'
+          - name: qcom-distro-prop-image
+            yamlfile: ':ci/qcom-distro-prop-image.yml'
         kernel:
           - type: default
             dirname: ""
@@ -117,6 +119,8 @@ jobs:
             yamlfile: ""
           - name: qcom-distro
             yamlfile: ':ci/qcom-distro.yml'
+          - name: qcom-distro-prop-image
+            yamlfile: ':ci/qcom-distro-prop-image.yml'
         kernel:
           - type: default
             dirname: ""
@@ -139,6 +143,11 @@ jobs:
                 type: additional
                 dirname: "+linux-yocto-lts"
                 yamlfile: ":ci/linux-yocto-lts.yml"
+        exclude:
+          # Incompatible builds
+          - machine: qcom-armv7a
+            distro:
+                name: qcom-distro-prop-image
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
       - uses: actions/checkout@v4

--- a/ci/qcom-distro-prop-image.yml
+++ b/ci/qcom-distro-prop-image.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+target: qcom-multimedia-proprietary-image


### PR DESCRIPTION
Enhance CI to build both images provided by meta-qcom-distro.
- qcom-multimedia-image
- qcom-multimedia-proprietary-image
