### PR TITLE
u-boot: don't override boot-${MACHINE}.img

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -18,5 +18,7 @@ uboot_compile_config:append:qcom() {
 
 # Symlink the 'main' u-boot.bin to boot.img so the qcom image bbclass pick it up
 uboot_deploy_config:append:qcom() {
-    cd ${DEPLOYDIR} && ln -sf u-boot-${type}-${PV}-${PR}.bin boot-${MACHINE}.img
+    if [ "${@d.getVar('PREFERRED_PROVIDER_virtual/bootloader')}" = "${PN}" ] ; then
+        cd ${DEPLOYDIR} && ln -sf u-boot-${type}-${PV}-${PR}.bin boot-${MACHINE}.img
+    fi
 }


### PR DESCRIPTION
Providing boot-${MACHINE}.img symlink might conflict with other bootloaders (or the linux kernel) providing the boot image symlink. Only deploy the symlink if the recipe is selected as a preferred bootloader.