### PR TITLE
QCLINUX: Wireplumber: Enable bluez plugin.

### DIFF
--- a/recipes-multimedia/audio/wireplumber_%.bbappend
+++ b/recipes-multimedia/audio/wireplumber_%.bbappend
@@ -1,0 +1,11 @@
+do_install:append:qcom () {
+
+  install -v -m 0644 \
+      ${S}/src/config/wireplumber.conf.d.examples/bluetooth.conf \
+      ${D}${datadir}/wireplumber/wireplumber.conf.d/
+
+  sed -i '/^[[:space:]]*main[[:space:]]*=[[:space:]]*{/,/^[[:space:]]*}/{
+    /policy\.standard[[:space:]]*=/a\
+  monitor.bluez.seat-monitoring = disabled
+  }' ${D}${datadir}/wireplumber/wireplumber.conf
+}


### PR DESCRIPTION
- The BlueZ monitors are integrated with logind to ensure that only one user at a time can use the Bluetooth audio devices.
For more information:
https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/bluetooth.html

- on QLI devices, there is no user login sessions enabled. so disable this feature will allow bluez plugin to launch without looking for logind session.

- Add bluetooth configuration file in wireplumber delta conf folder for user preferred configuration.
- To alter supported sampling rate, codecs, profiles and etc.,