### PR TITLE
Bluetooth: Add Bluetooth BD address setup service and script

### DIFF
--- a/recipes-connectivity/bluez5/bluez5/qca_set_bdaddr.service
+++ b/recipes-connectivity/bluez5/bluez5/qca_set_bdaddr.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=start set BDA script for bluetooth
+ConditionPathExists=/sys/devices/soc0/serial_number
+Requires=bluetooth.service
+After=bluetooth.service
+
+[Service]
+Type=simple
+ExecStart=+/etc/initscripts/qca_set_bdaddr.sh
+
+[Install]
+WantedBy=bluetooth.target

--- a/recipes-connectivity/bluez5/bluez5/qca_set_bdaddr.sh
+++ b/recipes-connectivity/bluez5/bluez5/qca_set_bdaddr.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Function to format BD-Address and Set it
+set_bda() {
+    # Read the serial number
+    serial_number=$(cat /sys/devices/soc0/serial_number)
+
+    # Convert to hexadecimal
+    hex_serial_number=$(printf '%x\n' $serial_number)
+
+    # Format the serial number
+    formatted_serial_number=$(echo "${hex_serial_number}" | sed 's/../&:/g;s/:$//')
+
+    # Append qualcomm general prefix BDA value 22:22
+    BDA=22:22:${formatted_serial_number:0:14}
+
+    #After FW download completed wait for some time
+    sleep 1
+
+    # Pass the formatted serial number to btmgmt tool
+    # Start btmgmt and send commands
+    {
+        echo "public-addr $BDA"
+        sleep 1
+    } | btmgmt
+}
+
+
+# Function to check BD Address and wait until it becomes configured or unconfigured
+validate_and_set_bda() {
+    while true; do
+        # Get the BD Address
+        hciconfig_output=$(hciconfig)
+
+        bd_address=$(echo "$hciconfig_output" | grep 'BD Address' | awk '{print $3}')
+        unconfigured=$(echo "$hciconfig_output" | grep -o 'DOWN RAW')
+        configured=$(echo "$hciconfig_output" | grep -o 'DOWN')
+
+        # Check if the BD Address is 00:00:00:00:00:00
+        if [[ "$bd_address" == "00:00:00:00:00:00" ]]; then
+            sleep 1
+        elif  [[ "$unconfigured" == "DOWN RAW" ]]; then
+           break
+        elif [[ "$configured" == "DOWN" ]]; then
+           echo "BD-Address already configured!!"
+           return 0
+        else
+           break
+        fi
+    done
+
+    # Call the set_bda function
+    set_bda
+}
+
+
+
+# Run bluetoothctl show and capture the output
+bluetoothctl_output=$(bluetoothctl show)
+
+# Check if the BD Address is valid
+if echo "$bluetoothctl_output" | grep -q "No default controller available"; then
+    # Call the validate_and_set_bda function
+    validate_and_set_bda
+fi

--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,52 @@
+inherit systemd
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+RRECOMMENDS:${PN} += " \
+    glibc-gconv-utf-16 \
+    glibc-gconv-utf-32 \
+"
+
+SRC_URI:append = " file://qca_set_bdaddr.service \
+                   file://qca_set_bdaddr.sh \
+"
+
+#Include obex to support obex related profiles like OPP, FTP, MAP, PBAP
+RDEPENDS:${PN} += "${PN}-obex"
+
+#Include only desired tools that are conditional on READLINE in bluez
+INST_TOOLS_READLINE = " \
+    tools/bluetooth-player \
+    tools/obexctl \
+    tools/btmgmt \
+"
+
+#Remove desired tools from noinst-tools
+NOINST_TOOLS:remove = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'readline', '${INST_TOOLS_READLINE}', '', d)} \
+"
+
+do_install:append:qcom() {
+
+    #Install desired tools that upstream leaves in build area
+    for f in ${INST_TOOLS_READLINE} ; do
+        install -m 755 ${B}/$f ${D}/${bindir}
+    done
+
+    #Create below directory which is used by obex service
+    install -d ${D}${localstatedir}/bluetooth
+
+    # Install script to set unique BDA
+    install -d ${D}${sysconfdir}/initscripts
+    install -m 755 ${UNPACKDIR}/qca_set_bdaddr.sh ${D}${sysconfdir}/initscripts/
+
+    # Install service that will run qca_set_bdaddr.sh script on boot
+    install -m 0644 ${UNPACKDIR}/qca_set_bdaddr.service -D ${D}${systemd_system_unitdir}/qca_set_bdaddr.service
+    install -d ${D}${systemd_system_unitdir}/bluetooth.target.wants/
+    ln -sf ${systemd_system_unitdir}/qca_set_bdaddr.service ${D}${systemd_system_unitdir}/bluetooth.target.wants/qca_set_bdaddr.service
+}
+
+SYSTEMD_SERVICE:${PN} += "qca_set_bdaddr.service"
+FILES:${PN}:append = "${systemd_system_unitdir}/qca_set_bdaddr.service \
+                           ${sysconfdir}/initscripts/qca_set_bdaddr.sh \
+"


### PR DESCRIPTION
 - If controller returns Bluetooth Device Address (BDA) which is not unique then device will set to unconfigured state, Hence add `qca_set_bdaddr.service` and `qca_set_bdaddr.sh` to configure a unique BDA on boot.
 - Add `bluez5_%.bbappend` to:
   - Include the new service and script in the BlueZ5 recipe.
   - Include obex to support obex related profiles like OPP, FTP, MAP, PBAP
   - Include only desired tools that are conditional on READLINE in bluez
   - Install the script to `/etc/initscripts` and the systemd unit to `bluetooth.target.wants`.