### PR TITLE
gstreamer1.0-plugins-base: Add bbappend to apply Qualcomm patches

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch
@@ -1,0 +1,179 @@
+From 3f1b805c6104b7e109bd6f0061f3fe14aa5dda0e Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 14 Feb 2025 15:05:28 +0530
+Subject: [PATCH] video: Add support for NV12_Q08C (compressed 8-bit) format
+
+Upstream-Status: Denied [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712]
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ gst-libs/gst/video/video-format.c | 23 ++++++++++++++++++++++
+ gst-libs/gst/video/video-format.h | 10 +++++++++-
+ gst-libs/gst/video/video-info.c   | 32 +++++++++++++++++++++++++++++++
+ gst-libs/gst/video/video-scaler.c |  1 +
+ tests/check/libs/video.c          |  4 ++++
+ 5 files changed, 69 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/video/video-format.c b/gst-libs/gst/video/video-format.c
+index 9bd9c69..b28abc3 100644
+--- a/gst-libs/gst/video/video-format.c
++++ b/gst-libs/gst/video/video-format.c
+@@ -1723,6 +1723,24 @@ unpack_NV21 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+   }
+ }
+ 
++#define PACK_NV12_Q08C GST_VIDEO_FORMAT_NV12, unpack_NV12_Q08C, 1, pack_NV12_Q08C
++static void
++unpack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    gpointer dest, const gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], gint x, gint y, gint width)
++{
++  GST_FIXME ("Unpack NV12_Q08C is not yet supported.");
++}
++
++static void
++pack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    const gpointer src, gint sstride, gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], GstVideoChromaSite chroma_site,
++    gint y, gint width)
++{
++  GST_FIXME ("Pack NV12_Q08C is not yet supported.");
++}
++
+ #define PACK_AV12 GST_VIDEO_FORMAT_AYUV, unpack_AV12, 1, pack_AV12
+ static void
+ unpack_AV12 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+@@ -8108,6 +8126,9 @@ static const VideoFormat formats[] = {
+       PSTR8888, PLANE0, OFFS0, SUB4444, PACK_Y416_BE),
+   MAKE_GRAY_LE_FORMAT (GRAY10_LE16, "raw video", DPTH10, PSTR2, PLANE0, OFFS0,
+       SUB4, PACK_GRAY10_LE16),
++  MAKE_YUV_FORMAT (NV12_Q08C, "raw video",
++      GST_MAKE_FOURCC ('Q', '0', '8', 'C'), DPTH888, PSTR122, PLANE011,
++      OFFS001, SUB420, PACK_NV12_Q08C),
+ };
+ 
+ G_GNUC_END_IGNORE_DEPRECATIONS;
+@@ -8368,6 +8389,8 @@ gst_video_format_from_fourcc (guint32 fourcc)
+       return GST_VIDEO_FORMAT_VUYA;
+     case GST_MAKE_FOURCC ('A', 'R', '3', '0'):
+       return GST_VIDEO_FORMAT_BGR10A2_LE;
++    case GST_MAKE_FOURCC ('Q', '0', '8', 'C'):
++      return GST_VIDEO_FORMAT_NV12_Q08C;
+ 
+     default:
+       return GST_VIDEO_FORMAT_UNKNOWN;
+diff --git a/gst-libs/gst/video/video-format.h b/gst-libs/gst/video/video-format.h
+index b59ec38..6593f8a 100644
+--- a/gst-libs/gst/video/video-format.h
++++ b/gst-libs/gst/video/video-format.h
+@@ -174,6 +174,7 @@ G_BEGIN_DECLS
+  * @GST_VIDEO_FORMAT_Y416_LE: packed 4:4:4:4 YUV, 16 bits per channel(U-Y-V-A) (Since: 1.26)
+  * @GST_VIDEO_FORMAT_Y416_BE: packed 4:4:4:4 YUV, 16 bits per channel(U-Y-V-A) (Since: 1.26)
+  * @GST_VIDEO_FORMAT_GRAY10_LE16: 10-bit grayscale, packed into 16bit words (6 bits padding) (Since: 1.26)
++ * @GST_VIDEO_FORMAT_NV12_Q08C: Qualcomm NV12 8bit compressed format
+  *
+  * Enum value describing the most common video formats.
+  *
+@@ -670,6 +671,13 @@ typedef enum {
+    */
+   GST_VIDEO_FORMAT_GRAY10_LE16,
+ 
++  /**
++   * GST_VIDEO_FORMAT_NV12_Q08C:
++   *
++   * Qualcomm NV12 8-bit compressed format.
++   */
++  GST_VIDEO_FORMAT_NV12_Q08C,
++
+   /* Update GST_VIDEO_FORMAT_LAST below when adding more formats here */
+ } GstVideoFormat;
+ 
+@@ -680,7 +688,7 @@ typedef enum {
+  *
+  * Since: 1.26
+  */
+-#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_GRAY10_LE16 + 1)
++#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q08C + 1)
+ 
+ #define GST_VIDEO_MAX_PLANES 4
+ #define GST_VIDEO_MAX_COMPONENTS 4
+diff --git a/gst-libs/gst/video/video-info.c b/gst-libs/gst/video/video-info.c
+index 04d52b0..f86b9b3 100644
+--- a/gst-libs/gst/video/video-info.c
++++ b/gst-libs/gst/video/video-info.c
+@@ -1389,6 +1389,38 @@ fill_planes (GstVideoInfo * info, gsize plane_size[GST_VIDEO_MAX_PLANES])
+       info->size = info->offset[1] + info->offset[1] / 2;
+       break;
+     }
++    case GST_VIDEO_FORMAT_NV12_Q08C:
++    {
++      gint y_plane_stride = 0, y_meta_stride = 0, y_meta_scanline = 0;
++      gint uv_plane_stride = 0, uv_meta_stride = 0, uv_meta_scanline = 0;
++      gint y_plane_scanline = 0, y_plane_size = 0, y_meta_size = 0;
++      gint uv_plane_scanline = 0, uv_plane_size = 0, uv_meta_size = 0;
++
++      y_plane_stride = GST_ROUND_UP_128 (width);
++      y_plane_scanline = GST_ROUND_UP_32 (height);
++      uv_plane_stride = GST_ROUND_UP_128 (width);
++      uv_plane_scanline = GST_ROUND_UP_32 (GST_ROUND_UP_2 (height) / 2);
++
++      y_meta_stride = GST_ROUND_UP_64 (GST_ROUND_UP_32 (width) / 32);
++      y_meta_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_8 (height) / 8);
++      uv_meta_stride = GST_ROUND_UP_64 (
++          GST_ROUND_UP_16 (GST_ROUND_UP_2 (width) / 2) / 16);
++      uv_meta_scanline = GST_ROUND_UP_16 (
++          GST_ROUND_UP_8 (GST_ROUND_UP_2 (height) / 2) / 8);
++
++      y_plane_size = GST_ROUND_UP_N (y_plane_stride * y_plane_scanline, 4096);
++      uv_plane_size = GST_ROUND_UP_N (uv_plane_stride * uv_plane_scanline, 4096);
++
++      y_meta_size = GST_ROUND_UP_N (y_meta_stride * y_meta_scanline, 4096);
++      uv_meta_size = GST_ROUND_UP_N (uv_meta_stride * uv_meta_scanline, 4096);
++
++      info->stride[0] = y_plane_stride;
++      info->stride[1] = uv_plane_stride;
++      info->offset[0] = 0;
++      info->offset[1] = y_plane_size + y_meta_size;
++      info->size = info->offset[1] + uv_plane_size + uv_meta_size;
++      break;
++    }
+     case GST_VIDEO_FORMAT_ENCODED:
+     case GST_VIDEO_FORMAT_DMA_DRM:
+       break;
+diff --git a/gst-libs/gst/video/video-scaler.c b/gst-libs/gst/video/video-scaler.c
+index d645087..0fa9e3d 100644
+--- a/gst-libs/gst/video/video-scaler.c
++++ b/gst-libs/gst/video/video-scaler.c
+@@ -1262,6 +1262,7 @@ get_functions (GstVideoScaler * hscale, GstVideoScaler * vscale,
+     case GST_VIDEO_FORMAT_NV21:
+     case GST_VIDEO_FORMAT_NV24:
+     case GST_VIDEO_FORMAT_NV61:
++    case GST_VIDEO_FORMAT_NV12_Q08C:
+       *bits = 8;
+       *n_elems = 2;
+       break;
+diff --git a/tests/check/libs/video.c b/tests/check/libs/video.c
+index 78a1786..5f8af9d 100644
+--- a/tests/check/libs/video.c
++++ b/tests/check/libs/video.c
+@@ -2185,6 +2185,9 @@ GST_START_TEST (test_video_pack_unpack2)
+     if (format == GST_VIDEO_FORMAT_DMA_DRM)
+       continue;
+ 
++    if (format == GST_VIDEO_FORMAT_NV12_Q08C)
++      continue;
++
+     finfo = gst_video_format_get_info (format);
+     fail_unless (finfo != NULL);
+ 
+@@ -3265,6 +3268,7 @@ GST_START_TEST (test_video_formats_pstrides)
+         || fmt == GST_VIDEO_FORMAT_NV12_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10BE_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10LE40_4L4
++        || fmt == GST_VIDEO_FORMAT_NV12_Q08C
+         || fmt == GST_VIDEO_FORMAT_DMA_DRM
+         || fmt == GST_VIDEO_FORMAT_MT2110T || fmt == GST_VIDEO_FORMAT_MT2110R) {
+       fmt++;
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch
@@ -1,0 +1,168 @@
+From 2e6037e7cd53f1bb05e76c24ebaff159c35751dd Mon Sep 17 00:00:00 2001
+From: Hui Liu <huliu@qti.qualcomm.com>
+Date: Tue, 18 Mar 2025 11:04:21 +0800
+Subject: [PATCH] video: Add support for NV12_Q10LE32C (compressed 10-bit)
+ format
+
+Upstream-Status: Denied [Same reason as 8-bit compressed format, https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712]
+
+Signed-off-by: Hui Liu <huliu@qti.qualcomm.com>
+---
+ gst-libs/gst/video/video-format.c | 23 +++++++++++++++++++++
+ gst-libs/gst/video/video-format.h | 10 ++++++++-
+ gst-libs/gst/video/video-info.c   | 34 +++++++++++++++++++++++++++++++
+ tests/check/libs/video.c          |  4 ++++
+ 4 files changed, 70 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/video/video-format.c b/gst-libs/gst/video/video-format.c
+index b28abc3..61a9912 100644
+--- a/gst-libs/gst/video/video-format.c
++++ b/gst-libs/gst/video/video-format.c
+@@ -1741,6 +1741,24 @@ pack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+   GST_FIXME ("Pack NV12_Q08C is not yet supported.");
+ }
+
++#define PACK_NV12_Q10LE32C GST_VIDEO_FORMAT_NV12_10LE32, unpack_NV12_Q10LE32C, 1, pack_NV12_Q10LE32C
++static void
++unpack_NV12_Q10LE32C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    gpointer dest, const gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], gint x, gint y, gint width)
++{
++  GST_FIXME ("Unpack NV12_Q10LE32C is not yet supported.");
++}
++
++static void
++pack_NV12_Q10LE32C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    const gpointer src, gint sstride, gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], GstVideoChromaSite chroma_site,
++    gint y, gint width)
++{
++  GST_FIXME ("Pack NV12_Q10LE32C is not yet supported.");
++}
++
+ #define PACK_AV12 GST_VIDEO_FORMAT_AYUV, unpack_AV12, 1, pack_AV12
+ static void
+ unpack_AV12 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+@@ -8129,6 +8147,9 @@ static const VideoFormat formats[] = {
+   MAKE_YUV_FORMAT (NV12_Q08C, "raw video",
+       GST_MAKE_FOURCC ('Q', '0', '8', 'C'), DPTH888, PSTR122, PLANE011,
+       OFFS001, SUB420, PACK_NV12_Q08C),
++  MAKE_YUV_FORMAT (NV12_Q10LE32C, "raw video",
++      GST_MAKE_FOURCC ('Q', '1', '0', 'C'), DPTH10_10_10, PSTR0, PLANE011,
++      OFFS001, SUB420, PACK_NV12_Q10LE32C),
+ };
+
+ G_GNUC_END_IGNORE_DEPRECATIONS;
+@@ -8391,6 +8412,8 @@ gst_video_format_from_fourcc (guint32 fourcc)
+       return GST_VIDEO_FORMAT_BGR10A2_LE;
+     case GST_MAKE_FOURCC ('Q', '0', '8', 'C'):
+       return GST_VIDEO_FORMAT_NV12_Q08C;
++    case GST_MAKE_FOURCC ('Q', '1', '0', 'C'):
++      return GST_VIDEO_FORMAT_NV12_Q10LE32C;
+
+     default:
+       return GST_VIDEO_FORMAT_UNKNOWN;
+diff --git a/gst-libs/gst/video/video-format.h b/gst-libs/gst/video/video-format.h
+index 6593f8a..6c4d61d 100644
+--- a/gst-libs/gst/video/video-format.h
++++ b/gst-libs/gst/video/video-format.h
+@@ -175,6 +175,7 @@ G_BEGIN_DECLS
+  * @GST_VIDEO_FORMAT_Y416_BE: packed 4:4:4:4 YUV, 16 bits per channel(U-Y-V-A) (Since: 1.26)
+  * @GST_VIDEO_FORMAT_GRAY10_LE16: 10-bit grayscale, packed into 16bit words (6 bits padding) (Since: 1.26)
+  * @GST_VIDEO_FORMAT_NV12_Q08C: Qualcomm NV12 8bit compressed format
++ * @GST_VIDEO_FORMAT_NV12_Q10LE32C: Qualcomm NV12 10-bit compressed format.
+  *
+  * Enum value describing the most common video formats.
+  *
+@@ -678,6 +679,13 @@ typedef enum {
+    */
+   GST_VIDEO_FORMAT_NV12_Q08C,
+
++  /**
++   * GST_VIDEO_FORMAT_NV12_Q10LE32C:
++   *
++   * Qualcomm NV12 10-bit compressed format.
++   */
++  GST_VIDEO_FORMAT_NV12_Q10LE32C,
++
+   /* Update GST_VIDEO_FORMAT_LAST below when adding more formats here */
+ } GstVideoFormat;
+
+@@ -688,7 +696,7 @@ typedef enum {
+  *
+  * Since: 1.26
+  */
+-#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q08C + 1)
++#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q10LE32C + 1)
+
+ #define GST_VIDEO_MAX_PLANES 4
+ #define GST_VIDEO_MAX_COMPONENTS 4
+diff --git a/gst-libs/gst/video/video-info.c b/gst-libs/gst/video/video-info.c
+index f86b9b3..0e31528 100644
+--- a/gst-libs/gst/video/video-info.c
++++ b/gst-libs/gst/video/video-info.c
+@@ -1421,6 +1421,40 @@ fill_planes (GstVideoInfo * info, gsize plane_size[GST_VIDEO_MAX_PLANES])
+       info->size = info->offset[1] + uv_plane_size + uv_meta_size;
+       break;
+     }
++    case GST_VIDEO_FORMAT_NV12_Q10LE32C:
++    {
++      gint y_plane_stride = 0, y_meta_stride = 0, y_meta_scanline = 0;
++      gint uv_plane_stride = 0, uv_meta_stride = 0, uv_meta_scanline = 0;
++      gint y_plane_scanline = 0, y_plane_size = 0, y_meta_size = 0;
++      gint uv_plane_scanline = 0, uv_plane_size = 0, uv_meta_size = 0;
++
++      y_plane_stride = GST_ROUND_UP_N (
++          (GST_ROUND_UP_N (width, 192) * 4 / 3), 256);
++      y_plane_scanline = GST_ROUND_UP_16 (height);
++      uv_plane_stride = GST_ROUND_UP_N (
++          (GST_ROUND_UP_N (width, 192) * 4 / 3), 256);
++      uv_plane_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_2 (height) / 2);
++
++      y_meta_stride = GST_ROUND_UP_64 (GST_ROUND_UP_N (width, 48) / 48);
++      y_meta_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_4 (height) / 4);
++      uv_meta_stride = GST_ROUND_UP_64 (
++          GST_ROUND_UP_N ((GST_ROUND_UP_2 (width) / 2), 24) / 24);
++      uv_meta_scanline = GST_ROUND_UP_16 (
++          GST_ROUND_UP_4 (GST_ROUND_UP_2 (height) / 2) / 4);
++
++      y_plane_size = GST_ROUND_UP_N (y_plane_stride * y_plane_scanline, 4096);
++      uv_plane_size = GST_ROUND_UP_N (uv_plane_stride * uv_plane_scanline, 4096);
++
++      y_meta_size = GST_ROUND_UP_N (y_meta_stride * y_meta_scanline, 4096);
++      uv_meta_size = GST_ROUND_UP_N (uv_meta_stride * uv_meta_scanline, 4096);
++
++      info->stride[0] = y_plane_stride;
++      info->stride[1] = uv_plane_stride;
++      info->offset[0] = 0;
++      info->offset[1] = y_plane_size + y_meta_size;
++      info->size = info->offset[1] + uv_plane_size + uv_meta_size;
++      break;
++    }
+     case GST_VIDEO_FORMAT_ENCODED:
+     case GST_VIDEO_FORMAT_DMA_DRM:
+       break;
+diff --git a/tests/check/libs/video.c b/tests/check/libs/video.c
+index 5f8af9d..dd3d696 100644
+--- a/tests/check/libs/video.c
++++ b/tests/check/libs/video.c
+@@ -2188,6 +2188,9 @@ GST_START_TEST (test_video_pack_unpack2)
+     if (format == GST_VIDEO_FORMAT_NV12_Q08C)
+       continue;
+
++    if (format == GST_VIDEO_FORMAT_NV12_Q10LE32C)
++      continue;
++
+     finfo = gst_video_format_get_info (format);
+     fail_unless (finfo != NULL);
+
+@@ -3269,6 +3272,7 @@ GST_START_TEST (test_video_formats_pstrides)
+         || fmt == GST_VIDEO_FORMAT_NV12_10BE_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10LE40_4L4
+         || fmt == GST_VIDEO_FORMAT_NV12_Q08C
++        || fmt == GST_VIDEO_FORMAT_NV12_Q10LE32C
+         || fmt == GST_VIDEO_FORMAT_DMA_DRM
+         || fmt == GST_VIDEO_FORMAT_MT2110T || fmt == GST_VIDEO_FORMAT_MT2110R) {
+       fmt++;
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-videometa-Update-the-aggregation-logic-for-stride-al.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-videometa-Update-the-aggregation-logic-for-stride-al.patch
@@ -1,0 +1,51 @@
+From 41b772e4fec4a4bbf5d0ff9a8ee5bc88b7ded428 Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+Date: Thu, 13 Mar 2025 22:11:35 +0530
+Subject: [PATCH] videometa: Update the aggregation logic for stride align
+
+- Stride aligns can be of any number
+- Current aggregation logic for stride align will work only
+  when the stride aligns are power of 2
+- Taking least common multiple of the stride aligns to aggregate
+
+Upstream-Status: Denied [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10195]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ gst-libs/gst/video/gstvideometa.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/gst-libs/gst/video/gstvideometa.c b/gst-libs/gst/video/gstvideometa.c
+index e3a2372..974fd2a 100644
+--- a/gst-libs/gst/video/gstvideometa.c
++++ b/gst-libs/gst/video/gstvideometa.c
+@@ -174,9 +174,24 @@ gst_video_meta_api_params_aggregator (GstStructure ** aggregated_params,
+   aggregated_align.padding_right =
+       MAX (align0.padding_right, align1.padding_right);
+
+-  for (int n = 0; n < GST_VIDEO_MAX_PLANES; ++n)
+-    aggregated_align.stride_align[n] =
+-        align0.stride_align[n] | align1.stride_align[n];
++  // Calculate the lowest common multiple for the stride alignments.
++  for (int n = 0; n < GST_VIDEO_MAX_PLANES; ++n) {
++    guint max = 0;
++
++    max = MAX (align0.stride_align[n], align1.stride_align[n]);
++    aggregated_align.stride_align[n] = max;
++
++    if ((align0.stride_align[n] == 0) || (align1.stride_align[n] == 0))
++      continue;
++
++    while (
++        ((aggregated_align.stride_align[n] + 1) % (align0.stride_align[n] + 1)
++            != 0)
++        || ((aggregated_align.stride_align[n] + 1)
++                % (align1.stride_align[n] + 1)
++            != 0))
++      aggregated_align.stride_align[n] += max + 1;
++  }
+
+   *aggregated_params = gst_structure_new_empty ("video-meta");
+
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,9 @@
+# To apply patches to support Qualcomm specific formats and fixes
+
+FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch \
+    file://0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch \
+    file://0003-videometa-Update-the-aggregation-logic-for-stride-al.patch \
+"


### PR DESCRIPTION
### Summary
This PR adds `bbappend` file to the `gstreamer1.0-plugins-base` recipe to append additional patches from an external series file after the base recipe patches. The patches are imported using `quilt` in the correct order and applied after existing patches.

### Key Changes
- Fetched additional patches and `series` file from external Git repository
- Skipped lines starting with `#` in the series file (treated as comments).
- Imported and applied patches in series file order using quilt import and push

### Temporary Setup
There is a separate pull request raised on the **patches repository** which is pending review and merge.  
Until that PR is merged, `SRC_URI` in this recipe points to **my forked repository** to fetch the patches.

### Merge Condition
**Please merge this PR only after the patches PR is merged** in the patches repository, `gst-qti-oss-patches`,  to ensure consistency.

### Testing
- Verified patches apply in correct order mentioned in `series` file.
- Confirmed that comment lines (`#`) in the series file, if any, are skipped.
- Build completed successfully with updated patches.