### PR TITLE
Enable GPU firmware even w/o OpenGL

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard820c.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-qca6174', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-serial', '', d)} \
     linux-firmware-qcom-apq8096-audio \

--- a/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-dragonboard845c.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-sdm845-modem', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x linux-firmware-qcom-sdm845-modem', '', d)} \
     linux-firmware-qcom-sdm845-audio \

--- a/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
@@ -6,7 +6,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-adreno-gmu-a621 linux-firmware-qcom-sar2130p-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-adreno-gmu-a621 linux-firmware-qcom-sar2130p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     firmware-qcom-qar2130p \

--- a/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
@@ -7,7 +7,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcs615-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcs615-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
     linux-firmware-qcom-venus-5.4 \

--- a/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     linux-firmware-qcom-qcs8300-audio \

--- a/recipes-bsp/packagegroups/packagegroup-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb1.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-qcm2290-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-qcm2290-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qcm2290-wifi ', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3950', '', d)} \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb2.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qrb4210-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3988', '', d)} \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcm6490-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcm6490-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcm6490-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \
     linux-firmware-qcom-qcm6490-audio \

--- a/recipes-bsp/packagegroups/packagegroup-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb5.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6390', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6390', '', d)} \
     linux-firmware-lt9611uxc \

--- a/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     linux-firmware-qcom-sa8775p-audio \

--- a/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-sm8150-hdk \

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sm8350-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sm8350-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8350-hdk \

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -8,12 +8,11 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sm8350-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8350-hdk \
     linux-firmware-lt9611uxc \
-    linux-firmware-qcom-sm8350-adreno \
     linux-firmware-qcom-sm8350-audio \
     linux-firmware-qcom-sm8350-compute \
     linux-firmware-qcom-sm8350-ipa \

--- a/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a730 linux-firmware-qcom-sm8450-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a730 linux-firmware-qcom-sm8450-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     firmware-qcom-sm8450-hdk \

--- a/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
@@ -6,7 +6,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a740 linux-firmware-qcom-sm8550-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a740 linux-firmware-qcom-sm8550-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     firmware-qcom-sm8550-hdk \

--- a/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-g790 linux-firmware-qcom-sm8650-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g790 linux-firmware-qcom-sm8650-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     firmware-qcom-sm8650-hdk \


### PR DESCRIPTION
Enabling of GPU isn't limited to OpenGL-only cases. Install GPU firmware if the distro enabled 'vulkan' or 'opencl' (where applicable).