### PR TITLE
Include prune.config to reduce kernel Image size

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -37,6 +37,7 @@ KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qcom-armv7a = "qcom_defconfig"
 
 KBUILD_CONFIG_EXTRA = "${@bb.utils.contains('DISTRO_FEATURES', 'hardened', '${S}/kernel/configs/hardening.config', '', d)}"
+KBUILD_CONFIG_EXTRA:append:aarch64 = "${S}/arch/arm64/configs/prune.config"
 
 do_configure:prepend() {
     # Use a copy of the 'defconfig' from the actual repo to merge fragments


### PR DESCRIPTION
Added prune.config to KBUILD_CONFIG_EXTRA for aarch64 builds to
disable non-target architectures configurations, thus significantly reducing kernel size.