### PR TITLE
ci: make compile_warmup depend on yocto-run-checks

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -62,7 +62,7 @@ jobs:
           ci/kas-container-shell-helper.sh ci/yocto-patchreview.sh
 
   compile_warm_up:
-    needs: kas-setup
+    needs: [kas-setup, yocto-run-checks]
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, qcom-u2404, amd64-ssd]
     strategy:


### PR DESCRIPTION
A failure in yocto-run-checks (check-layer or patchreview) is already enough to trigger a CI failure.