### PR TITLE
Revert "mesa: workaround build issue on OE-Core"

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -8,8 +8,3 @@ PACKAGECONFIG_FREEDRENO = "\
 "
 
 PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"
-
-# Remove once the recipe in OE-Core gets dependency on Clang
-CLANG_DEP = ""
-CLANG_DEP:qcom = " clang"
-PACKAGECONFIG[opencl] = "-Dgallium-rusticl=true -Dmesa-clc-bundle-headers=enabled, -Dgallium-rusticl=false, bindgen-cli-native${CLANG_DEP}"


### PR DESCRIPTION
This reverts commit a1903fc022ed ("mesa: workaround build issue on OE-Core"), the fix is now a part of OE-Core.