### PR TITLE
Support custom ESP images in qcomflash

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -8,7 +8,7 @@ IMAGE_TYPES += "qcomflash"
 QCOM_BOOT_FIRMWARE ?= ""
 
 QCOM_ESP_IMAGE ?= "${@bb.utils.contains("MACHINE_FEATURES", "efi", "esp-qcom-image", "", d)}"
-QCOM_ESP_FILE ?= "${@'efi.bin' if d.getVar('QCOM_ESP_IMAGE') else ''}"
+QCOM_ESP_FILE ?= "${@'${DEPLOY_DIR_IMAGE}/${QCOM_ESP_IMAGE}-${MACHINE}${IMAGE_NAME_SUFFIX}.vfat' if d.getVar('QCOM_ESP_IMAGE') else ''}"
 
 # There is currently no upstream-compatible way for the firmware to
 # identify and load the correct DTB from a combined-dtb that contains all
@@ -38,9 +38,7 @@ IMAGE_TYPEDEP:qcomflash += "${IMAGE_QCOMFLASH_FS_TYPE}"
 
 create_qcomflash_pkg() {
     # esp image
-    if [ -n "${QCOM_ESP_FILE}" ]; then
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_ESP_IMAGE}-${MACHINE}${IMAGE_NAME_SUFFIX}.vfat ${QCOM_ESP_FILE}
-    fi
+    [ -n "${QCOM_ESP_FILE}" ] && install -m 0644 ${QCOM_ESP_FILE} efi.bin
 
     # dtb image
     if [ -n "${QCOM_DTB_DEFAULT}" ] && \


### PR DESCRIPTION
Repurpose QCOM_ESP_FILE to support custom ESP images (as needed with meta-updater), and remove QCOM_ROOTFS_FILE as there is no need for a custom variable defining the rootfs image filename.