### PR TITLE
kgsl-dlkm: update KGSL tip

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
 PV = "0.0+git"
-SRCREV = "704a2e947c8a462a3b6771a984cfedcb3f9ebc55"
+SRCREV = "40ed596f3e5fe26dcf939b6d7eda836530c73cb0"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https \
     file://kgsl.rules \


### PR DESCRIPTION
Update the SRCREV to point to the latest commit in the KGSL source code repository. This update brings in few improvements and fixes:

- Update mm_get_unmapped_area() parameter for kernel 6.19+
- Return early if FUSA resource is missing
- Add DT status check for zap and secure context bank nodes
- Skip msm-adreno-tz algorithm when single power level in use
- Add buffer overflow check for perfcounter dynamic list