### PR TITLE
packagegroup-qcom: drop msm-gbm-backend from RDEPENDS

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -17,9 +17,6 @@ RDEPENDS:${PN}-boot-essential = " \
     tqftpserv \
 "
 
-RDEPENDS:${PN}-boot-additional = " \
-    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opengl', 'msm-gbm-backend', '', d)} \
-"
 RDEPENDS:${PN}-boot-additional:append:aarch64 = " \
     fastrpc \
 "


### PR DESCRIPTION
The qcom-adreno package now pulls in the msm-gbm-backend. Drop it from the packagegroup-qcom's RDEPENDS.