### PR TITLE
ci/qcom-distro.yml: Add meta-ar layer to Yocto distribution

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -25,6 +25,10 @@ repos:
     url: https://git.yoctoproject.org/git/meta-virtualization
     branch: master
 
+  meta-audioreach:
+    url: https://github.com/Audioreach/meta-ar.git
+    branch: main
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"


### PR DESCRIPTION
This change integrates the `meta-audioreach` layer into the Qualcomm Yocto distribution configuration, enabling support for AudioReach components via the PipeWire plugin.