### PR TITLE
qcom-adreno: Add runtime dependency on msm-gbm-backend

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.838.1.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.838.1.bb
@@ -31,8 +31,8 @@ RPROVIDES:${PN}-cl += "virtual-opencl-icd"
 RPROVIDES:${PN}-vulkan += "virtual-vulkan-icd"
 
 RDEPENDS:${PN}-common += " kgsl-dlkm"
-RDEPENDS:${PN}-egl += " ${PN}-common ${PN}-gles1 ${PN}-gles2"
-RDEPENDS:${PN}-vulkan += " ${PN}-common"
+RDEPENDS:${PN}-egl += " ${PN}-common ${PN}-gles1 ${PN}-gles2 msm-gbm-backend"
+RDEPENDS:${PN}-vulkan += " ${PN}-common msm-gbm-backend"
 RDEPENDS:${PN}-cl += " ${PN}-common"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
qcom-adreno doesn't have RDEPENDS on msm-gbm-backend due to which it is not being pulled into the image. Hence add RDEPENDS on msm-gbm-backend.