### PR TITLE
camx: package provide all components of the Qualcomm Camera X (CamX)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.4.bb
@@ -1,0 +1,95 @@
+SUMMARY = "CamX camera module with core interface utilities, extended image processing libraries, and CHI developer kit including sensor, tuning binaries"
+DESCRIPTION = "This recipe introduces Qualcomm CamX camera module which creates three components.\
+   camxlib: Includes common utilities, image processing algorithms and hardware support libraries extending CamX functionality for platform-specific enhancements. \
+   camx: Core CamX engine that manages camera pipelines, mediates between camera clients and hardware, and exposes structured interfaces to higher-level frameworks. \
+   chicdk: Camera hardware interface development kit delivering a configurable mechanism for use case selection and camera pipeline topology creation. \
+   Includes configurable sensor and tuning binaries, which are essential for enabling full camera functionality."
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=7a5da794b857d786888bbf2b7b7529c8 \
+                    file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
+
+SRC_URI = " \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
+   "
+SRC_URI[camxlib.sha256sum] = "55afef79b50eeded709af6079f22fd1565580cab3fc23568e3e1b9691bf10a29"
+SRC_URI[camx.sha256sum] = "632c9b7e43cef62488760f8318a00c16ee6aca04b85ad4fcb66d32a2151ec171"
+SRC_URI[chicdk.sha256sum] = "c03c94fac84563f2f2c9b464b1338d7b65ce09b51d270e70b0cbf92e40b8188d"
+PBT_BUILD_DATE = "260102"
+
+S = "${UNPACKDIR}"
+
+DEPENDS += "glib-2.0 fastrpc protobuf libxml2 virtual/egl virtual/libgles2 virtual/libopencl1"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+# Disable configure and compile steps since this recipe uses prebuilt binaries.
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${libdir}
+    install -d ${D}${datadir}/doc/${BPN}
+    install -d ${D}${datadir}/doc/camx-kodiak
+    install -d ${D}${datadir}/doc/chicdk-kodiak
+    install -d ${D}${bindir}
+
+    cp -r ${S}/usr/lib/* ${D}${libdir}
+    cp -r ${S}/usr/bin/* ${D}${bindir}
+
+    # Remove unnecessary development symlinks (.so) from the staged image
+    rm -f ${D}${libdir}/camx/kodiak/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/camera/components/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/hw/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/camera/*${SOLIBSDEV}
+
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NOTICE ${D}${datadir}/doc/${BPN}
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/${BPN}
+
+    install -m 0644 ${S}/usr/share/doc/camx-kodiak/NOTICE ${D}${datadir}/doc/camx-kodiak
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/camx-kodiak
+
+    install -m 0644 ${S}/usr/share/doc/chicdk-kodiak/NOTICE ${D}${datadir}/doc/chicdk-kodiak
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/chicdk-kodiak
+}
+
+PACKAGE_BEFORE_PN += "camx-kodiak chicdk-kodiak"
+RDEPENDS:${PN} += "chicdk-kodiak"
+
+FILES:camx-kodiak = "\
+    ${libdir}/camx/kodiak/libchilog*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node.eisv*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node.swregistration*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/camera.qcom*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcamera_hardware*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcamxexternalformatutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcom.qti.camx.chiiqutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcom.qti.node.eisv*${SOLIBS} \
+    "
+FILES:chicdk-kodiak = "\
+    ${libdir}/camx/kodiak/com.qti.feature2*${SOLIBS} \
+    ${libdir}/camx/kodiak/libchimldw*${SOLIBS} \
+    ${libdir}/camx/kodiak/com.qualcomm*${SOLIBS} \
+    ${libdir}/camx/kodiak/chiofflinepostproclib*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcommonchiutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libiccprofile*${SOLIBS} \
+    ${libdir}/camx/kodiak/com.qti.chiusecaseselector*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/com.qti.sensormodule*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/libshdr3*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/libbanding_correction*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.stats.hafoverride*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/*.bin \
+    ${libdir}/camx/kodiak/camera/com.qti.sensor*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/com.qti.chi.*${SOLIBS} \
+    ${bindir}/ \
+    "
+FILES:${PN} = "\
+    ${libdir}/camx/kodiak/*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/*${SOLIBS} \
+    "

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.4.bb
@@ -1,0 +1,95 @@
+SUMMARY = "CamX camera module with core interface utilities, extended image processing libraries, and CHI developer kit including sensor, tuning binaries"
+DESCRIPTION = "This recipe introduces Qualcomm CamX camera module which creates three components.\
+   camxlib: Includes common utilities, image processing algorithms and hardware support libraries extending CamX functionality for platform-specific enhancements. \
+   camx: Core CamX engine that manages camera pipelines, mediates between camera clients and hardware, and exposes structured interfaces to higher-level frameworks. \
+   chicdk: Camera hardware interface development kit delivering a configurable mechanism for use case selection and camera pipeline topology creation. \
+   Includes configurable sensor and tuning binaries, which are essential for enabling full camera functionality."
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=7a5da794b857d786888bbf2b7b7529c8 \
+                    file://usr/share/doc/${BPN}/NOTICE;md5=198d001f49d9a313355d5219f669a76c"
+
+SRC_URI = " \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-lemans_${PV}_armv8-2a.tar.gz;name=camx \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-lemans_${PV}_armv8-2a.tar.gz;name=chicdk \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camxcommon-lemans_${PV}_armv8-2a.tar.gz;name=camxcommon \
+    "
+
+SRC_URI[camxlib.sha256sum] = "e9c49b6e818db2a4a27ff80bf54c335861359e15de2055d52b6cf9aad995f0d5"
+SRC_URI[camx.sha256sum] = "3baea58276298602d5e9b980a814a089378f0c9095683503befa7c32eee01dba"
+SRC_URI[chicdk.sha256sum] = "bb73acd375abf114056c2fdfb345f648a3501a46ca292d5edf717a2ebae4b026"
+SRC_URI[camxcommon.sha256sum] = "9f028650c176e306da8f979adc52fd1010e588379fe53971bd909ef776e5519f"
+PBT_BUILD_DATE = "260102"
+
+S = "${UNPACKDIR}"
+
+DEPENDS += "glib-2.0 fastrpc protobuf libxml2"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+# Disable configure and compile steps since this recipe uses prebuilt binaries.
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${libdir}
+    install -d ${D}${datadir}/doc/${BPN}
+    install -d ${D}${datadir}/doc/camx-lemans
+    install -d ${D}${datadir}/doc/chicdk-lemans
+    install -d ${D}${bindir}
+    install -d ${D}/${sysconfdir}/camera/test/NHX/
+
+    cp -r ${S}/usr/lib/* ${D}${libdir}
+    cp -r ${S}/etc/camera/test/NHX/NHX.YUV_NV12_Prev_MaxRes.json ${D}/${sysconfdir}/camera/test/NHX/
+    cp -r ${S}/usr/bin/* ${D}${bindir}
+
+    # Remove unnecessary development symlinks (.so) from the staged image
+    rm -f ${D}${libdir}/camx/lemans/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/lemans/camera/components/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/lemans/hw/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/lemans/camera/*${SOLIBSDEV}
+
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NOTICE ${D}${datadir}/doc/${BPN}
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/${BPN}
+
+    install -m 0644 ${S}/usr/share/doc/camx-lemans/NOTICE ${D}${datadir}/doc/camx-lemans
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/camx-lemans
+
+    install -m 0644 ${S}/usr/share/doc/chicdk-lemans/NOTICE ${D}${datadir}/doc/chicdk-lemans
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NO.LOGIN.BINARY.LICENSE.QTI.pdf ${D}${datadir}/doc/chicdk-lemans
+}
+
+RPROVIDES:${PN} = "camxlib-monaco"
+PACKAGE_BEFORE_PN += "camx-lemans chicdk-lemans"
+RDEPENDS:${PN} += "chicdk-lemans"
+
+FILES:camx-lemans = "\
+    ${libdir}/camx/lemans/hw/camera.qcom*${SOLIBS} \
+    ${libdir}/camx/lemans/libcamera_hardware*${SOLIBS} \
+    ${libdir}/camx/lemans/libcamxexternalformatutils*${SOLIBS} \
+    ${libdir}/camx/lemans/libcom.qti.camx.chiiqutils*${SOLIBS} \
+    ${libdir}/camx/lemans/libcom.qti.node.eisv*${SOLIBS} \
+    "
+FILES:chicdk-lemans = "\
+    ${libdir}/camx/lemans/com.qti.feature2*${SOLIBS} \
+    ${libdir}/camx/lemans/com.qualcomm*${SOLIBS} \
+    ${libdir}/camx/lemans/libcommonchiutils*${SOLIBS} \
+    ${libdir}/camx/lemans/libiccprofile*${SOLIBS} \
+    ${libdir}/camx/lemans/com.qti.chiusecaseselector*${SOLIBS} \
+    ${libdir}/camx/lemans/camera/components/com.qti.node*${SOLIBS} \
+    ${libdir}/camx/lemans/camera/com.qti.sensormodule*${SOLIBS} \
+    ${libdir}/camx/lemans/camera/*.bin \
+    ${libdir}/camx/lemans/camera/com.qti.sensor*${SOLIBS} \
+    ${libdir}/camx/lemans/hw/com.qti.chi.*${SOLIBS} \
+    ${sysconfdir}/camera/test/NHX/ \
+    ${bindir}/ \
+    "
+FILES:${PN} = "\
+    ${libdir}/camx/lemans/*${SOLIBS} \
+    ${libdir}/camx/lemans/camera/components/com.qti.node.swregistration*${SOLIBS} \
+    ${libdir}/camx/lemans/hw/*${SOLIBS} \
+    ${libdir}/camx/lemans/camera/components/*${SOLIBS} \
+    "


### PR DESCRIPTION
The camx-lib package provides all camera libraries, shared across all components of the Qualcomm Camera X (CamX).
This recipe help to create separate camx packages.
This PR support QLI 1.6 features for KLM targets
