### PR TITLE
ci: Optimizing costs for AWS self-hosted runners

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   kas-setup:
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - name: Update kas-container
         run: |
@@ -44,7 +44,7 @@ jobs:
   yocto-run-checks:
     needs: kas-setup
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +64,7 @@ jobs:
   compile_warm_up:
     needs: [kas-setup, yocto-run-checks]
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:
       fail-fast: true
       matrix:
@@ -108,7 +108,7 @@ jobs:
   compile:
     needs: compile_warm_up
     if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     outputs:
       url: ${{ steps.compile_kas.outputs.url }}
     strategy:
@@ -184,7 +184,7 @@ jobs:
 
   publish_summary:
     needs: compile
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - name: 'Download build URLs'
         uses: actions/download-artifact@v6


### PR DESCRIPTION
With this update, the AWS self-hosted runner instance type will change from "c5ad.8xlarge" to "m8a.4xlarge". This adjustment will improve build performance by at least 20% and lower the hourly cost by 30%.

The runner instance has been tested in the Stage environment. For reference, here is a sample build workflow:
https://github.com/qualcomm-linux-stg/aws-meta-qcom/actions/runs/20283368465

<img width="1332" height="317" alt="image" src="https://github.com/user-attachments/assets/f8997e2b-42dd-4fe5-b7ed-de2ebd0a0d8a" />
