### PR TITLE
qcom-fastcv-binaries: split FastCV library packages

### DIFF
--- a/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.3.bb
+++ b/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.3.bb
@@ -48,12 +48,21 @@ do_install() {
 
 }
 
+PACKAGE_BEFORE_PN = "${PN}-dsp"
+
 PACKAGES += "\
     ${PN}-qcs615-ride-dsp \
     ${PN}-qcs8300-ride-dsp \
     ${PN}-sa8775p-ride-dsp \
     ${PN}-thundercomm-rb3gen2-dsp \
 "
+
+FILES:${PN}-dsp = "${libdir}/libfastcvdsp_stub.so.*"
+
+RDEPENDS:${PN}-qcs615-ride-dsp = "${PN}-dsp"
+RDEPENDS:${PN}-qcs8300-ride-dsp = "${PN}-dsp"
+RDEPENDS:${PN}-sa8775p-ride-dsp = "${PN}-dsp"
+RDEPENDS:${PN}-thundercomm-rb3gen2-dsp = "${PN}-dsp"
 
 INSANE_SKIP:${PN}-qcs615-ride-dsp = "arch libdir"
 INSANE_SKIP:${PN}-qcs8300-ride-dsp = "arch libdir"


### PR DESCRIPTION
FastCV can function without the DSP. Split the FastRPC stubs to a separate package, keeping the main package to bare minimum.