### PR TITLE
Disable PCIe ASPM through kernel command line for iq-8275-evk

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -8,6 +8,8 @@ MACHINE_FEATURES += "efi pci"
 
 QCOM_DTB_DEFAULT ?= "monaco-evk"
 
+KERNEL_CMDLINE_EXTRA ?= "pcie_aspm=off"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk.dtb \
                       qcom/monaco-evk-camera-imx577.dtb \


### PR DESCRIPTION
PCIe ASPM is not working with the current boards, so disable ASPM with kernel command line.