### PR TITLE
Add qcom-fastcv-binaries to RDEPENDS for OpenCV to enable FastCV DSP functionality.

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
@@ -2,3 +2,4 @@ PACKAGECONFIG:append:qcom = " tests"
 
 # Only on ARMv8 Qualcomm machines
 PACKAGECONFIG:append:qcom:aarch64 = " fastcv"
+RDEPENDS:${PN}:append:qcom:aarch64 = " qcom-fastcv-binaries"


### PR DESCRIPTION
OpenCV now supports FastCV DSP acceleration, which requires the entry-point library libfastcvopt.so provided by the qcom-fastcv-binaries package. This change ensures the correct runtime dependency is included for qcom aarch64 builds.