### PR TITLE
u-boot: update compile append to use builddir 

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -8,7 +8,7 @@ COMPILE_EXTRA_DEPENDS:qcom = "virtual/kernel:do_deploy"
 do_compile[depends] += "${COMPILE_EXTRA_DEPENDS}"
 
 uboot_compile_config:append:qcom() {
-    cd ${B}/${config}
+    cd ${B}/${builddir}
     touch empty-file
     rm -f u-boot-nodtb.bin.gz
     gzip -k u-boot-nodtb.bin


### PR DESCRIPTION
oe-core [1] updated the default build path to be unique for each
UBOOT_CONFIG, so update local append to use the new builddir
variable instead of the old config one.

[1] https://git.openembedded.org/openembedded-core/commit/?id=22e96b32b0be02ec0971c9334d4b1df7c9ef8d84