### PR TITLE
CI: reduce number of simultaneous builds jobs

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -75,8 +75,6 @@ jobs:
           - name: poky-altcfg
             yamlfile: ""
           - name: qcom-distro
-            yamlfile: ':ci/qcom-distro.yml'
-          - name: qcom-distro-prop-image
             yamlfile: ':ci/qcom-distro-prop-image.yml'
           # kvm is compatible with all the compile warm up machines
           - name: qcom-distro-kvm
@@ -123,15 +121,12 @@ jobs:
           - qcs615-ride
           - qcs8300-ride-sx
           - qcs9100-ride-sx
-          - qcom-armv7a
           - rb1-core-kit
           - sm8750-mtp
         distro:
           - name: poky-altcfg
             yamlfile: ""
           - name: qcom-distro
-            yamlfile: ':ci/qcom-distro.yml'
-          - name: qcom-distro-prop-image
             yamlfile: ':ci/qcom-distro-prop-image.yml'
           - name: qcom-distro-sota
             yamlfile: ':ci/qcom-distro-sota.yml'
@@ -147,7 +142,7 @@ jobs:
           - machine: qcom-armv8a
             distro:
                 name: qcom-distro
-                yamlfile: ':ci/qcom-distro.yml'
+                yamlfile: ':ci/qcom-distro-prop-image.yml'
             kernel:
                 type: additional
                 dirname: "+linux-yocto-dev"
@@ -161,11 +156,22 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
-        exclude:
-          # Incompatible builds
           - machine: qcom-armv7a
             distro:
-                name: qcom-distro-prop-image
+                name: poky-altcfg
+                yamlfile: ''
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: qcom-armv7a
+            distro:
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
       - uses: actions/checkout@v4

--- a/ci/qcom-distro-prop-image.yml
+++ b/ci/qcom-distro-prop-image.yml
@@ -5,4 +5,6 @@ header:
   includes:
    - ci/qcom-distro.yml
 
-target: qcom-multimedia-proprietary-image
+target:
+  - qcom-multimedia-image
+  - qcom-multimedia-proprietary-image


### PR DESCRIPTION
Our CI builds use a lot of parallel jobs, resulting in a high resource usage. Reduce the number of jobs being by merging two qcom-distro jobs into a single one and using special jobs for qcom-armv7a builds (since we don't support proprietary builds on qcom-armv7a).
