### PR TITLE
iris-video-dlkm: stop pretending to have version 1.0

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
@@ -3,6 +3,8 @@ LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
+PV = "0.0+git"
+
 SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.0.0"
 SRCREV  = "170ac561d70a366bc6502810079fa6b6c914920d"
 


### PR DESCRIPTION
Iris video module isn't versioned (and doesn't have version 1.0 anyway). Change its PV to be 0.0+git in order to capture that it's a Git snapshot.