### PR TITLE
Update CDT for IQ-8275-EVK board

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -22,7 +22,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-8275-evk-hexagon-dsp-binaries \
 "
 
-QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk"
+QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk_pro_sku"
 QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-8275-evk/ufs"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -10,10 +10,10 @@ BOOTBINARIES = "QCS8300_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk.zip;downloadfilename=cdt-qcs8275-iq-8275-evk_${PV}.zip;name=qcs8275-iq-8275-evk \
+    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \
     "
 SRC_URI[qcs8300-ride-sx.sha256sum] = "d7fc667372b28383a36d586333097d84b9d9c104f4dd1845d33904e2d6b39f80"
-SRC_URI[qcs8275-iq-8275-evk.sha256sum] = "070a61e6442316234b72af203c03a2cab82a1a5b8822f0af0d3fcca294ffda55"
+SRC_URI[cdt-iq8275-evk-pro-sku.sha256sum] = "cbe2009c8ef7dbacd716141bf01b8e1b26788c4a4f3145e60fe3b4a6b3aabc04"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs8300"
 


### PR DESCRIPTION
The IQ-8275-EVK board uses the pro SKU configuration. Fetch correct CDT in firmware-qcom-boot-qcs8300 recipe and point QCOM_CDT_FILE in machine config to the same.