### PR TITLE
firmware-boot: correct the license file and hash values

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS615 platform"
-LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcs615-le-1-0"
@@ -9,9 +9,11 @@ BOOTBINARIES = "QCS615_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
     "
 SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs615"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Robotics RB3Gen2 platform"
-LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
@@ -9,9 +9,11 @@ BOOTBINARIES = "QCM6490_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \
     "
 SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcm6490"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS8300 platform"
-LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcs8300-le-1-0"
@@ -9,11 +9,13 @@ BOOTBINARIES = "QCS8300_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \
     "
 SRC_URI[qcs8300-ride-sx.sha256sum] = "d7fc667372b28383a36d586333097d84b9d9c104f4dd1845d33904e2d6b39f80"
 SRC_URI[cdt-iq8275-evk-pro-sku.sha256sum] = "cbe2009c8ef7dbacd716141bf01b8e1b26788c4a4f3145e60fe3b4a6b3aabc04"
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs8300"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS9100 platform"
-LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
 FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
@@ -9,11 +9,13 @@ BOOTBINARIES = "QCS9100_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx_v3.zip;downloadfilename=cdt-qcs9100-ride-sx-v3_${PV}.zip;name=qcs9100-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/rb8_core_kit.zip;downloadfilename=cdt-qcs9100-rb8-core-kit_${PV}.zip;name=qcs9100-rb8-ck \
     "
 SRC_URI[qcs9100-rb8-ck.sha256sum] = "a252244f800d7c9e15883e12935af4113f9f2ecba6490e46cd9b943169f15bfa"
 SRC_URI[qcs9100-ride-sx.sha256sum] = "377a8405899ac82199deaf70bca3648c15b924a3fcef8f109555e661ed70f4b9"
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs9100"
 


### PR DESCRIPTION
According to the latest legal guideline, correct the license information used for non-login boot binaries.