### PR TITLE
Enable hardware watchdog support in CI images

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -42,6 +42,7 @@ local_conf_header:
     DISTRO_FEATURES:append = " efi pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
+    WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
 
 machine: unset
 


### PR DESCRIPTION
Enabling hardware watchdog in CI images is essential for collecting system dumps in case of hangs or crashes.
Set `WATCHDOG_RUNTIME_SEC` to 30 seconds via local.conf to ensure the `RuntimeWatchdogSec=` parameter 
in `/etc/systemd/system.conf` reflects this value, thereby activating the watchdog.