### PR TITLE
Rb3gen2: Add support for Open Boot firmware (TF-A, OP-TEE and U-Boot) build

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -235,6 +235,14 @@ jobs:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+          - machine: rb3gen2-core-kit-open-fw
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
       - uses: actions/checkout@v4

--- a/ci/meta-arm.yml
+++ b/ci/meta-arm.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+
+repos:
+  meta-arm:
+    url: https://git.yoctoproject.org/meta-arm
+    layers:
+      meta-arm:
+      meta-arm-toolchain:

--- a/ci/rb3gen2-core-kit-open-fw.yml
+++ b/ci/rb3gen2-core-kit-open-fw.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+  - ci/meta-arm.yml
+
+machine: rb3gen2-core-kit-open-fw

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,16 +10,18 @@ BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "6"
 
 LAYERDEPENDS_qcom = "core"
-LAYERRECOMMENDS_qcom = "openembedded-layer"
+LAYERRECOMMENDS_qcom = "openembedded-layer meta-arm"
 LAYERSERIES_COMPAT_qcom = "whinlatter"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 
 BBFILES_DYNAMIC += " \
-    openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
-    openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
+    meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bb \
+    meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
+    openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     qcom-distro:${LAYERDIR}/dynamic-layers/qcom-distro/*/*/*.bb \
     qcom-distro:${LAYERDIR}/dynamic-layers/qcom-distro/*/*/*.bbappend \
     selinux:${LAYERDIR}/dynamic-layers/selinux/*/*/*.bb \

--- a/conf/machine/rb3gen2-core-kit-open-fw.conf
+++ b/conf/machine/rb3gen2-core-kit-open-fw.conf
@@ -1,0 +1,13 @@
+#@TYPE: Machine
+#@NAME: Qualcomm RB3Gen2 Development Kit (Core Kit with open boot firmware)
+#@DESCRIPTION: Machine configuration for Qualcomm RB3Gen2 development Kit, with QCS6490
+
+require conf/machine/rb3gen2-core-kit.conf
+
+EXTRA_IMAGEDEPENDS += "trusted-firmware-a-qcom"
+
+MACHINE_FEATURES += "optee"
+MACHINE_EXTRA_RRECOMMENDS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-arm', 'packagegroup-optee', '', d)}"
+
+UBOOT_CONFIG = "qcs6490-rb3gen2"
+UBOOT_CONFIG[qcs6490-rb3gen2] = "qcm6490_defconfig"

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -1,0 +1,33 @@
+DEPENDS += "qtestsign-native optee-os-qcom"
+
+SRC_URI += "git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc_blobs;subdir=qc_blobs;branch=main"
+SRCREV_qc_blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
+
+LICENSE += "& LICENSE.qcom"
+LIC_FILES_CHKSUM:qcm6490 += "file://${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/LICENSE;md5=fa83f30385e617b56ef0934f13645621"
+
+COMPATIBLE_MACHINE:qcm6490 = "qcm6490"
+TFA_PLATFORM:qcm6490 = "rb3gen2"
+
+TFA_UBOOT ?= "1"
+TFA_BUILD_TARGET = "bl2 fip"
+TFA_SPD = "opteed"
+
+EXTRA_OEMAKE:append = " \
+    BL32=${RECIPE_SYSROOT}/${nonarch_base_libdir}/firmware/tee-raw.bin \
+   "
+
+EXTRA_OEMAKE:append:qcm6490 = " \
+    QTISECLIB_PATH=${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/libqtisec.a \
+   "
+
+do_install:append:qcm6490() {
+    export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
+
+    ${OBJCOPY} -I binary -B aarch64 -O elf64-littleaarch64 ${D}${FIRMWARE_DIR}/fip.bin ${D}${FIRMWARE_DIR}/fip.o
+    ${LD} ${D}${FIRMWARE_DIR}/fip.o -o ${D}${FIRMWARE_DIR}/fip_unsigned.elf -EL -T ${S}/tools/qti/fip-elf.lds --defsym=ELFENTRY=0x9fc00000 -Ttext=0x9fc00000
+    rm -f ${D}${FIRMWARE_DIR}/fip.o
+
+    qtestsign -v6 aboot -o ${D}${FIRMWARE_DIR}/fip.elf ${D}${FIRMWARE_DIR}/fip_unsigned.elf
+    rm -f ${D}${FIRMWARE_DIR}/fip_unsigned.elf
+}

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
@@ -1,0 +1,8 @@
+require recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
+
+PV = "2.14.0-qcom+git"
+
+SRC_URI = "git://github.com/qualcomm-linux/trusted-firmware-a.git;protocol=https;name=tfa;branch=qcom-next"
+SRCREV_tfa = "78d883ea408d58786287102bc704a5bfce2cbd90"
+
+require trusted-firmware-a-qcom.inc

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
@@ -1,0 +1,8 @@
+require recipes-security/optee/optee-os.inc
+
+PV = "4.9.0-qcom+git"
+
+SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;branch=qcom-next"
+SRCREV_optee = "c2b0684fcd89929976a8726e6e3af922b48dd2c7"
+
+require optee-qcom.inc

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit_%.bbappend
@@ -1,0 +1,4 @@
+MACHINE_OPTEE_REQUIRE ?= ""
+MACHINE_OPTEE_REQUIRE:qcom = "optee-qcom.inc"
+
+require ${MACHINE_OPTEE_REQUIRE}

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-qcom.inc
@@ -1,0 +1,2 @@
+COMPATIBLE_MACHINE:qcm6490 = "qcm6490"
+OPTEEMACHINE:qcm6490 = "qcom-kodiak"

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-test_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-test_%.bbappend
@@ -1,0 +1,6 @@
+# Machine specific configurations
+
+MACHINE_OPTEE_REQUIRE ?= ""
+MACHINE_OPTEE_REQUIRE:qcom = "optee-qcom.inc"
+
+require ${MACHINE_OPTEE_REQUIRE}

--- a/dynamic-layers/meta-arm/recipes-security/packagegroups/packagegroup-optee.bb
+++ b/dynamic-layers/meta-arm/recipes-security/packagegroups/packagegroup-optee.bb
@@ -1,0 +1,7 @@
+SUMMARY = "Packages for the OP-TEE support"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os-tadevkit optee-client optee-test', '', d)} \
+"


### PR DESCRIPTION
Currently the open boot firmware stack has only been enabled on RB3Gen2 platform which can be built using following:

```
$ kas build ci/rb3gen2-core-kit-open-fw.yml:ci/meta-arm.yml
```

And currently the boot stack includes TF-A, OP-TEE and U-Boot. In future the plan is to enable upstream edk2 as well. Along with that the next target for open boot firmware is Lemans based IoT EVK platform.

Right now the build generates 2 firmware payloads as bl2.elf (unsigned) and fip.elf (test signed using qtestsign). It is required to sign bl2.elf with QTI signature using sectools but in future the plan is to drop QTI signature requirement with an updated release of XBL/XBL-SEC.

Once signing is done, one need to update following binaries in qcomflash tarball and then proceed with QDL flashing:
- tz.mbn -> bl2.mbn
- uefi.elf -> fip.elf