### PR TITLE
CI: drop useless page_owner=on kernel arg

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -34,7 +34,7 @@ local_conf_header:
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " page_owner=on qcom_scm.download_mode=1"
+    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
The kernel complains about the unknown parameter:

Unknown kernel command line parameters "page_owner=on", will be passed to user space.

This warning makes sense, as page_owner=on is only available if CONFIG_PAGE_OWNER is also enabled. As such, it doesn't make sense to have this param in the default configuration: to make it useful it would be required to rebuild the kernel anyway.

Drop it from the CI config.