### PR TITLE
ci: qcom-distro-prop-image: add container orchestration image

### DIFF
--- a/ci/qcom-distro-prop-image.yml
+++ b/ci/qcom-distro-prop-image.yml
@@ -8,3 +8,4 @@ header:
 target:
   - qcom-multimedia-image
   - qcom-multimedia-proprietary-image
+  - qcom-container-orchestration-image


### PR DESCRIPTION
Include qcom-container-orchestration-image to target list.

Purpose:
Enable validation of container orchestration and related technologies against the qcom-next kernel and ensure the Qualcomm reference distro includes the packages needed to support Kubernetes and container runtimes out of the box.

Related: https://github.com/qualcomm-linux/meta-qcom-distro/pull/127