### PR TITLE
BACKPORT: ofono: enable D-Bus use with PipeWire

### DIFF
--- a/recipes-connectivity/ofono/ofono_2.18.bbappend
+++ b/recipes-connectivity/ofono/ofono_2.18.bbappend
@@ -1,0 +1,6 @@
+do_install:append:qcom () {
+  sed -i '/<\/busconfig>/i\
+  <policy user="\pipewire\">\
+    <allow send_destination=\"org.ofono\"/>\
+  </policy>' ${D}${sysconfdir}/dbus-1/system.d/ofono.conf
+}


### PR DESCRIPTION
Added configuration rule in ofono.conf to establish correct D-Bus communication with PipeWire, when
pipewire running as a systemd service.

Link:
https://git.kernel.org/pub/scm/network/ofono/ofono.git/commit/?id=1a414d4bf3404117e952ec2ab942c0288af4d341

This change is part of the ofono master branch and will be available in later versions (starting from 2.19). Therefore, we have added this change to the specific version of ofono used on the QLI mainline.