### PR TITLE
opencv: drop qcom-fastcv-binaries dependency

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-support/opencv/opencv_%.bbappend
@@ -2,4 +2,3 @@ PACKAGECONFIG:append:qcom = " tests"
 
 # Only on ARMv8 Qualcomm machines
 PACKAGECONFIG:append:qcom:aarch64 = " fastcv"
-RDEPENDS:${PN}:append:qcom:aarch64 = " qcom-fastcv-binaries"


### PR DESCRIPTION
The dependency upon qcom-fastcv-binaries is now handled by the recipe itself, it the fastcv is enabled in PACKAGECONFIG. Drop it from our bbappend.