### PR TITLE
Replace the event handler-based check with a custom task in image-adbd.bbclass     

### DIFF
--- a/classes-recipe/image-adbd.bbclass
+++ b/classes-recipe/image-adbd.bbclass
@@ -20,11 +20,11 @@ enable_adbd_at_boot () {
 
 ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], 'enable_adbd_at_boot; ', '',d)}"
 
-python oelayer_check() {
-    if 'openembedded-layer' not in e.data.getVar('BBFILE_COLLECTIONS').split():
+addtask oelayer_check before do_build
+do_oelayer_check[nostamp] = "1"
+python do_oelayer_check() {
+    if 'openembedded-layer' not in d.getVar('BBFILE_COLLECTIONS').split():
         bb.warn("'image-adbd' is inherited but the meta-openembedded layer"
                 " is not included in bblayers. ADBD may not work as expected.")
 }
 
-addhandler oelayer_check
-oelayer_check[eventmask] = "bb.event.RecipePreFinalise"


### PR DESCRIPTION
The 'ConfigParsed' event is triggered when base configuration files
like bitbake.conf and global INHERIT statements are parsed. Since
these are common across all builds, the oelayer_check warning appears
in nearly every build, which is unwarranted.

To prevent this, replace the event handler-based check with a task that
verifies layer presence and shows a warning. As tasks are scheduled only
when the recipe inheriting image-adbd.bbclass is selected for build, this
change avoids unnecessary warnings.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1079