### PR TITLE
sensinghub: add recipe for sensing hub

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_1.0.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_1.0.3.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Qualcomm Sensing hub library"
+DESCRIPTION = "Userspace libraries that provides interface to interact with Qualcomm Sensing Hub"
+HOMEPAGE = "https://github.com/qualcomm/sensinghub"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9701d0ef17353f1d05d7b74c8712ebbd"
+
+SRCREV = "15eaa4651923da584f8d9f3417c3e92d0b61de35"
+PV = "1.0.3"
+
+SRC_URI = "git://github.com/qualcomm/sensinghub.git;protocol=https;branch=main;tag=v${PV}"
+
+DEPENDS = "protobuf protobuf-native"
+
+inherit autotools pkgconfig
+
+EXTRA_OECONF = "--enable-versioned-lib"


### PR DESCRIPTION
Add new recipe for Qualcomm Sensing Hub Userspace modules which allows users/clients to read sensors data from Sensing Hub.