### PR TITLE
Fix COMPATIBLE_MACHINE usage

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
@@ -25,5 +25,5 @@ module_conf_msm_kgsl = "blacklist msm_kgsl"
 FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"
 
 # The module is only promised to support ARMv8 machines
-COMPATIBLE_MACHINES = ""
-COMPATIBLE_MACHINES:aarch64 = "(.*)"
+COMPATIBLE_MACHINE = ""
+COMPATIBLE_MACHINE:aarch64 = "(.*)"

--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.bb
@@ -12,5 +12,5 @@ MAKE_TARGETS = "modules"
 
 # This package is designed to run exclusively on ARMv8 (aarch64) machines.
 # Therefore, builds for other architectures are not necessary and are explicitly excluded.
-COMPATIBLE_MACHINES = ""
-COMPATIBLE_MACHINES:aarch64 = "(.*)"
+COMPATIBLE_MACHINE = ""
+COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
The correct variable is COMPATIBLE_MACHINE, not COMPATIBLE_MACHINES.