### PR TITLE
mesa: drop freedreno-fdperf PACKAGECONFIG

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -4,7 +4,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 PACKAGECONFIG_FREEDRENO = "\
     freedreno \
     tools \
-    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'freedreno-fdperf', '', d)} \
 "
 
 PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"


### PR DESCRIPTION
The freedreno-fdperf PACKAGECONFIG has been folded into the main freedreno & tools options. Drop it from the layer's bbappend.