### PR TITLE
ci: Add sota.yml for sota feature support

### DIFF
--- a/ci/sota.yml
+++ b/ci/sota.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+repos:
+  meta-updater:
+    url: https://github.com/uptane/meta-updater
+    branch: master
+
+local_conf_header:
+  extra: |
+    DISTRO_FEATURES:append = " sota"


### PR DESCRIPTION
Add ci/sota.yml to enable sota integration in CI by including the meta-updater repository(branch: master) for uptane-based support and appending sota to
DISTRO_FEATURES in local_conf_header for proper build configuration.