### PR TITLE
qcom-tee: add a library for security feature support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/qcomtee/qcomtee_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/qcomtee/qcomtee_git.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Qualcomm qcom-tee library"
+DESCRIPTION = " \
+QCOM-TEE Library provides an interface for communication to \
+the Qualcomm Trusted Execution Environment (QTEE) via the \
+QCOM-TEE driver registered with the Linux TEE subsystem. \
+"
+HOMEPAGE = "https://github.com/quic/quic-teec.git"
+SECTION = "libs"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93"
+
+inherit cmake
+
+SRC_URI = "git://github.com/quic/quic-teec.git;branch=main;protocol=https"
+SRCREV = "a40de2d23dc04f2fad144315848c31e70c869d3d"
+PV = "0.0+git"
+
+DEPENDS += "qcbor"


### PR DESCRIPTION
The QCOM-TEE library introduces an interface that facilitates secure communication with QTEE, supporting security feature integration.
Add the qcom-tee library to dynamic-layer because it depends on the qcobr library from the meta-openembedded dynamic layer.