### PR TITLE
kgsl-dlkm: update KGSL tip

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
 PV = "0.0+git"
-SRCREV = "7e903430c17a2594b1b2907d459f04b2c3d2295b"
+SRCREV = "704a2e947c8a462a3b6771a984cfedcb3f9ebc55"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https \
     file://kgsl.rules \


### PR DESCRIPTION
Update the SRCREV to point to the latest commit in the KGSL source code repository. This update brings in few improvements and fixes:

- add power level speedbins for A643
- add support for simple_ondemand governor for Adreno GPU
- add .gitignore to exclude build artifacts
- remove last_governor from the kgsl_pwrscale struct
- fix double OPP reference put in power level parsing
- conditionally compile msm_adreno_tz and gpubw_mon files