### PR TITLE
iris-video-dlkm: Update to bring firmware loading and colorspace fixes

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.0.0"
-SRCREV  = "466922b32a5f967176651ace14c38f6874c61b9b"
+SRCREV  = "170ac561d70a366bc6502810079fa6b6c914920d"
 
 inherit module
 


### PR DESCRIPTION
Fixes included for QCM6490 QCS8300 and SA8775p:
- amend firmware path to point to upstream instead of a custom git.
- update the properties in SOC platform data to match with respective device tree.
- remove support for nonstandard color space types.