### PR TITLE
camx-dlkm: Update to the latest revision

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_git.bb
+++ b/recipes-multimedia/camx/camx-dlkm_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SRC_URI = "git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0"
 
 PV = "0.0+git"
-SRCREV = "336a8f53aa022c4c8795e7d65b315493f40963d9"
+SRCREV = "ebf3a6a5c83d200eac437d90fdee44ee41889ae5"
 
 inherit module
 


### PR DESCRIPTION
This change includes the following updates:

- Add kernel‑compatible hard IRQ helper. Linux v6.19 removes in_irq() in favor of in_hardirq(), while ≤ v6.18 still provides in_irq(), causing camera‑kernel builds to fail on v6.19.

- Fix potential use‑after‑free on scratch buffers. User‑mode drivers provide scratch buffers for internal use by HW/kernel drivers.

- Fix CPAS DT node parsing with FIT runtime overlays. of_find_node_by_name() searches recursively and can return nodes outside the expected subtree, leading to incorrect references and cleanup issues when overlays are applied at runtime.

- Backports from 1.0 camera kernel component Pull in assorted fixes and cleanups from the 1.0 camera kernel component to keep behavior consistent across camera-kernel versions.