### PR TITLE
opencv: add DEPENDS on qcom-fastcv-binaries for qcom aarch64 builds

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
@@ -2,4 +2,10 @@ PACKAGECONFIG:append:qcom = " tests"
 
 # Only on ARMv8 Qualcomm machines
 PACKAGECONFIG:append:qcom:aarch64 = " fastcv"
-RDEPENDS:${PN}:append:qcom:aarch64 = " qcom-fastcv-binaries"
+
+#Ensures shlibdeps can resolve libfastcvopt.so and add RDEPENDS to avoid unresolvable shlib QA errors.
+DEPENDS:append:qcom:aarch64 = " qcom-fastcv-binaries"
+
+RDEPENDS:libopencv-core:append:qcom:aarch64 = " libfastcvopt1"
+RDEPENDS:libopencv-fastcv:append:qcom:aarch64 = " libfastcvopt1"
+RDEPENDS:libopencv-imgproc:append:qcom:aarch64 = " libfastcvopt1"


### PR DESCRIPTION
Dynamic OpenCV packages such as libopencv_core, libopencv_fastcv, and libopencv_imgproc now include FastCV DSP functionality. These components require libfastcvopt.so as the entry point for the pipeline, which is provided by qcom-fastcv-binaries.
