### PR TITLE
workflows: switch download-artifact to v6

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: kas-lock
           path: ci/
@@ -170,7 +170,7 @@ jobs:
     runs-on: [self-hosted, qcom-u2404, amd64-ssd]
     steps:
       - name: 'Download build URLs'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: build-url*

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download result files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
             run-id: ${{ inputs.workflow_id }}
             path: artifacts

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
       - name: Download event file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
             run-id: ${{ github.event.workflow_run.id }}
             path: artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Download build URLs'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.build_id }}
@@ -68,7 +68,7 @@ jobs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
     steps:
       - name: 'Download job templates'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: testjobs-*
 
@@ -89,7 +89,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-job-list.outputs.jobmatrix) }}
     steps:
       - name: 'Download job templates'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: testjobs-*
 
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 


### PR DESCRIPTION
v6 release fixes an off-by-one bug when there are more than 100 artifacts to download. More details in actions/toolkit PR#2165 https://github.com/actions/toolkit/pull/2165

The problem manifests as downloading only 100 artifacts when there are more than 100 and fewer than 200. As default page size is 100, only 1st page is retrieved. It affected test result reporting in meta-qcom