### PR TITLE
Move linux-qcom-next to qcom-next-6.17-rc5-20250910 tag

### DIFF
--- a/conf/machine/qcs9075-iq-9075-evk.conf
+++ b/conf/machine/qcs9075-iq-9075-evk.conf
@@ -6,10 +6,10 @@ require conf/machine/include/qcom-qcs9100.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "qcs9075-iq-9075-evk"
+QCOM_DTB_DEFAULT ?= "lemans-evk"
 
 KERNEL_DEVICETREE ?= " \
-                      qcom/qcs9075-iq-9075-evk.dtb \
+                      qcom/lemans-evk.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.16-rel+6.17-rc3"
+LINUX_VERSION ?= "6.16-rel+6.17-rc5"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-6.17-rc3-20250826
-SRCREV ?= "90a817a947eaa439d2edaf86f51271fcffc1155e"
+# tag: qcom-next-6.17-rc5-20250910
+SRCREV ?= "81052b1bbda772a5065724fb304e6e4482e5389b"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
qcom-next-6.17-rc5-20250910 is the latest RC tag available in qcom-next kernel.