### PR TITLE
ci: fix path in qcom-distro LAVA jobs

### DIFF
--- a/ci/lava/qcom-distro/dragonboard-410c/boot.yaml
+++ b/ci/lava/qcom-distro/dragonboard-410c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/qcom-armv8a/boot-apq8016-sbc-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/boot-apq8016-sbc-qcom-armv8a.img"
       rootfs:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:

--- a/ci/lava/qcom-distro/dragonboard-820c/boot.yaml
+++ b/ci/lava/qcom-distro/dragonboard-820c/boot.yaml
@@ -7,11 +7,11 @@ actions:
       boot:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/qcom-armv8a/boot-apq8096-db820c-qcom-armv8a.img"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/boot-apq8096-db820c-qcom-armv8a.img"
       rootfs:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:

--- a/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/poky-altcfg/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main


### PR DESCRIPTION
LAVA jobs for qcom-distro builds used poky-altcfg path. This patch fixes the mitake which originated from copying test job files.