### PR TITLE
qcs615-adp-air: include Hexagon DSP binaries in essential recommends

### DIFF
--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs615-adp-air-firmware \
+    packagegroup-qcs615-adp-air-hexagon-dsp-binaries \
 "
 
 QCOM_CDT_FILE = "cdt_adp_air_sa6155p"


### PR DESCRIPTION
Add packagegroup-qcs615-adp-air-hexagon-dsp-binaries to
MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS so that the required DSP
binaries are always included in images for this machine.