### PR TITLE
workflows: allow test jobs to fail and continue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
   submit-job:
     needs: prepare-job-list
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix: ${{ fromJson(needs.prepare-job-list.outputs.jobmatrix) }}
     steps:
@@ -106,8 +107,8 @@ jobs:
           lava_url: 'lava.infra.foundries.io'
           job_definition: ${{ matrix.target }}
           wait_for_job: true
-          fail_action_on_failure: false
-          fail_action_on_incomplete: false
+          fail_action_on_failure: true
+          fail_action_on_incomplete: true
           save_result_as_artifact: true
           save_job_details: true
           result_file_name: "${{ env.RESULT_NAME }}"


### PR DESCRIPTION
Add continue-on-fail to the test job submission task. This allows individual test jobs to fail and the workflow to continue. Failed jobs are marker "red" in the workflow which allows users to restart just the failed tasks. It's very helpful to mitigate infrastructure errors.