### PR TITLE
ci: fix job/steps definition

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -5,10 +5,11 @@ on:
   - cron: "22 10 2 * *"   # montly job - at "random" time - top of hour can be busy in github
 
 jobs:
-  # Clean up the persistant sstate-cache dir
-  # keep current and last month to allow smooth end of month transition
   sstate-cache-cleanup:
     if: github.repository == 'qualcomm-linux/meta-qcom'
     runs-on: [self-hosted, qcom-u2404, amd64-ssd]
     steps:
-      rm -rf /efs/qli/meta-qcom/sstate-cache-$(date -d '2 months ago' '+%Y-%m')
+      - name: Clean up the persistant sstate-cache dir
+        run: |
+          # keep current and last month to allow smooth end of month transition
+          rm -rf /efs/qli/meta-qcom/sstate-cache-$(date -d '2 months ago' '+%Y-%m')


### PR DESCRIPTION
In 4a87c0a35321 the steps for the cleanup sstate job have a syntax error, and the job is invalid. Fix the obvious syntax issue.