### PR TITLE
initramfs-firmware-sm8650-hdk: add sm8550 packagegroup as opkg w/around

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-sm8650-hdk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8650-hdk-image.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Tiny ramdisk image with SM8650 HDK devices firmware files"
 
 PACKAGE_INSTALL += " \
     packagegroup-sm8650-hdk-firmware \
+    packagegroup-sm8550-hdk-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \


### PR DESCRIPTION
There is a memory bug somewhere in opkg/libsolv, which results in a crash when building this image. Add sm8550 packagegroup as a "simple" workaround for the issue.

For the record (without debug symbols, but sill):

$ valgrind \
/work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/bin/opkg --volatile-cache \ -f \
/work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/opkg.conf \ -t \
/work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/temp/ipktemp/ \ -o \
/work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/rootfs \ --force-postinstall \
--prefer-arch-to-version  install packagegroup-sm8650-hdk-firmware

[...]

==2937== Invalid read of size 1
==2937==    at 0x4B50D20: stringpool_strn2id (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x4B4A3DB: pool_str2id (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x487936C: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x487A17C: opkg_solver_install (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x4865731: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x4865DB1: opkg_cmd_exec (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x10AA4C: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/bin/opkg)
==2937==    by 0x48AFF67: (below main) (in /work/build/tmp/sysroots-uninative/x86_64-linux/lib/libc.so.6)
==2937==  Address 0xe1b5728 is 219,928 bytes inside a block of size 458,752 free'd
==2937==    at 0x484C82F: realloc (vg_replace_malloc.c:1437)
==2937==    by 0x4B835FD: solv_realloc (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x4B50C86: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x4B50F26: stringpool_strn2id (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x4B4A3DB: pool_str2id (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libsolv.so.1)
==2937==    by 0x487936C: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x487A17C: opkg_solver_install (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x4865731: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x4865DB1: opkg_cmd_exec (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/lib/libopkg.so.1.0.0)
==2937==    by 0x10AA4C: ??? (in /work/build/tmp/work/qcom_armv8a-qcom-linux/initramfs-firmware-sm8650-hdk-image/1.0/recipe-sysroot-native/usr/bin/opkg)
==2937==    by 0x48AFF67: (below main) (in /work/build/tmp/sysroots-uninative/x86_64-linux/lib/libc.so.6)