### PR TITLE
ci: add kas config for qcom-distro-selinux

### DIFF
--- a/ci/qcom-distro-selinux.yml
+++ b/ci/qcom-distro-selinux.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+distro: qcom-distro-selinux


### PR DESCRIPTION
A selinux based distro is avaiable on meta-qcom-distro. Introduce a KAS config for it.