### PR TITLE
linux-qcom-next: Added security hardening.config to kernel config

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -36,10 +36,13 @@ S = "${UNPACKDIR}/${BP}"
 KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qcom-armv7a = "qcom_defconfig"
 
+CONFIG_LIST =  "${@" ".join(find_cfgs(d))}"
+CONFIG_LIST += "${@bb.utils.contains('DISTRO_FEATURES', 'hardened', '${S}/kernel/configs/hardening.config', '', d)}"
+
 do_configure:prepend() {
     # Use a copy of the 'defconfig' from the actual repo to merge fragments
     cp ${S}/arch/${ARCH}/configs/${KBUILD_DEFCONFIG} ${B}/.config
 
     # Merge fragment for QCOM value add features
-    ${S}/scripts/kconfig/merge_config.sh -m -O ${B} ${B}/.config ${@" ".join(find_cfgs(d))}
+    ${S}/scripts/kconfig/merge_config.sh -m -O ${B} ${B}/.config ${CONFIG_LIST}
 }


### PR DESCRIPTION
This PR introduces support for conditionally including `hardening.config` during kernel configuration for linux-qcom-next.
The inclusion is based on DISTRO_FEATURES containing **hardened**.
Uses merge_config.sh to combine the base .config, hardening.config, and any additional fragments.
Default it's not enabled for all build and only for production builds with "hardened" is enabled.

Changes:
Added logic in `do_configure:prepend` to merge `hardening.config` when `hardened` is present in DISTRO_FEATURES.
No changes for distros without this feature.

Verified build on qcs9100-ride-sx with DISTRO_FEATURES += "hardened".
Kernel config includes hardening options as expected.