### PR TITLE
linux-yocto-6.16: import patch, hopefully fixing issues with db820c

### DIFF
--- a/recipes-kernel/linux/linux-yocto-6.16/workarounds/f553aff9a3ab245e722349cc617bcdfe778c69af.patch
+++ b/recipes-kernel/linux/linux-yocto-6.16/workarounds/f553aff9a3ab245e722349cc617bcdfe778c69af.patch
@@ -1,0 +1,29 @@
+From f553aff9a3ab245e722349cc617bcdfe778c69af Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Thu, 13 Jul 2023 23:38:44 +0200
+Subject: [PATCH] arm64: dts: qcom: apq8096-db820c: keep s2 regulator always on
+
+Needed to keep the GPU alive in our farm setup.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Signed-off-by: David Heidelberg <david@ixit.cz>
+Upstream-Status: Inappropriate [lame workaround instead of CPR3 driver]
+---
+ arch/arm64/boot/dts/qcom/apq8096-db820c.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/apq8096-db820c.dts b/arch/arm64/boot/dts/qcom/apq8096-db820c.dts
+index 5b2e88915c2f..e74c9fb8f559 100644
+--- a/arch/arm64/boot/dts/qcom/apq8096-db820c.dts
++++ b/arch/arm64/boot/dts/qcom/apq8096-db820c.dts
+@@ -702,6 +702,7 @@ vdd_gfx: s2 {
+ 		regulator-name = "VDD_GFX";
+ 		regulator-min-microvolt = <980000>;
+ 		regulator-max-microvolt = <980000>;
++		regulator-always-on;
+ 	};
+ };
+ 
+-- 
+GitLab
+

--- a/recipes-kernel/linux/linux-yocto_6.16.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.16.bbappend
@@ -1,0 +1,3 @@
+SRC_URI:append:qcom = " \
+    file://workarounds/f553aff9a3ab245e722349cc617bcdfe778c69af.patch \
+"


### PR DESCRIPTION
We lack proper power supply driver for the GPU on APQ8096. This can result in the board resetting when the GPU being turned on or off. Add the patch that has been carried over by Mesa CI that makes the GPU more stable on that board.