### PR TITLE
workflows: switch to lava-action@v9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Submit ${{ matrix.target }}
         timeout-minutes: 20
-        uses: foundriesio/lava-action@v8
+        uses: foundriesio/lava-action@v9
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'


### PR DESCRIPTION
lava-action@v9 fixes the output colouring issue. It uses ANSI 8bit colours to match the github action to original LAVA log.