### PR TITLE
Don't build MSM GBM backend without 'opengl' DISTRO_FEATURE

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -18,7 +18,7 @@ RDEPENDS:${PN}-boot-essential = " \
 "
 
 RDEPENDS:${PN}-boot-additional = " \
-    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opengl vulkan', 'msm-gbm-backend', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opengl', 'msm-gbm-backend', '', d)} \
 "
 RDEPENDS:${PN}-boot-additional:append:aarch64 = " \
     fastrpc \

--- a/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
+++ b/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
@@ -16,7 +16,7 @@ SRC_URI = "git://git.codelinaro.org/clo/le/display/libgbm.git;branch=display.qcl
 inherit meson pkgconfig features_check
 
 DEPENDS = "mesa libdrm libxml2"
-ANY_OF_DISTRO_FEATURES = "opengl vulkan"
+REQUIRED_DISTRO_FEATURES = "opengl"
 
 FILES:${PN} = "${libdir}/gbm/msm_gbm.so* ${sysconfdir}/gbm/default_fmt_alignment.xml"
 


### PR DESCRIPTION
msm-gbm-backend sets ANY_OF_DISTRO_FEATURES to 'opengl vulkan', but it's not correct: libgbm isn't being built without EGL / OpenGL being enabled. Drop 'vulkan' from the list of possible DISTRO_FEATUREs and limit the condition to 'opengl' only.