### PR TITLE
fastrpc: upgrade 1.0.1 -> 1.0.2

### DIFF
--- a/recipes-support/fastrpc/fastrpc_1.0.2.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.2.bb
@@ -4,10 +4,11 @@ SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b67986b6880754696d418dbaa2cf51d1"
+DEPENDS = "libyaml"
 
-SRCREV = "27235935b19fad234cb561b1e9d4984a51ee9e9f"
+SRCREV = "cff7d44c4f1a2a9657514eecc0348caa3f455de4"
 SRC_URI = "\
-    git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https \
+    git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
     file://adsprpcd.service \
     file://cdsprpcd.service \
     file://sdsprpcd.service \
@@ -15,7 +16,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-inherit autotools systemd ptest
+inherit autotools systemd ptest pkgconfig
 
 PACKAGES += "${PN}-systemd"
 RRECOMMENDS:${PN} += "${PN}-systemd"


### PR DESCRIPTION
Upgrade FastRPC from version 1.0.1 to 1.0.2.
Add necessary dependencies to the recipe as part of this change.

Top-Level Changelog:
**Core Enhancements**

- Enabled ARMOR public API compatibility checks and header validation for improved API stability.
- Updated DSP mount and search path configuration for better runtime flexibility.

**Testing & Examples**

- Enhanced test runner and examples with improved error handling for more robust validation.

**Bug Fixes & Stability**

- Fixed linking of test libraries to the correct version libcdsprpc.so.1.
- Built domain-correct paths and cleaned up shell open logs for cleaner execution and debugging.

Full Changelog: https://github.com/qualcomm/fastrpc/compare/v1.0.1...v1.0.2