### PR TITLE
ci/poky: add kas config yml

### DIFF
--- a/ci/poky.yml
+++ b/ci/poky.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+repos:
+  oe-core:
+    layers:
+      meta: disabled
+
+  meta-yocto:
+    layers:
+      meta-poky: disabled
+
+  poky:
+    url: https://github.com/yoctoproject/poky
+    layers:
+      meta:
+      meta-poky:

--- a/ci/poky.yml
+++ b/ci/poky.yml
@@ -3,6 +3,15 @@
 header:
   version: 14
 
+# FIXME: until my patch lands in kas
+bblayers_conf_header:
+  FIXME: |
+    # override the default kas BBLAYERS
+    BBLAYERS = " \
+    /repo \
+    /work/poky/meta \
+    /work/poky/meta-poky"
+
 repos:
   oe-core:
     layers:
@@ -17,3 +26,7 @@ repos:
     layers:
       meta:
       meta-poky:
+
+  # FIXME: until my patch lands in kas
+  # Multiple init scripts found (poky vs. oe-core). Resolve ambiguity by removing one of the repos
+  oe-core: null


### PR DESCRIPTION
This kas configuration poky.yml file is intended to override the base.yml.

[kas|kas-container] {...} ci/base.yml:ci/poky.yml
[kas|kas-container] {...} ci/machine.yml:ci/poky.yml

With that we disbale the layers in the base.yml and we add the main poky layers.
This allows you to change the distribution from the nodistro to the poky.