### PR TITLE
recipes-connectivity: wpa-supplicant: enable 802.11be, MBO, OWE

### DIFF
--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,8 @@
+do_configure:append:qcom() {
+        if ${@ bb.utils.contains('PACKAGECONFIG', 'openssl', 'true', 'false', d) }; then
+                sed -i -e 's/^#\(CONFIG_OWE=y\)/\1/' wpa_supplicant/.config
+        fi
+
+        sed -i -e 's/^#\(CONFIG_IEEE80211BE=y\)/\1/' \
+               -e 's/^#\(CONFIG_MBO=y\)/\1/' wpa_supplicant/.config
+}


### PR DESCRIPTION
wpa_supplicant has supported IEEE 802.11be (Wi-Fi 7) for over three years. With growing market demand for Wi-Fi 7, it is now an appropriate time to enable IEEE 802.11be Extremely High Throughput (EHT) support.

This patch also enables the following features:
Opportunistic Wireless Encryption (OWE)
Multi Band Operation (MBO)