### PR TITLE
ci: fix URLs for qcom-distro images

### DIFF
--- a/ci/lava/qcom-distro/README.md
+++ b/ci/lava/qcom-distro/README.md
@@ -16,7 +16,7 @@ This happens for the following triggers:
 Job templates can use the following variables:
  - `DEVICE_TYPE`: name of the LAVA device type or alias. Full list can be found on [LAVA master web interface](https://lava.infra.foundries.io/scheduler/device_types)
  - `GITHUB_SHA`: Commit ID corresponding to the github action trigger
- - `BUILD_FILE_NAME`: Name of the build artifact to be downloaded. It's constructed as: `core-image-base-${DEVICE_TYPE}.rootfs.qcomflash.tar.gz`
+ - `BUILD_FILE_NAME`: Name of the build artifact to be downloaded. It's constructed as: `qcom-multimedia-image-${DEVICE_TYPE}.rootfs.qcomflash.tar.gz`
  - `BUILD_DOWNLOAD_URL`: URL where the build artifacts can be found. This variable is constructed as: `${{inputs.url}}/${DEVICE_TYPE}/${BUILD_FILE_NAME}` where `{{inputs.url}}` comes from the build action.
  - `GITHUB_RUN_ID`: ID of the current Github run.
 

--- a/ci/lava/qcom-distro/dragonboard-410c/boot.yaml
+++ b/ci/lava/qcom-distro/dragonboard-410c/boot.yaml
@@ -11,14 +11,14 @@ actions:
       rootfs:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/qcom-multimedia-image-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
         steps:
         - export IMAGE_PATH=$PWD
-        - img2simg core-image-base-qcom-armv8a.rootfs.ext4 core-image-base-qcom-armv8a.rootfs.img
+        - img2simg qcom-multimedia-image-qcom-armv8a.rootfs.ext4 qcom-multimedia-image-qcom-armv8a.rootfs.img
 - deploy:
     timeout:
       minutes: 15
@@ -27,7 +27,7 @@ actions:
       boot:
         url: downloads://boot-apq8016-sbc-qcom-armv8a.img
       rootfs:
-        url: downloads://core-image-base-qcom-armv8a.rootfs.img
+        url: downloads://qcom-multimedia-image-qcom-armv8a.rootfs.img
         apply-overlay: true
 - command:
     name: pre_power_command

--- a/ci/lava/qcom-distro/dragonboard-820c/boot.yaml
+++ b/ci/lava/qcom-distro/dragonboard-820c/boot.yaml
@@ -11,14 +11,14 @@ actions:
       rootfs:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/core-image-base-qcom-armv8a.rootfs.ext4.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/qcom-armv8a/qcom-multimedia-image-qcom-armv8a.rootfs.ext4.gz"
         compression: gz
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
         steps:
         - export IMAGE_PATH=$PWD
-        - img2simg core-image-base-qcom-armv8a.rootfs.ext4 core-image-base-qcom-armv8a.rootfs.img
+        - img2simg qcom-multimedia-image-qcom-armv8a.rootfs.ext4 qcom-multimedia-image-qcom-armv8a.rootfs.img
 - deploy:
     timeout:
       minutes: 15
@@ -27,7 +27,7 @@ actions:
       boot:
         url: downloads://boot-apq8096-db820c-qcom-armv8a.img
       rootfs:
-        url: downloads://core-image-base-qcom-armv8a.rootfs.img
+        url: downloads://qcom-multimedia-image-qcom-armv8a.rootfs.img
         apply-overlay: true
 - command:
     name: pre_power_command

--- a/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
@@ -21,7 +21,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+        url: downloads://qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:

--- a/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
@@ -21,7 +21,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+        url: downloads://qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:

--- a/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
@@ -21,7 +21,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+        url: downloads://qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:

--- a/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
@@ -21,7 +21,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+        url: downloads://qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:

--- a/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-distro/{{DEVICE_TYPE}}/qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main
@@ -21,7 +21,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://core-image-base-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
+        url: downloads://qcom-multimedia-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:


### PR DESCRIPTION
File name for qcom-distro images start with qcom-multimedia-image. This patch fixes the broken names after adding jobs for qcom-distro.