### PR TITLE
recipes-graphics: Add support for qcom-adreno-cl with drm

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.838.3.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.838.3.bb
@@ -34,9 +34,8 @@ RPROVIDES:${PN}-egl += "virtual-egl-icd"
 RPROVIDES:${PN}-cl += "virtual-opencl-icd"
 RPROVIDES:${PN}-vulkan += "virtual-vulkan-icd"
 
-RDEPENDS:${PN}-common += " kgsl-dlkm"
-RDEPENDS:${PN}-egl += " ${PN}-common ${PN}-gles1 ${PN}-gles2 msm-gbm-backend"
-RDEPENDS:${PN}-vulkan += " ${PN}-common msm-gbm-backend"
+RDEPENDS:${PN}-egl += " kgsl-dlkm ${PN}-common ${PN}-gles1 ${PN}-gles2 msm-gbm-backend"
+RDEPENDS:${PN}-vulkan += " kgsl-dlkm ${PN}-common msm-gbm-backend"
 RDEPENDS:${PN}-cl += " ${PN}-common"
 RDEPENDS:${PN}-dev += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'opencl-headers-dev', '', d)}"
 


### PR DESCRIPTION
qcom-adreno-cl has capability to run with drm, but due to RDEPENDS on qcom-adreno-common, which RDEPENDS on kgsl-dlkm, it is not able to run with drm.

Remove qcom-adreno-common RDEPENDS on kgsl-dlkm and add qcom-adreno-egl and qcom-adreno-vulkan RDEPENDS on kgsl-dlkm.