### PR TITLE
qcbor: library to expose Qualcomm Security Package

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-extended/qcbor/qcbor_1.5.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-extended/qcbor/qcbor_1.5.3.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = " \
+    QCBOR is a powerful, commercial-quality CBOR encoder/decoder that \
+    implements these RFCs: RFC8949, RFC7049, RFC8742, RFC8943 \
+"
+
+HOMEPAGE = "https://github.com/laurencelundblade/QCBOR"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=9abe2371333f4ab0e62402a486f308a5"
+
+SRC_URI = "git://github.com/laurencelundblade/QCBOR;protocol=https;branch=master;tag=v${PV}"
+
+SRCREV = "4ace4620d549f22c1163c5b00d3ae0c0dae1d207"
+
+
+inherit pkgconfig
+
+CFLAGS += " \
+    -DUSEFULBUF_DISABLE_ALL_FLOAT \
+"
+
+do_install(){
+    install -d ${D}${libdir}
+    install -m 755 ${S}/libqcbor.a ${D}${libdir}/
+    install -d ${D}${includedir}/qcbor
+    install -m 644 ${S}/inc/*.h ${D}${includedir}
+    install -m 644 ${S}/inc/qcbor/*.h ${D}${includedir}/qcbor
+}


### PR DESCRIPTION
Add a recipe to build qcbor, library to work with security functionality on Qualcomm platforms.

The libqcbor, which are only available through meta-oe, is depended by Qcom-teec and MinkIPC. Thus add libqcbor recipe to the corresponding dynamic-layers subdir.

The qcbor library is used for decoding and encoding data structures.