### PR TITLE
qcom-qcs6490.inc: add msm.dpu_use_virtual_planes=1 to kernel cmdline

### DIFF
--- a/conf/machine/include/qcom-qcs6490.inc
+++ b/conf/machine/include/qcom-qcs6490.inc
@@ -7,6 +7,8 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
+KERNEL_CMDLINE_EXTRA:append = " msm.dpu_use_virtual_planes=1"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs6490-soc \


### PR DESCRIPTION
Add msm.dpu_use_virtual_planes=1 to KERNEL_CMDLINE_EXTRA for QCS6490 platform to enable virtual planes in the MSM DPU driver.