### PR TITLE
fit-dtb-compatible: specify compatible for IQ-X7181

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -6,6 +6,7 @@
 FIT_DTB_COMPATIBLE[apq8016-sbc] = "qcom,apq8016-sbc"
 FIT_DTB_COMPATIBLE[apq8096-db820c] = "qcom,apq8096-sbc"
 FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
+FIT_DTB_COMPATIBLE[hamoa-iot-evk] = "qcom,hamoa-evk"
 FIT_DTB_COMPATIBLE[lemans-evk] = "qcom,qcs9075v2-iot"
 FIT_DTB_COMPATIBLE[lemans-evk-camera-csi1-imx577] = "qcom,lemans-evk"
 FIT_DTB_COMPATIBLE[lemans-evk-camx] = "qcom,qcs9075v2-iot-camx"


### PR DESCRIPTION
Specify multi-DTB compatible for IQ-X7181 device (hamoa-iot-evk).