### PR TITLE
libdiag: Fix header installation path

### DIFF
--- a/recipes-test/libdiag/libdiag_1.0.3.bb
+++ b/recipes-test/libdiag/libdiag_1.0.3.bb
@@ -38,5 +38,5 @@ do_install() {
 
     # Install headers
     install -d ${D}${includedir}/diag
-    install -m 0644 ${S}/usr/include/diag/*.h ${D}${includedir}/
+    install -m 0644 ${S}/usr/include/diag/*.h ${D}${includedir}/diag/
 }


### PR DESCRIPTION
Install diag headers to the correct subdirectory path. Previously headers were installed to / directly,
now they are correctly installed to /diag/
to maintain proper header organization and avoid conflicts.