### PR TITLE
packagegroup-qcs615-ride: use correct Adreno firmware package

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcs615-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs615-ride.bb
@@ -8,7 +8,7 @@ PACKAGES = " \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
-    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcs615-adreno', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a612 linux-firmware-qcom-qcs615-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
     linux-firmware-qcom-qcs615-audio \


### PR DESCRIPTION
Since 20250808 linux-firmware provides A612-specific firmware package (containing RGMU firmware), which in turn depends on the A630 one (providing SQE file). Use platform-specific Adreno firmware package.