### PR TITLE
mesa: workaround build issue on OE-Core

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -8,3 +8,8 @@ PACKAGECONFIG_FREEDRENO = "\
 "
 
 PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"
+
+# Remove once the recipe in OE-Core gets dependency on Clang
+CLANG_DEP = ""
+CLANG_DEP:qcom = " clang"
+PACKAGECONFIG[opencl] = "-Dgallium-rusticl=true -Dmesa-clc-bundle-headers=enabled, -Dgallium-rusticl=false, bindgen-cli-native${CLANG_DEP}"


### PR DESCRIPTION
With the split of LLVM from Clang in OE-Core, building of OpenCL is broek because mesa recipe doesn't pull in Clang libs. While we are waiting for the fix to hit OE-Core, land temporal fix into meta-qcom.