### PR TITLE
workflows: mark workflow failed when tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,6 @@ jobs:
           echo $GITHUB_WORKSPACE
           ls -R $GITHUB_WORKSPACE
 
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          files: "${{ github.workspace }}/artifacts/**/*.xml"
-
       - name: Publish Test Job Details
         run: |
           for json_file in $(find ${{ github.workspace }} -name "test-job-*.json")
@@ -146,3 +141,10 @@ jobs:
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)"
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)" >> $GITHUB_STEP_SUMMARY
           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "${{ github.workspace }}/artifacts/**/*.xml"
+          action_fail: true
+          action_fail_on_inconclusive: true


### PR DESCRIPTION
When tests fail the workflow should be marked as failed. This change allows reporting action to mark worflow as failed when:
 - test results are missing
 - there are failed tests in results