### PR TITLE
iris-video-dlkm: update iris driver to the latest

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
@@ -5,12 +5,8 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV = "0.0+git"
 
-SRC_URI = " \
-    git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.0.0 \
-    file://0001-video-driver-follow-v4l2_fh_add-_del-API-changes.patch \
-    file://0001-video-driver-stop-playing-tricks-with-Kbuild.patch \
-"
-SRCREV  = "170ac561d70a366bc6502810079fa6b6c914920d"
+SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.0.0"
+SRCREV  = "c70ab433d51dc5d12c5e7e1810e5c9c4b2661201"
 
 inherit module
 


### PR DESCRIPTION
This tag brings a number of updates for Qcom Iris

- Fix V4L2_PIX_FMT_AV1 redefinition when the kernel already defines it
- Enable VIDIOC_CREATE_BUFS for runtime buffer allocation
- Rework DMA-buffer and refcount handling to fix corruption
- Use V4L2_PIX_FMT_QC10C for 10-bit content
- Follow updated v4l2_fh_add() / v4l2_fh_del() API (Linux ≥ 6.18)
- Use explicit ccflags-y instead of Kbuild find tricks
- Add CI workflows for the video driver