### PR TITLE
Update hexagon-dsp-binaries to the latest release

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-8275-evk-firmware \
+    packagegroup-iq-8275-evk-hexagon-dsp-binaries \
 "
 
 QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk"

--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs615-adp-air-firmware \
+    packagegroup-qcs615-adp-air-hexagon-dsp-binaries \
 "
 
 QCOM_CDT_FILE = "cdt_adp_air_sa6155p"

--- a/conf/machine/qcs9075-iq-9075-evk.conf
+++ b/conf/machine/qcs9075-iq-9075-evk.conf
@@ -13,8 +13,8 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    packagegroup-sa8775p-ride-firmware \
-    packagegroup-sa8775p-ride-hexagon-dsp-binaries \
+    packagegroup-iq-9075-evk-firmware \
+    packagegroup-iq-9075-evk-hexagon-dsp-binaries \
 "
 
 QCOM_CDT_FILE = "cdt_rb8_core_kit"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20250917.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20250917.bb
@@ -12,7 +12,7 @@ LICENSE = " \
 LIC_FILES_CHKSUM = "\
     file://LICENSE.qcom;md5=56e86b6c508490dadc343f39468b5f5e \
     file://LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0 \
-    file://WHENCE;md5=76bb6e36d4cc64bbc46a1be16f84b1b3 \
+    file://WHENCE;md5=cc95028da846699ee01c5383872edc92 \
 "
 NO_GENERIC_LICENSE[dspso-qcom] = "LICENSE.qcom"
 NO_GENERIC_LICENSE[dspso-qcom-2] = "LICENSE.qcom-2"
@@ -22,7 +22,7 @@ SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk \
 "
 
-SRCREV = "1d73849501371b6f4a0b9c6e897e848ccfe3c1d3"
+SRCREV = "89cd58272e40bd4e98239f6bc4daa9832e52e386"
 
 inherit allarch
 
@@ -36,6 +36,14 @@ do_install () {
 
 PACKAGES =+ "\
     ${PN}-qcom-db820c-adsp \
+    ${PN}-qcom-iq8275-evk-adsp \
+    ${PN}-qcom-iq8275-evk-cdsp \
+    ${PN}-qcom-iq8275-evk-gdsp \
+    ${PN}-qcom-iq9075-evk-adsp \
+    ${PN}-qcom-iq9075-evk-cdsp \
+    ${PN}-qcom-iq9075-evk-gdsp \
+    ${PN}-qcom-qcs615-ride-adsp \
+    ${PN}-qcom-qcs615-ride-cdsp \
     ${PN}-qcom-qcs8300-ride-adsp \
     ${PN}-qcom-qcs8300-ride-cdsp \
     ${PN}-qcom-qcs8300-ride-gdsp \
@@ -57,6 +65,14 @@ PACKAGES =+ "\
 
 LICENSE:${PN} = "dspso-WHENCE"
 LICENSE:${PN}-qcom-db820c-adsp = "dspso-qcom"
+LICENSE:${PN}-qcom-iq8275-evk-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq8275-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq8275-evk-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs615-ride-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs815-ride-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-qcs8300-ride-adsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-qcs8300-ride-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-qcs8300-ride-gdsp = "dspso-qcom-2"
@@ -76,6 +92,14 @@ LICENSE:${PN}-thundercomm-rb5-cdsp = "dspso-qcom"
 LICENSE:${PN}-thundercomm-rb5-sdsp = "dspso-qcom"
 
 RDEPENDS:${PN}-qcom-db820c-adsp = "linux-firmware-qcom-apq8096-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-adsp = "linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-cdsp = "linux-firmware-qcom-qcs8300-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-gdsp = "linux-firmware-qcom-qcs8300-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-adsp = "linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-cdsp = "linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-gdsp = "linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs615-ride-adsp = "linux-firmware-qcom-qcs615-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs615-ride-cdsp = "linux-firmware-qcom-qcs615-compute (= 1:${PV})"
 RDEPENDS:${PN}-qcom-qcs8300-ride-adsp = "linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
 RDEPENDS:${PN}-qcom-qcs8300-ride-cdsp = "linux-firmware-qcom-qcs8300-compute (= 1:${PV})"
 RDEPENDS:${PN}-qcom-qcs8300-ride-gdsp = "linux-firmware-qcom-qcs8300-generalpurpose (= 1:${PV})"
@@ -95,6 +119,14 @@ RDEPENDS:${PN}-thundercomm-rb5-cdsp = "linux-firmware-qcom-sm8250-compute (= 1:$
 RDEPENDS:${PN}-thundercomm-rb5-sdsp = "linux-firmware-qcom-sm8250-thundercomm-rb5-sensors (= 1:${PV})"
 
 FILES:${PN}-qcom-db820c-adsp = "${datadir}/qcom/apq8096/Qualcomm/db820c/dsp/adsp"
+FILES:${PN}-qcom-iq8275-evk-adsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp"
+FILES:${PN}-qcom-iq8275-evk-cdsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp*"
+FILES:${PN}-qcom-iq8275-evk-gdsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp*"
+FILES:${PN}-qcom-iq9075-evk-adsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp"
+FILES:${PN}-qcom-iq9075-evk-cdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp*"
+FILES:${PN}-qcom-iq9075-evk-gdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp*"
+FILES:${PN}-qcom-qcs615-ride-adsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/adsp"
+FILES:${PN}-qcom-qcs615-ride-cdsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/cdsp*"
 FILES:${PN}-qcom-qcs8300-ride-adsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp"
 FILES:${PN}-qcom-qcs8300-ride-cdsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp*"
 FILES:${PN}-qcom-qcs8300-ride-gdsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp*"
@@ -114,6 +146,8 @@ FILES:${PN}-thundercomm-rb5-cdsp = "${datadir}/qcom/sm8250/Thundercomm/RB5/dsp/c
 FILES:${PN}-thundercomm-rb5-sdsp = "${datadir}/qcom/sm8250/Thundercomm/RB5/dsp/sdsp"
 
 INSANE_SKIP:${PN}-qcom-db820c-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs615-ride-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs615-ride-cdsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:${PN}-qcom-qcs8300-ride-adsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:${PN}-qcom-qcs8300-ride-cdsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:${PN}-qcom-qcs8300-ride-gdsp = "arch libdir file-rdeps textrel"

--- a/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -14,4 +15,10 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-qcs8300-compute \
     linux-firmware-qcom-qcs8300-generalpurpose \
     linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-iq8275-evk-adsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-cdsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-gdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Packages for the IQ-9075-EVK platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
+    linux-firmware-qcom-qcs8300-audio \
+    linux-firmware-qcom-qcs8300-compute \
+    linux-firmware-qcom-qcs8300-generalpurpose \
+    linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-iq9075-evk-adsp \
+    hexagon-dsp-binaries-qcom-iq9075-evk-cdsp \
+    hexagon-dsp-binaries-qcom-iq9075-evk-gdsp \
+"

--- a/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs615-adp-air.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -11,4 +12,9 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
     linux-firmware-qcom-venus-5.4 \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-qcs615-ride-adsp \
+    hexagon-dsp-binaries-qcom-qcs615-ride-cdsp \
 "


### PR DESCRIPTION
Latest hexagon-dsp-binaries release provide packages for QCS615-RIDE, IQ8275-EVK and IQ9075-EVK platforms. 