### PR TITLE
qcom-distro: Migrate meta-ar to meta-audioreach

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -26,8 +26,8 @@ repos:
     branch: master
 
   meta-audioreach:
-    url: https://github.com/Audioreach/meta-ar
-    branch: main
+    url: https://github.com/AudioReach/meta-audioreach
+    branch: master
 
   meta-selinux:
     branch: master


### PR DESCRIPTION
Update qcom-distro.yml to use the new meta-audioreach repository:
- Replace URL with https://github.com/AudioReach/meta-audioreach
- Change branch from main to master