### PR TITLE
Align qcs615 boot firmware with qclinux 1.5 and add missing CDT

### DIFF
--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -16,5 +16,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs615-adp-air-firmware \
 "
 
+QCOM_CDT_FILE = "cdt_adp_air_sa6155p"
 QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs615-adp-air"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -9,7 +9,9 @@ BOOTBINARIES = "QCS615_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
     "
+SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs615"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00095.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "c9b0332873feda447b32491dcbbc96255c3cf88da1868d89ac5113b01cb42f75"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00096.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00096.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "4500b904d8195e89dd59c0d196e934b88c4737c57b5be20c60f156b8b73e9ddb"


### PR DESCRIPTION
Align boot firmware for qcs615 with the release used as part of qclinux 1.5 and include the missing CDT for the target.