### PR TITLE
packagegroup-iq-8275-evk: add BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
@@ -10,7 +10,7 @@ PACKAGES = " \
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x', '', d)} \
     linux-firmware-qcom-qcs8300-audio \
     linux-firmware-qcom-qcs8300-compute \
     linux-firmware-qcom-qcs8300-generalpurpose \


### PR DESCRIPTION
The IQ-8275-EVK platform need support WCN685x connectivity module over the M.2 interface and therefore needs the corresponding firmware.

Add the required firmware packages for the supported modules:

WCN685x connectivity module requires:
  - linux-firmware-qca-wcn685x (BT UART firmware)
  - linux-firmware-qca-qca61x4-usb (BT USB firmware)