### PR TITLE
packagegroup-iq-9075-evk: include qca-qca61x4-usb

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
@@ -9,8 +9,8 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x linux-firmware-qca-wcn7850', '', d)} \
     linux-firmware-qcom-sa8775p-audio \
     linux-firmware-qcom-sa8775p-compute \
     linux-firmware-qcom-sa8775p-generalpurpose \


### PR DESCRIPTION
This firmware is required for setting up BT with HSP USB interface on the iq-9075-evk platform. Therefore add linux-firmware-qca-qca61x4-usb.