### PR TITLE
qcs615-adp-air: update the default storage type

### DIFF
--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -18,4 +18,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "cdt_adp_air_sa6155p"
 QCOM_BOOT_FILES_SUBDIR = "qcs615"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs615-adp-air/ufs"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs615-adp-air/emmc"


### PR DESCRIPTION
Set the default storage variant to emmc for qcs615-adp-air