### PR TITLE
workflows: fix missing event file download

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           path: artifacts
 
+      - name: Download event file
+        uses: actions/download-artifact@v4
+        with:
+            run-id: ${{ github.event.workflow_run.id }}
+            path: artifacts
+            github-token: ${{ github.token }}
+
       - name: "List files"
         run: |
           echo $GITHUB_WORKSPACE


### PR DESCRIPTION
Event file download action was mistakenly removed from test-pr.yml workflow by commit 88ab5c880f2053f9530f74d071b76081ec99bd45. This patch fixes the mistake and adds the Event File download step.