### PR TITLE
ci: yocto-check-layer: silent git hint

### DIFF
--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -25,7 +25,7 @@ _is_dir "$WORK_DIR"
 # script to avoid a contaminated environment.
 BUILDDIR="$(mktemp -p $WORK_DIR -d -t build-yocto-check-layer-XXXX)"
 source $WORK_DIR/oe-core/oe-init-build-env $BUILDDIR
-git -c advice.detachedHead=false clone --quiet --shared $REPO_DIR meta-qcom
+git -c advice.detachedHead=false -c init.defaultBranch=master clone --quiet --shared $REPO_DIR meta-qcom
 
 # Yocto Project layer checking tool
 CMD="yocto-check-layer"


### PR DESCRIPTION
```
hint: Using 'master' as the name for the initial branch. This default branch name hint: is subject to change. To configure the initial branch name to use in all hint: of your new repositories, which will suppress this warning, call: hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and hint: 'development'. The just-created branch can be renamed via this command: hint:
hint: 	git branch -m <name>
```