### PR TITLE
Update boot bins to 00103.0 release

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -18,8 +18,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk"
 QCOM_BOOT_FILES_SUBDIR = "qcs8300"
-
-# FIXME provide device-specific table
-QCOM_PARTITION_FILES_SUBDIR = "partitions/qcs8300-ride-sx"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-8275-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"

--- a/conf/machine/qcs9075-iq-9075-evk.conf
+++ b/conf/machine/qcs9075-iq-9075-evk.conf
@@ -19,8 +19,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "cdt_rb8_core_kit"
 QCOM_BOOT_FILES_SUBDIR = "qcs9100"
-
-# FIXME provide device-specific table
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs9100-ride-sx/ufs"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-9075-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00096.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00096.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "4500b904d8195e89dd59c0d196e934b88c4737c57b5be20c60f156b8b73e9ddb"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00103.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00103.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "fb0f29a9d092ed127e6ea6eb6ef44332bfeb8fc487fc305b6a48fd65e053b78e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00095.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "9c100d7b184ecf0ab9c4be71a8bb7c243fdc79a64380ca3025024dd2b14c5078"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00103.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00103.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "74cde8a44295681a91a9033097343792b1111bb048c1d86f6a9584358e9d5442"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -18,3 +18,14 @@ SRC_URI[qcs8275-iq-8275-evk.sha256sum] = "070a61e6442316234b72af203c03a2cab82a1a
 QCOM_BOOT_IMG_SUBDIR = "qcs8300"
 
 include firmware-qcom-boot-common.inc
+
+do_deploy:append() {
+    if [ -d "${UNPACKDIR}/${BOOTBINARIES}/sail_nor" ]; then
+        SAIL_FILES="gpt_backup0.bin gpt_main0.bin prog_firehose_ddr.elf patch0.xml rawprogram0.xml sailhyp.elf sailsw1.elf"
+
+        install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/sail_nor
+        for sail_file in ${SAIL_FILES}; do
+            install -m 0644 ${UNPACKDIR}/${BOOTBINARIES}/sail_nor/${sail_file} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/sail_nor
+        done
+    fi
+}

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00095.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "463ffd7f20d243a5673ac49d744c8a35a3ab2067c3588be2741c2e6551f5a8f5"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00103.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00103.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "9928e12bf7d6eacc9e7059915f254e5e6276d6f84c136bc689fc6d6f7b1b019a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -21,7 +21,7 @@ include firmware-qcom-boot-common.inc
 
 do_deploy:append() {
     if [ -d "${UNPACKDIR}/${BOOTBINARIES}/sail_nor" ]; then
-        SAIL_FILES="gpt_backup0.bin gpt_main0.bin prog_firehose_ddr.elf patch0.xml rawprogram0.xml sailfreertos.elf"
+        SAIL_FILES="gpt_backup0.bin gpt_main0.bin prog_firehose_ddr.elf patch0.xml rawprogram0.xml sailhyp.elf sailsw1.elf"
 
         install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/sail_nor
         for sail_file in ${SAIL_FILES}; do

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00095.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00095.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "c201c9e966a706c9e76685ff4298f0940958c4d4877299eee1248ef26b809aa0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00103.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00103.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "efe9e256054eb07dd347059afb9f2989c47ec1214c2050012d9502e6a783e57f"

--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "abf334c24cb24140a8b5c4cc99b633a119244639"
+SRCREV = "f410a567c4913c6a6b719eb6ea8103f2cd5c6be0"
 
 INHIBIT_DEFAULT_DEPS = "1"
 

--- a/recipes-devtools/partition-utils/qcom-ptool_git.bb
+++ b/recipes-devtools/partition-utils/qcom-ptool_git.bb
@@ -9,7 +9,7 @@ RDEPENDS:${PN} += "python3-xml"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
 
-SRCREV = "abf334c24cb24140a8b5c4cc99b633a119244639"
+SRCREV = "f410a567c4913c6a6b719eb6ea8103f2cd5c6be0"
 
 PV = "0.0+git"
 


### PR DESCRIPTION
00103.0 release of boot bins has support for FIT based multi-DTB in UEFI. Start consuming this release to be able to enable this feature.