### PR TITLE
Enable FastCV DSP packages for supported platforms to improve computer vision performance.

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -20,6 +20,7 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-8275-evk-firmware \
     packagegroup-iq-8275-evk-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-qcs8300-ride-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk_pro_sku"

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -20,6 +20,7 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-9075-evk-firmware \
     packagegroup-iq-9075-evk-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-sa8775p-ride-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_rb8_core_kit"

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
 "
 
 QCOM_BOOT_FILES_SUBDIR = "qcm6490"

--- a/conf/machine/qcs615-adp-air.conf
+++ b/conf/machine/qcs615-adp-air.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs615-adp-air-firmware \
     packagegroup-qcs615-adp-air-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-qcs615-ride-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_adp_air_sa6155p"

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -19,6 +19,7 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs8300-ride-firmware \
     packagegroup-qcs8300-ride-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-qcs8300-ride-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_ride_sx"

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -25,6 +25,7 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-sa8775p-ride-firmware \
     packagegroup-sa8775p-ride-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-sa8775p-ride-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_ride_sx"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -20,6 +20,7 @@ KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
 "
 
 QCOM_CDT_FILE = "cdt_core_kit"


### PR DESCRIPTION
Added FastCV DSP support in machine configurations for: iq-8275-evk, iq-9075-evk, qcm6490-idp, qcs615-adp-air,qcs6490-rb3gen2-core-kit, qcs8300-ride-sx, and qcs9100-ride-sx.This change ensures DSP acceleration for FastCV workloads on these platforms.