### PR TITLE
ci: clean up sstate cache with a dedicated monthly job

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -30,8 +30,6 @@ runs:
       shell: bash
       run: |
         # use a monthly sstate cache folder
-        # keep current and last month to allow smooth end of month transition
-        rm -rf ${{inputs.cache_dir}}/sstate-cache-$(date -d '2 months ago' '+%Y-%m')
         echo "DL_DIR=${{inputs.cache_dir}}/downloads" >> $GITHUB_ENV
         echo "SSTATE_DIR=${{inputs.cache_dir}}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
         echo "KAS_WORK_DIR=$PWD/../kas" >> $GITHUB_ENV

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,14 @@
+name: Monthly job
+
+on:
+  schedule:
+  - cron: "22 10 2 * *"   # montly job - at "random" time - top of hour can be busy in github
+
+jobs:
+  # Clean up the persistant sstate-cache dir
+  # keep current and last month to allow smooth end of month transition
+  sstate-cache-cleanup:
+    if: github.repository == 'qualcomm-linux/meta-qcom'
+    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    steps:
+      rm -rf /efs/qli/meta-qcom/sstate-cache-$(date -d '2 months ago' '+%Y-%m')


### PR DESCRIPTION
We use a 'monthly' persistent sstate cache folder, to limit the disk usage. Up until now, we were cleaning up the 'old' folder (2 months back), in the the 'compile' step.

The CI failed on 10/1, with errors like this one:

rm: cannot remove
'/efs/qli/meta-qcom/sstate-cache-2025-08/96/8d/sstate:libxfixes:armv8-2a-qcom-linux:6.0.1:r0:armv8-2a:14:968dbabfeff8c1be8f64efbc2780ddb4e4e4d16759c27cef155838329d7de706_create_spdx.tar.zst': Stale file handle

This is because several compile jobs were started , for each machine, and they stepped onto each other. To avoid that, I am moving the cleanup of sstate cache folder into a proper monthly 'cron' job, which will be executed only once.