### PR TITLE
packagegroup-hamoa-iot-evk: add WiFi and BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
@@ -9,8 +9,8 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g705 linux-firmware-qcom-x1e80100-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
     linux-firmware-qcom-x1e80100-audio \
     linux-firmware-qcom-x1e80100-compute \
     linux-firmware-qcom-vpu \


### PR DESCRIPTION
The HAMOA-IOT-EVK platform need support WCN685x and WCN7850 connectivity modules over the M.2 interface and therefore needs the corresponding firmware.

Add the required firmware packages for the supported modules:

WCN685x connectivity module requires:
  - linux-firmware-qca-qca61x4-usb (BT USB firmware)
  - linux-firmware-ath11k-wcn6855 (WiFi firmware)

WCN7850 connectivity module requires:
  - linux-firmware-qca-qca61x4-usb (BT USB firmware)