### PR TITLE
Add resize-rootfs_1.0.bb recipe to install rootfs resize script

### DIFF
--- a/recipes-bsp/partition/files/resize-rootfs.service
+++ b/recipes-bsp/partition/files/resize-rootfs.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Resize rootfs to use available disk space
+After=systemd-remount-fs.service
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/sbin/resize-rootfs.sh
+ExecStartPost=/bin/systemctl disable resize-rootfs.service
+
+[Install]
+WantedBy=basic.target

--- a/recipes-bsp/partition/files/resize-rootfs.sh
+++ b/recipes-bsp/partition/files/resize-rootfs.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-clear
+
+[ $(whoami) = "root" ] || { echo "ERROR: Must be a root user to resize rootfs." && exit 1; }
+
+RESIZE2FS=$(which resize2fs) || { echo "ERROR: 'resize2fs' utility not found." && exit 1; }
+
+ROOT_DEVICE="$(readlink -f "$(findmnt / -o source -n -v)")"
+
+${RESIZE2FS} "${ROOT_DEVICE}"

--- a/recipes-bsp/partition/resize-rootfs_1.0.bb
+++ b/recipes-bsp/partition/resize-rootfs_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Scripts to resize root filesystem at first boot"
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
+
+SRC_URI += " \
+    file://resize-rootfs.service \
+    file://resize-rootfs.sh \
+"
+
+S = "${UNPACKDIR}"
+
+inherit features_check systemd
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+do_install () {
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/resize-rootfs.sh ${D}${sbindir}
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/resize-rootfs.service ${D}${systemd_unitdir}/system
+}
+
+SYSTEMD_SERVICE:${PN} = "resize-rootfs.service"
+RDEPENDS:${PN} += "e2fsprogs-resize2fs"


### PR DESCRIPTION
To be able to flash across various boards, the root filesystem is generated 
with a minimal size. This `resize-rootfs.sh` script, automatically resizes the 
rootfs on first boot to utilize the full available disk space.