### PR TITLE
ci: qcom-distro: add meta-updater to layer configuration

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -33,6 +33,10 @@ repos:
     branch: master
     url: https://git.yoctoproject.org/meta-selinux
 
+  meta-updater:
+    branch: master
+    url: https://github.com/uptane/meta-updater
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"


### PR DESCRIPTION
meta-updater provides support for ostree-based (sota) images, to be leveraged by a new qcom-distro-sota distro configuration.