### PR TITLE
workflows: add comment with action link in PR

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Prepare PR comment
         id: pr_comment_prep
         run: |
-          echo "## Test jobs for commit ${{ github.event.workflow_run.head_sha }}" > pr-comment.txt
+          echo "## Test run [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" > pr-comment.txt
+          echo "## Test jobs for commit ${{ github.event.workflow_run.head_sha }}" >> pr-comment.txt
           for json_file in $(find ${{ github.workspace }} -name "test-job-*.json")
           do
               DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")


### PR DESCRIPTION
When running tests on pull request it's not easy to identify the proper workflow. This patch adds a link to the workflow to the PR comment. This way it will be easy to find the proper workflow should the tests fail.