### PR TITLE
qcom-partition-conf: bump SRCREV to consume contents.xml.in

### DIFF
--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "b4613bf6133f9e8e64ec1f6245e8625e1c9cfe9e"
+SRCREV = "7520239e6eec6d04df29159f79e8e29e28fef0b5"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Update SRCREV to the revision that includes contents.xml support for IQ-X7181. contents.xml will be deployed under spinor subfolder to support Axiom flashing.