### PR TITLE
Fix qcom-adreno errors on ARMv7-A machines

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.838.1.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.838.1.bb
@@ -19,6 +19,11 @@ inherit features_check
 
 ANY_OF_DISTRO_FEATURES = "glvnd vulkan opencl"
 
+COMPATIBLE_MACHINE = "^$"
+# It should be armv8-2a, but then it wouldn't be possible to use it for
+# qcom-armv8a machine.
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
 PACKAGE_BEFORE_PN += " ${PN}-common ${PN}-gles1 ${PN}-gles2 ${PN}-egl ${PN}-vulkan ${PN}-cl"
 
 RPROVIDES:${PN}-egl += "virtual-egl-icd"


### PR DESCRIPTION
CI for qcom-armv7a machine started to fail with the following error:
```
2025-09-18T18:55:56.5099934Z 2025-09-18 18:55:56 - INFO     - NOTE: Resolving any missing task queue dependencies
2025-09-18T18:55:56.9907928Z 2025-09-18 18:55:56 - INFO     - NOTE: Multiple providers are available for runtime libnss-mdns (avahi-libnss-mdns, mdns)
2025-09-18T18:55:56.9908679Z 2025-09-18 18:55:56 - INFO     - Consider defining a PREFERRED_RPROVIDER entry to match libnss-mdns
2025-09-18T18:55:57.4838148Z 2025-09-18 18:55:57 - ERROR    - ERROR: Nothing RPROVIDES 'kgsl-dlkm' (but /work/build/../../repo/recipes-graphics/adreno/qcom-adreno_1.838.1.bb RDEPENDS on or otherwise requires it)
2025-09-18T18:55:57.4839514Z 2025-09-18 18:55:57 - ERROR    - kgsl-dlkm was skipped: incompatible with machine qcom-armv7a (not in COMPATIBLE_MACHINE)
2025-09-18T18:55:57.4842578Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'kgsl-dlkm' is unbuildable, removing...
2025-09-18T18:55:57.4843175Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['kgsl-dlkm']
2025-09-18T18:55:57.4847813Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'qcom-adreno-gles1' is unbuildable, removing...
2025-09-18T18:55:57.4848621Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['qcom-adreno-gles1', 'kgsl-dlkm']
2025-09-18T18:55:57.4891854Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'qcom-adreno' is unbuildable, removing...
2025-09-18T18:55:57.4892515Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['qcom-adreno', 'kgsl-dlkm']
2025-09-18T18:55:57.4933632Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'qcom-adreno-common' is unbuildable, removing...
2025-09-18T18:55:57.4934342Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['qcom-adreno-common', 'kgsl-dlkm']
2025-09-18T18:55:57.4972244Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'qcom-adreno-gles2' is unbuildable, removing...
2025-09-18T18:55:57.4972936Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['qcom-adreno-gles2', 'kgsl-dlkm']
2025-09-18T18:55:57.5012884Z 2025-09-18 18:55:57 - INFO     - NOTE: Runtime target 'qcom-adreno-dev' is unbuildable, removing...
2025-09-18T18:55:57.5013565Z 2025-09-18 18:55:57 - INFO     - Missing or unbuildable dependency chain was: ['qcom-adreno-dev', 'kgsl-dlkm']
```

Limit the qcom-adreno package to ARMv8 too.