### PR TITLE
Correct firmware packages for IQ-9075-EVK

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
@@ -8,12 +8,12 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
-    linux-firmware-qcom-qcs8300-audio \
-    linux-firmware-qcom-qcs8300-compute \
-    linux-firmware-qcom-qcs8300-generalpurpose \
+    linux-firmware-qcom-sa8775p-audio \
+    linux-firmware-qcom-sa8775p-compute \
+    linux-firmware-qcom-sa8775p-generalpurpose \
     linux-firmware-qcom-vpu \
 "
 


### PR DESCRIPTION
 The IQ-9075-EVK board is based on SA8775P, but the packagegroup was incorrectly
 including QCS8300 firmware. Replace these with appropriate SA8775P packages.