### PR TITLE
packagegroup-qcs8300-ride: Add correct firmware packgegroups for GPU

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcs8300-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     linux-firmware-qcom-qcs8300-audio \


### PR DESCRIPTION
GPU present on qcs8300 chipset requires a650_sqe.fw and a623_gmu.bin. Correct the packagegroups to get these firmware files.