### PR TITLE
ci: increase download timeouts in LAVA jobs

### DIFF
--- a/ci/lava/poky-altcfg/iq-9075-evk/boot.yaml
+++ b/ci/lava/poky-altcfg/iq-9075-evk/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs9100-rb8" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -59,5 +59,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/poky-altcfg/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/poky-altcfg/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs6490-rb3gen2" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -59,5 +59,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/poky-altcfg/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/poky-altcfg/qcs8300-ride-sx/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs8300" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -59,5 +59,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/poky-altcfg/qcs9100-ride-sx/boot.yaml
+++ b/ci/lava/poky-altcfg/qcs9100-ride-sx/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs9100" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -59,5 +59,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/poky-altcfg/qrb2210-rb1-core-kit/boot.yaml
+++ b/ci/lava/poky-altcfg/qrb2210-rb1-core-kit/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qrb2210-rb1" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -59,5 +59,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-distro/iq-9075-evk/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs9100-rb8" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -61,5 +61,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs6490-rb3gen2" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -61,5 +61,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs8300-ride-sx/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs8300" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -61,5 +61,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
+++ b/ci/lava/qcom-distro/qcs9100-ride-sx/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qcs9100" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -61,5 +61,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public

--- a/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
+++ b/ci/lava/qcom-distro/qrb2210-rb1-core-kit/boot.yaml
@@ -16,7 +16,7 @@ actions:
         - echo "DEVICE_TYPE=qrb2210-rb1" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 5
+      minutes: 10
     to: downloads
 - deploy:
     images:
@@ -61,5 +61,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 15
+    minutes: 20
 visibility: public


### PR DESCRIPTION
Due to low download speeds in one of the locations the download timeouts are increased by 100%. Let's hope it solves the problem for now.