### PR TITLE
minkipc: add REDEPENDS for minkipc-qteesupplicant

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_git.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_git.bb
@@ -33,6 +33,8 @@ FILES:${PN}-qteesupplicant = "${bindir}/qtee_supplicant \
                               ${nonarch_libdir}/udev/rules.d/99-qcomtee-udev.rules \
 "
 
+RDEPENDS:${PN}-qteesupplicant = "${PN}"
+
 # Currently, this recipe only builds and installs for ARMv8 (aarch64) machine.
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
Ensure the minkipc-qteesupplicant package declares a runtime dependency on minkipc.

The minkipc-qteesupplicant component requires the minkipc related libraries at runtime. Without an explicit runtime dependency the minkipc package may not be pulled into images, which can lead to runtime failures for qtee_supplicant. Add a RDEPENDS entry to the minkipc_git.bb recipe so package managers and image assembly pull in minkipc automatically.