### PR TITLE
lttng: workaroud build issue on kernel 6.17.x

### DIFF
--- a/recipes-kernel/lttng/lttng-modules/0001-ring-buffer-clarify-requirement-for-disabled-page-fa.patch
+++ b/recipes-kernel/lttng/lttng-modules/0001-ring-buffer-clarify-requirement-for-disabled-page-fa.patch
@@ -1,0 +1,80 @@
+From 330651c1c896fe9991434fbe6849fb77daed4259 Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Wed, 10 Sep 2025 15:43:00 -0400
+Subject: [PATCH 1/6] ring buffer: clarify requirement for disabled page fault
+ handler
+
+The implementation is OK, but let's improve clarity about the need to
+call those functions with the page fault handler disabled.
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Change-Id: If30514085777d9b2225fd1513d77356510a6af6d
+---
+ include/ringbuffer/backend.h             |  6 +++---
+ src/lib/ringbuffer/ring_buffer_backend.c | 18 +++++++++---------
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/include/ringbuffer/backend.h b/include/ringbuffer/backend.h
+index ddcf8749..4f8ff598 100644
+--- a/include/ringbuffer/backend.h
++++ b/include/ringbuffer/backend.h
+@@ -170,9 +170,9 @@ size_t lib_ring_buffer_do_strcpy(const struct lttng_kernel_ring_buffer_config *c
+  * Returns the number of bytes copied. Does *not* terminate @dest with
+  * NULL terminating character.
+  *
+- * This function deals with userspace pointers, it should never be called
+- * directly without having the src pointer checked with access_ok()
+- * previously.
++ * This function deals with userspace pointers. It should be called
++ * after having the src pointer checked with access_ok() and with page
++ * fault handler disabled.
+  */
+ static inline __attribute__((always_inline))
+ size_t lib_ring_buffer_do_strcpy_from_user_inatomic(const struct lttng_kernel_ring_buffer_config *config,
+diff --git a/src/lib/ringbuffer/ring_buffer_backend.c b/src/lib/ringbuffer/ring_buffer_backend.c
+index b5ecde4d..f31a3c85 100644
+--- a/src/lib/ringbuffer/ring_buffer_backend.c
++++ b/src/lib/ringbuffer/ring_buffer_backend.c
+@@ -809,9 +809,9 @@ EXPORT_SYMBOL_GPL(_lib_ring_buffer_pstrcpy);
+  * @src : source address
+  * @len : length to write
+  *
+- * This function deals with userspace pointers, it should never be called
+- * directly without having the src pointer checked with access_ok()
+- * previously.
++ * This function deals with userspace pointers. It should be called
++ * after having the src pointer checked with access_ok() and with page
++ * fault handler disabled.
+  */
+ void _lib_ring_buffer_copy_from_user_inatomic(struct lttng_kernel_ring_buffer_backend *bufb,
+ 				      size_t offset, const void __user *src, size_t len)
+@@ -862,9 +862,9 @@ EXPORT_SYMBOL_GPL(_lib_ring_buffer_copy_from_user_inatomic);
+  * @len : length to write
+  * @pad : character to use for padding
+  *
+- * This function deals with userspace pointers, it should never be called
+- * directly without having the src pointer checked with access_ok()
+- * previously.
++ * This function deals with userspace pointers. It should be called
++ * after having the src pointer checked with access_ok() and with page
++ * fault handler disabled.
+  */
+ void _lib_ring_buffer_strcpy_from_user_inatomic(struct lttng_kernel_ring_buffer_backend *bufb,
+ 		size_t offset, const char __user *src, size_t len, int pad)
+@@ -952,9 +952,9 @@ EXPORT_SYMBOL_GPL(_lib_ring_buffer_strcpy_from_user_inatomic);
+  * The length of the pascal strings in the ring buffer is explicit: it
+  * is either the array or sequence length.
+  *
+- * This function deals with userspace pointers, it should never be called
+- * directly without having the src pointer checked with access_ok()
+- * previously.
++ * This function deals with userspace pointers. It should be called
++ * after having the src pointer checked with access_ok() and with page
++ * fault handler disabled.
+  */
+ void _lib_ring_buffer_pstrcpy_from_user_inatomic(struct lttng_kernel_ring_buffer_backend *bufb,
+ 			size_t offset, const char __user *src, size_t len, int pad)
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules/0002-Fix-Protect-syscall-probes-with-preemption-disable.patch
+++ b/recipes-kernel/lttng/lttng-modules/0002-Fix-Protect-syscall-probes-with-preemption-disable.patch
@@ -1,0 +1,109 @@
+From 79d7eda5a701a6cf388b1dabcd79e62c72fe1844 Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Wed, 1 Oct 2025 16:04:55 -0400
+Subject: [PATCH 2/6] Fix: Protect syscall probes with preemption disable
+
+Since kernel v6.13, the syscall tracepoints call the probes from
+faultable context (with preemption enabled).
+
+Adapt to this change to ensure that the LTTng-modules per-cpu data
+structures that expect preemption to be disabled don't get corrupted.
+
+This has been noticed through a linked list corruption of the
+lttng-tp-mempool per-cpu allocator.
+
+This only affects preemptible kernel configurations (PREEMPT,
+PREEMPT_LAZY).
+
+Non-preemptible kernel configurations are not affected (PREEMPT_NONE,
+PREEMPT_VOLOUNTARY).
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Change-Id: I67211e9f8ae96dce0e05a377827d606d1e54b0f8
+---
+ src/lttng-syscalls.c | 40 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/src/lttng-syscalls.c b/src/lttng-syscalls.c
+index 3548052f..c85b722c 100644
+--- a/src/lttng-syscalls.c
++++ b/src/lttng-syscalls.c
+@@ -33,6 +33,10 @@
+ #include <lttng/utils.h>
+ #include <lttng/kernel-version.h>
+ 
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,13,0))
++#include <linux/cleanup.h>
++#endif
++
+ #include "lttng-syscalls.h"
+ 
+ #ifndef CONFIG_COMPAT
+@@ -131,6 +135,15 @@ static void syscall_entry_event_unknown(struct hlist_head *unknown_action_list_h
+ 	unsigned long args[LTTNG_SYSCALL_NR_ARGS];
+ 	struct lttng_kernel_event_common_private *event_priv;
+ 
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,13,0))
++	/*
++	 * Starting with kernel v6.13, the syscall probes are called
++	 * with preemption enabled, but the ring buffer and per-cpu data
++	 * require preemption to be disabled.
++	 */
++	guard(preempt_notrace)();
++#endif
++
+ 	lttng_syscall_get_arguments(current, regs, args);
+ 	lttng_hlist_for_each_entry_rcu(event_priv, unknown_action_list_head, u.syscall.node) {
+ 		if (unlikely(in_compat_syscall()))
+@@ -249,6 +262,15 @@ void syscall_entry_event_probe(void *__data, struct pt_regs *regs, long id)
+ 	const struct trace_syscall_entry *table, *entry;
+ 	size_t table_len;
+ 
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,13,0))
++	/*
++	 * Starting with kernel v6.13, the syscall probes are called
++	 * with preemption enabled, but the ring buffer and per-cpu data
++	 * require preemption to be disabled.
++	 */
++	guard(preempt_notrace)();
++#endif
++
+ #ifdef CONFIG_X86_X32_ABI
+ 	if (in_x32_syscall()) {
+ 		/* x32 system calls are not supported. */
+@@ -306,6 +328,15 @@ static void syscall_exit_event_unknown(struct hlist_head *unknown_action_list_he
+ 	unsigned long args[LTTNG_SYSCALL_NR_ARGS];
+ 	struct lttng_kernel_event_common_private *event_priv;
+ 
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,13,0))
++	/*
++	 * Starting with kernel v6.13, the syscall probes are called
++	 * with preemption enabled, but the ring buffer and per-cpu data
++	 * require preemption to be disabled.
++	 */
++	guard(preempt_notrace)();
++#endif
++
+ 	lttng_syscall_get_arguments(current, regs, args);
+ 	lttng_hlist_for_each_entry_rcu(event_priv, unknown_action_list_head, u.syscall.node) {
+ 		if (unlikely(in_compat_syscall()))
+@@ -433,6 +464,15 @@ void syscall_exit_event_probe(void *__data, struct pt_regs *regs, long ret)
+ 	size_t table_len;
+ 	long id;
+ 
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,13,0))
++	/*
++	 * Starting with kernel v6.13, the syscall probes are called
++	 * with preemption enabled, but the ring buffer and per-cpu data
++	 * require preemption to be disabled.
++	 */
++	guard(preempt_notrace)();
++#endif
++
+ #ifdef CONFIG_X86_X32_ABI
+ 	if (in_x32_syscall()) {
+ 		/* x32 system calls are not supported. */
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules/0003-Fix-Add-wrapper-for-get_pfnblock_migatetype.patch
+++ b/recipes-kernel/lttng/lttng-modules/0003-Fix-Add-wrapper-for-get_pfnblock_migatetype.patch
@@ -1,0 +1,179 @@
+From 3fbc0fa29f4dd6df45e5816b49a12602b08235bb Mon Sep 17 00:00:00 2001
+From: Kienan Stewart <kstewart@efficios.com>
+Date: Tue, 30 Sep 2025 18:45:41 +0000
+Subject: [PATCH 3/6] Fix: Add wrapper for `get_pfnblock_migatetype`
+
+As of Linux v6.17, lttng-modules builds fail with the following error:
+
+```
+MODPOST Module.symvers
+ERROR: modpost: "get_pfnblock_migratetype" [probes/lttng-probe-kmem.ko] undefined!
+make[4]: *** [linux/v6.17/sources/scripts/Makefile.modpost:147: Module.symvers] Error 1
+```
+
+The `get_pageblock_migratetype` macro has changed to use
+`get_pfnblock_migratetype` rather than `get_pfnblock_flags_mask`.
+
+See upstream commit  42f46ed99ac6c07adf7f3bcbe9040b0c52d62d0f
+
+    commit 42f46ed99ac6c07adf7f3bcbe9040b0c52d62d0f
+    Author: Zi Yan <ziy@nvidia.com>
+    Date:   Mon Jun 16 22:11:09 2025 -0400
+
+        mm/page_alloc: pageblock flags functions clean up
+
+        Patch series "Make MIGRATE_ISOLATE a standalone bit", v10.
+
+        This patchset moves MIGRATE_ISOLATE to a standalone bit to avoid being
+        overwritten during pageblock isolation process.  Currently,
+        MIGRATE_ISOLATE is part of enum migratetype (in include/linux/mmzone.h),
+        thus, setting a pageblock to MIGRATE_ISOLATE overwrites its original
+        migratetype.  This causes pageblock migratetype loss during
+        alloc_contig_range() and memory offline, especially when the process fails
+        due to a failed pageblock isolation and the code tries to undo the
+        finished pageblock isolations.
+
+        In terms of performance for changing pageblock types, no performance
+        change is observed:
+
+        1. I used perf to collect stats of offlining and onlining all memory
+           of a 40GB VM 10 times and see that get_pfnblock_flags_mask() and
+           set_pfnblock_flags_mask() take about 0.12% and 0.02% of the whole
+           process respectively with and without this patchset across 3 runs.
+
+        2. I used perf to collect stats of dd from /dev/random to a 40GB tmpfs
+           file and find get_pfnblock_flags_mask() takes about 0.05% of the
+           process with and without this patchset across 3 runs.
+
+        This patch (of 6):
+
+        No functional change is intended.
+
+        1. Add __NR_PAGEBLOCK_BITS for the number of pageblock flag bits and use
+           roundup_pow_of_two(__NR_PAGEBLOCK_BITS) as NR_PAGEBLOCK_BITS to take
+           right amount of bits for pageblock flags.
+        2. Rename PB_migrate_skip to PB_compact_skip.
+        3. Add {get,set,clear}_pfnblock_bit() to operate one a standalone bit,
+           like PB_compact_skip.
+        3. Make {get,set}_pfnblock_flags_mask() internal functions and use
+           {get,set}_pfnblock_migratetype() for pageblock migratetype operations.
+        4. Move pageblock flags common code to get_pfnblock_bitmap_bitidx().
+        3. Use MIGRATETYPE_MASK to get the migratetype of a pageblock from its
+           flags.
+        4. Use PB_migrate_end in the definition of MIGRATETYPE_MASK instead of
+           PB_migrate_bits.
+        5. Add a comment on is_migrate_cma_folio() to prevent one from changing it
+           to use get_pageblock_migratetype() and causing issues.
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Change-Id: I81bc8e4384e57e805621fa4d2c12d0d0f17758b3
+Signed-off-by: Kienan Stewart <kstewart@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ include/instrumentation/events/kmem.h |  1 -
+ include/wrapper/page_alloc.h          | 24 +++++++++++++++++-
+ src/wrapper/page_alloc.c              | 36 ++++++++++++++++++++++++++-
+ 3 files changed, 58 insertions(+), 3 deletions(-)
+
+diff --git a/include/instrumentation/events/kmem.h b/include/instrumentation/events/kmem.h
+index b761a67b..3390f35f 100644
+--- a/include/instrumentation/events/kmem.h
++++ b/include/instrumentation/events/kmem.h
+@@ -470,7 +470,6 @@ LTTNG_TRACEPOINT_EVENT_MAP(mm_page_alloc_extfrag,
+ 			(alloc_migratetype == get_pageblock_migratetype(page)))
+ 	)
+ )
+-
+ #endif /* LTTNG_TRACE_KMEM_H */
+ 
+ /* This part must be outside protection */
+diff --git a/include/wrapper/page_alloc.h b/include/wrapper/page_alloc.h
+index 8efe406f..d76aac9c 100644
+--- a/include/wrapper/page_alloc.h
++++ b/include/wrapper/page_alloc.h
+@@ -20,7 +20,6 @@
+  * the get_pageblock_migratetype() macro uses it.
+  */
+ #ifdef CONFIG_KALLSYMS
+-
+ #define get_pfnblock_flags_mask		wrapper_get_pfnblock_flags_mask
+ 
+ #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,14,0))
+@@ -50,4 +49,27 @@ int wrapper_get_pfnblock_flags_mask_init(void)
+ 
+ #endif
+ 
++/*
++ * We need to redefine get_pfnblock_migratetype to our wrapper because
++ * the get_pageblock_migratetype() macro uses it.
++ */
++#ifdef CONFIG_KALLSYMS
++#define get_pfnblock_migratetype	wrapper_get_pfnblock_migratetype
++
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0))
++enum migratetype wrapper_get_pfnblock_migratetype(const struct page *page,
++		unsigned long pfn);
++int wrapper_get_pfnblock_migratetype_init(void);
++
++#else
++
++static inline
++int wrapper_get_pfnblock_migratetype_init(void)
++{
++	return 0;
++}
++#endif /* else LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0) */
++
++#endif /* else CONFIG_KALLSYMS */
++
+ #endif /* _LTTNG_WRAPPER_PAGE_ALLOC_H */
+diff --git a/src/wrapper/page_alloc.c b/src/wrapper/page_alloc.c
+index 69988e66..011eef81 100644
+--- a/src/wrapper/page_alloc.c
++++ b/src/wrapper/page_alloc.c
+@@ -106,7 +106,41 @@ int wrapper_get_pfnblock_flags_mask_init(void)
+ }
+ EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_flags_mask_init);
+ 
+-#else
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0))
++static
++enum migratetype (*get_pfnblock_migratetype_sym)(const struct page *page,
++		unsigned long pfn);
++
++enum migratetype wrapper_get_pfnblock_migratetype(const struct page *page,
++		unsigned long pfn)
++{
++	WARN_ON_ONCE(!get_pfnblock_migratetype_sym);
++	if (get_pfnblock_migratetype_sym) {
++		struct irq_ibt_state irq_ibt_state;
++		enum migratetype ret;
++
++		irq_ibt_state = wrapper_irq_ibt_save();
++		ret = get_pfnblock_migratetype_sym(page, pfn);
++		wrapper_irq_ibt_restore(irq_ibt_state);
++		return ret;
++	}
++	return -ENOSYS;
++}
++
++int wrapper_get_pfnblock_migratetype_init(void)
++{
++	get_pfnblock_migratetype_sym =
++		(void *) kallsyms_lookup_funcptr("get_pfnblock_migratetype");
++	if (!get_pfnblock_migratetype_sym)
++		return -1;
++	return 0;
++}
++
++EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_migratetype);
++EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_migratetype_init);
++#endif /* LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0) */
++
++#else /* CONFIG_KALLSYMS */
+ 
+ #include <linux/pageblock-flags.h>
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules/0004-fix-remove-duplicated-MODULE-macros.patch
+++ b/recipes-kernel/lttng/lttng-modules/0004-fix-remove-duplicated-MODULE-macros.patch
@@ -1,0 +1,66 @@
+From 622d33aa5262dc8296155ff4dc67ca7371bc0278 Mon Sep 17 00:00:00 2001
+From: Michael Jeanson <mjeanson@efficios.com>
+Date: Wed, 8 Oct 2025 11:29:40 -0400
+Subject: [PATCH 4/6] fix: remove duplicated MODULE macros
+
+The lttng-tracer.ko module has multiple source files defining the
+'MODULE_' macros resulting in duplicated metadata in the modinfo. Keep
+only one set of macros in 'src/lttng-events.c'.
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Change-Id: I55c2b9ee48956b7759db23073fac1babd8894c3d
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ src/lttng-kprobes.c    | 8 --------
+ src/lttng-kretprobes.c | 8 --------
+ src/lttng-uprobes.c    | 4 ----
+ 3 files changed, 20 deletions(-)
+
+diff --git a/src/lttng-kprobes.c b/src/lttng-kprobes.c
+index 75eb4141..c3b3d8c9 100644
+--- a/src/lttng-kprobes.c
++++ b/src/lttng-kprobes.c
+@@ -240,11 +240,3 @@ void lttng_kprobes_destroy_event_private(struct lttng_kernel_event_common *event
+ 	kfree(event->priv->desc->event_name);
+ 	kfree(event->priv->desc);
+ }
+-
+-MODULE_LICENSE("GPL and additional rights");
+-MODULE_AUTHOR("Mathieu Desnoyers <mathieu.desnoyers@efficios.com>");
+-MODULE_DESCRIPTION("LTTng kprobes probes");
+-MODULE_VERSION(__stringify(LTTNG_MODULES_MAJOR_VERSION) "."
+-	__stringify(LTTNG_MODULES_MINOR_VERSION) "."
+-	__stringify(LTTNG_MODULES_PATCHLEVEL_VERSION)
+-	LTTNG_MODULES_EXTRAVERSION);
+diff --git a/src/lttng-kretprobes.c b/src/lttng-kretprobes.c
+index 7bc38499..15d6fed4 100644
+--- a/src/lttng-kretprobes.c
++++ b/src/lttng-kretprobes.c
+@@ -330,11 +330,3 @@ void lttng_kretprobes_destroy_event_private(struct lttng_kernel_event_common *ev
+ 	kfree(event->priv->desc);
+ 	lttng_kretprobes_put_krp(event->priv->u.kretprobe.lttng_krp);
+ }
+-
+-MODULE_LICENSE("GPL and additional rights");
+-MODULE_AUTHOR("Mathieu Desnoyers <mathieu.desnoyers@efficios.com>");
+-MODULE_DESCRIPTION("LTTng kretprobes probes");
+-MODULE_VERSION(__stringify(LTTNG_MODULES_MAJOR_VERSION) "."
+-	__stringify(LTTNG_MODULES_MINOR_VERSION) "."
+-	__stringify(LTTNG_MODULES_PATCHLEVEL_VERSION)
+-	LTTNG_MODULES_EXTRAVERSION);
+diff --git a/src/lttng-uprobes.c b/src/lttng-uprobes.c
+index cb9b1663..39c09b8f 100644
+--- a/src/lttng-uprobes.c
++++ b/src/lttng-uprobes.c
+@@ -371,7 +371,3 @@ void lttng_uprobes_destroy_event_private(struct lttng_kernel_event_common *event
+ 	kfree(event->priv->desc->event_name);
+ 	kfree(event->priv->desc);
+ }
+-
+-MODULE_LICENSE("GPL and additional rights");
+-MODULE_AUTHOR("Yannick Brosseau");
+-MODULE_DESCRIPTION("Linux Trace Toolkit Uprobes Support");
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules/0005-fix-get_pfnblock_flags_mask-get_pfnblock_migratetype.patch
+++ b/recipes-kernel/lttng/lttng-modules/0005-fix-get_pfnblock_flags_mask-get_pfnblock_migratetype.patch
@@ -1,0 +1,156 @@
+From e3c5819c4a45e088fd24f193a7f08716414539fe Mon Sep 17 00:00:00 2001
+From: Michael Jeanson <mjeanson@efficios.com>
+Date: Wed, 8 Oct 2025 15:12:25 -0400
+Subject: [PATCH 5/6] fix: get_pfnblock_flags_mask / get_pfnblock_migratetype
+ wrappers for v6.17
+
+* Add a version gate for the get_pfnblock_flags_mask wrapper as the
+  symbol was removed in v6.17 and thus initialization would always fail
+  preventing the modules load.
+* Add missing initialization of the get_pfnblock_migratetype wrapper
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Change-Id: I5ab3babade87ca501018d91ea2fd04239b9e5d27
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ include/wrapper/page_alloc.h | 11 +++++++----
+ src/lttng-events.c           |  5 +++++
+ src/wrapper/page_alloc.c     | 16 ++++++++++------
+ 3 files changed, 22 insertions(+), 10 deletions(-)
+
+diff --git a/include/wrapper/page_alloc.h b/include/wrapper/page_alloc.h
+index d76aac9c..af8a8f68 100644
+--- a/include/wrapper/page_alloc.h
++++ b/include/wrapper/page_alloc.h
+@@ -15,11 +15,13 @@
+ #include <linux/mm_types.h>
+ #include <lttng/kernel-version.h>
+ 
++#if defined(CONFIG_KALLSYMS) && \
++	(LTTNG_LINUX_VERSION_CODE < LTTNG_KERNEL_VERSION(6,17,0))
++
+ /*
+  * We need to redefine get_pfnblock_flags_mask to our wrapper, because
+  * the get_pageblock_migratetype() macro uses it.
+  */
+-#ifdef CONFIG_KALLSYMS
+ #define get_pfnblock_flags_mask		wrapper_get_pfnblock_flags_mask
+ 
+ #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,14,0))
+@@ -49,14 +51,16 @@ int wrapper_get_pfnblock_flags_mask_init(void)
+ 
+ #endif
+ 
++
++#if defined(CONFIG_KALLSYMS) && \
++	(LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0))
++
+ /*
+  * We need to redefine get_pfnblock_migratetype to our wrapper because
+  * the get_pageblock_migratetype() macro uses it.
+  */
+-#ifdef CONFIG_KALLSYMS
+ #define get_pfnblock_migratetype	wrapper_get_pfnblock_migratetype
+ 
+-#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0))
+ enum migratetype wrapper_get_pfnblock_migratetype(const struct page *page,
+ 		unsigned long pfn);
+ int wrapper_get_pfnblock_migratetype_init(void);
+@@ -68,7 +72,6 @@ int wrapper_get_pfnblock_migratetype_init(void)
+ {
+ 	return 0;
+ }
+-#endif /* else LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0) */
+ 
+ #endif /* else CONFIG_KALLSYMS */
+ 
+diff --git a/src/lttng-events.c b/src/lttng-events.c
+index 93057d3c..58240e41 100644
+--- a/src/lttng-events.c
++++ b/src/lttng-events.c
+@@ -3579,6 +3579,11 @@ static int __init lttng_events_init(void)
+ 	ret = wrapper_get_pfnblock_flags_mask_init();
+ 	if (ret)
+ 		return ret;
++
++	ret = wrapper_get_pfnblock_migratetype_init();
++	if (ret)
++		return ret;
++
+ 	ret = lttng_probes_init();
+ 	if (ret)
+ 		return ret;
+diff --git a/src/wrapper/page_alloc.c b/src/wrapper/page_alloc.c
+index 011eef81..32f26c81 100644
+--- a/src/wrapper/page_alloc.c
++++ b/src/wrapper/page_alloc.c
+@@ -21,7 +21,9 @@
+ #include <wrapper/kallsyms.h>
+ #include <lttng/kernel-version.h>
+ 
+-#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,14,0))
++/* get_pfnblock_flags_mask() was removed in 6.17 */
++#if (LTTNG_LINUX_VERSION_CODE < LTTNG_KERNEL_VERSION(6,17,0))
++# if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,14,0))
+ static
+ unsigned long (*get_pfnblock_flags_mask_sym)(const struct page *page,
+ 		unsigned long pfn,
+@@ -44,7 +46,7 @@ unsigned long wrapper_get_pfnblock_flags_mask(const struct page *page,
+ 		return -ENOSYS;
+ 	}
+ }
+-#elif (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0))
++# elif (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0))
+ static
+ unsigned long (*get_pfnblock_flags_mask_sym)(struct page *page,
+ 		unsigned long pfn,
+@@ -67,7 +69,7 @@ unsigned long wrapper_get_pfnblock_flags_mask(struct page *page,
+ 		return -ENOSYS;
+ 	}
+ }
+-#else	/* #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0)) */
++# else	/* #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0)) */
+ static
+ unsigned long (*get_pfnblock_flags_mask_sym)(struct page *page,
+ 		unsigned long pfn,
+@@ -92,7 +94,7 @@ unsigned long wrapper_get_pfnblock_flags_mask(struct page *page,
+ 		return -ENOSYS;
+ 	}
+ }
+-#endif /* #else #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0)) */
++# endif /* #else #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,9,0)) */
+ 
+ EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_flags_mask);
+ 
+@@ -105,7 +107,10 @@ int wrapper_get_pfnblock_flags_mask_init(void)
+ 	return 0;
+ }
+ EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_flags_mask_init);
++#endif
++
+ 
++/* get_pfnblock_migratetype() was introduced in 6.17 */
+ #if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0))
+ static
+ enum migratetype (*get_pfnblock_migratetype_sym)(const struct page *page,
+@@ -126,6 +131,7 @@ enum migratetype wrapper_get_pfnblock_migratetype(const struct page *page,
+ 	}
+ 	return -ENOSYS;
+ }
++EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_migratetype);
+ 
+ int wrapper_get_pfnblock_migratetype_init(void)
+ {
+@@ -135,8 +141,6 @@ int wrapper_get_pfnblock_migratetype_init(void)
+ 		return -1;
+ 	return 0;
+ }
+-
+-EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_migratetype);
+ EXPORT_SYMBOL_GPL(wrapper_get_pfnblock_migratetype_init);
+ #endif /* LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(6,17,0) */
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules/0006-fix-always-print-to-kernel-log-on-module-load-failur.patch
+++ b/recipes-kernel/lttng/lttng-modules/0006-fix-always-print-to-kernel-log-on-module-load-failur.patch
@@ -1,0 +1,54 @@
+From 1bdcdf525d453a985b61cf8fdc300d7831728793 Mon Sep 17 00:00:00 2001
+From: Michael Jeanson <mjeanson@efficios.com>
+Date: Wed, 8 Oct 2025 15:25:47 -0400
+Subject: [PATCH 6/6] fix: always print to kernel log on module load failure
+
+Upstream-Status: Inappropriate [for 2.14.1 only]
+Change-Id: I1c52c926e340eef7de0836c5169c2d58a6ac7fee
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ src/lttng-events.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/src/lttng-events.c b/src/lttng-events.c
+index 58240e41..bc9eca85 100644
+--- a/src/lttng-events.c
++++ b/src/lttng-events.c
+@@ -3578,18 +3578,20 @@ static int __init lttng_events_init(void)
+ 
+ 	ret = wrapper_get_pfnblock_flags_mask_init();
+ 	if (ret)
+-		return ret;
++		goto error;
+ 
+ 	ret = wrapper_get_pfnblock_migratetype_init();
+ 	if (ret)
+-		return ret;
++		goto error;
+ 
+ 	ret = lttng_probes_init();
+ 	if (ret)
+-		return ret;
++		goto error;
++
+ 	ret = lttng_context_init();
+ 	if (ret)
+-		return ret;
++		goto error;
++
+ 	ret = lttng_tracepoint_init();
+ 	if (ret)
+ 		goto error_tp;
+@@ -3673,6 +3675,8 @@ error_kmem_event_recorder:
+ 	lttng_tracepoint_exit();
+ error_tp:
+ 	lttng_context_exit();
++
++error:
+ 	printk(KERN_NOTICE "LTTng: Failed to load modules v%s.%s.%s%s (%s)%s%s\n",
+ 		__stringify(LTTNG_MODULES_MAJOR_VERSION),
+ 		__stringify(LTTNG_MODULES_MINOR_VERSION),
+-- 
+2.34.1
+

--- a/recipes-kernel/lttng/lttng-modules_2.14.1.bbappend
+++ b/recipes-kernel/lttng/lttng-modules_2.14.1.bbappend
@@ -1,0 +1,16 @@
+python __anonymous() {
+    bb.warn("meta-qcom bbappend for lttng-modules is active")
+}
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+
+SRC_URI += " \
+    file://0001-ring-buffer-clarify-requirement-for-disabled-page-fa.patch \
+    file://0002-Fix-Protect-syscall-probes-with-preemption-disable.patch \
+    file://0003-Fix-Add-wrapper-for-get_pfnblock_migatetype.patch \
+	file://0004-fix-remove-duplicated-MODULE-macros.patch \
+	file://0005-fix-get_pfnblock_flags_mask-get_pfnblock_migratetype.patch \
+	file://0006-fix-always-print-to-kernel-log-on-module-load-failur.patch \
+"
+


### PR DESCRIPTION
lttng-moduels_2.14.1 has a build issue on kernel 6.17.x, and version 2.14.2 fixs this. waiting for oe-core updating lltng-modules to 2.14.2 wasts too much time, so use this workaroud approach until oe-core updates lttng-modules to version 2.14.2.