### PR TITLE
Update linux-qcom-next to tag qcom-next-6.18-rc5-20251114

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.17+6.18-rc4"
+LINUX_VERSION ?= "6.17+6.18-rc5"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-6.18-rc4-20251106
-SRCREV ?= "963d75401ece29442ce792094421e7574c4b5063"
+# tag: qcom-next-6.18-rc5-20251114
+SRCREV ?= "53919c1f684a75dc898ae3e5290d9ed8919b32ac"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag  qcom-next-6.18-rc5-20251114, which corresponds to kernel version 6.18-rc5.