### PR TITLE
packagegroup-sa8775p-ride: correct BT firmware packages

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sa8775p-ride.bb
@@ -10,7 +10,7 @@ PACKAGES = " \
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
     linux-firmware-qcom-sa8775p-audio \
     linux-firmware-qcom-sa8775p-compute \
     linux-firmware-qcom-sa8775p-generalpurpose \


### PR DESCRIPTION
Based on the subversion ID of the HSP card on the sa8775p-ride platform, the HSP card should correspond to the QCA6698 firmware. Therefore, update the BT firmware package by replacing
`linux-firmware-qca-qca2066` with `linux-firmware-qca-qca6698`.
CRs-fixed: 4368127