### PR TITLE
README: Use shields.io to fix broken badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # meta-qcom
 
-[![Build on push](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml/badge.svg)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml)
-[![Nightly Build](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml/badge.svg)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml)
+![Build on push](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml)
+![Nightly Build](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml)
 
 ## Introduction
 


### PR DESCRIPTION
GitHub badges require authentication for projects that one is a member of. Members of the project who should really see these badges will have to login with GitHub before seeing these. Use shields.io as a badge proxying and caching service.

Largely based on https://github.com/qualcomm-linux/qcom-deb-images/pull/189

Suggested-by: Loïc Minier <loic.minier@oss.qualcomm.com>