### PR TITLE
firmware-qcom-boot-qrb2210-rb1: specify correct license

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Prebuilt bootlader images for Qualcomm RB1"
 
-LICENSE = "Proprietary"
+LICENSE = "LICENSE.qcom"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=cbbe399f2c983ad51768f4561587f000"
 
 SRC_URI = "https://releases.linaro.org/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"


### PR DESCRIPTION
Correct the license name as LICENSE.qcom to match license file in boot firmware tarball.