### PR TITLE
workflows/pr.yml: skip on documentation changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,10 @@ name: Build on PR
 
 on:
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'README'
+      - 'SECURITY.md'
 
 permissions:
   checks: write


### PR DESCRIPTION
Documentation changes do not need full builds to be run. Skip to save resources.