### PR TITLE
ci/base: drop buildstats from inherit

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -30,7 +30,7 @@ repos:
 local_conf_header:
   base: |
     CONF_VERSION = "2"
-    INHERIT += "buildstats buildstats-summary"
+    INHERIT += "buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
   cmdline: |


### PR DESCRIPTION
Th buildstats is now [1] enabled by default

[1] https://git.openembedded.org/openembedded-core/commit/?id=b297c9d6168e3906b581387f1d731ea95e17dd83