### PR TITLE
libdiag: Add runtime dependency on diag-router

### DIFF
--- a/recipes-test/libdiag/libdiag_1.0.3.bb
+++ b/recipes-test/libdiag/libdiag_1.0.3.bb
@@ -11,6 +11,7 @@ SRC_URI[sha256sum] = "e6780a404aaa89ffa7f20e659efae4f7b45beaeda8ca1fc05b5a1229ae
 S = "${UNPACKDIR}"
 
 DEPENDS += "glib-2.0"
+RDEPENDS:${PN} += "diag-router"
 
 inherit lib_package
 


### PR DESCRIPTION
Add RDEPENDS on diag-router package as libdiag operates in a client-server architecture where the library connects to the diag-router daemon at runtime.