### PR TITLE
packagegroup-qcs8300-ride: correct WLAN firmware packages

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs8300-ride.bb
@@ -9,7 +9,7 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
     linux-firmware-qcom-qcs8300-audio \
     linux-firmware-qcom-qcs8300-compute \


### PR DESCRIPTION
Based on the subversion ID of the HSP card on the qcs8300-ride platform,
the HSP card should correspond to the QCA6698AQ firmware. Therefore,
update the WLAN firmware package by replacing
`linux-firmware-ath11k-wcn6855` with `linux-firmware-ath11k-qca6698aq`.