### PR TITLE
android-tools-conf-configfs: handle multiple UDC controllers on IQ-X7181

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+sleep 10
+
+ls /sys/class/udc/ | head -n 1 | xargs echo -n > /sys/kernel/config/usb_gadget/adb/UDC
+
+echo "Setting UDC $(ls /sys/class/udc/ | head -n 1) for USB ADB Gadget usage"


### PR DESCRIPTION
On IQ-X7181 EVK board, below command in android-gadget-start script will hit issue as there are multiple UDC controllers. Overwrite the script to ensure adb work normally.

ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/adb/UDC 
in https://github.com/openembedded/meta-openembedded/blob/master/meta-oe/dynamic-layers/selinux/recipes-devtool/android-tools/android-tools-conf-configfs/android-gadget-start

Error:
root@iq-x7181-evk:/# ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/adb/UDC 
ls: write error: Device or resource busy