### PR TITLE
Add initial changes for Glymur-CRD board

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -139,6 +139,7 @@ jobs:
       fail-fast: true
       matrix:
         machine:
+          - glymur-crd
           - iq-615-evk
           - iq-8275-evk
           - iq-9075-evk

--- a/ci/glymur-crd.yml
+++ b/ci/glymur-crd.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: glymur-crd

--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -1,0 +1,25 @@
+#@TYPE: Machine
+#@NAME: Qualcomm Glymur Compute Reference Device
+#@DESCRIPTION: Machine configuration for Qualcomm Glymur Compute Reference Device
+
+require conf/machine/include/qcom-glymur.inc
+
+MACHINE_FEATURES = "efi pci"
+
+QCOM_DTB_DEFAULT ?= "glymur-crd"
+
+KERNEL_DEVICETREE ?= " \
+    qcom/glymur-crd.dtb \
+"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-glymur-crd-firmware \
+    packagegroup-glymur-crd-hexagon-dsp-binaries \
+"
+
+QCOM_CDT_FILE = "cdt_glymur_crd_0.1.0"
+QCOM_BOOT_FILES_SUBDIR = "glymur-crd"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/glymur-crd/nvme"
+QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/glymur-crd/spinor"
+
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-glymur"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -6,6 +6,7 @@
 
 FIT_DTB_COMPATIBLE[apq8016-sbc] = "qcom,apq8016-sbc"
 FIT_DTB_COMPATIBLE[apq8096-db820c] = "qcom,apq8096-sbc"
+FIT_DTB_COMPATIBLE[glymur-crd] = "qcom,glymur-crd"
 FIT_DTB_COMPATIBLE[hamoa-iot-evk] = " \
     qcom,hamoa-evk \
     qcom,hamoav2.1-evk \

--- a/conf/machine/include/qcom-glymur.inc
+++ b/conf/machine/include/qcom-glymur.inc
@@ -1,0 +1,16 @@
+# Configurations and variables for glymur SoC family.
+
+SOC_FAMILY = "glymur"
+require conf/machine/include/qcom-base.inc
+require conf/machine/include/qcom-common.inc
+
+DEFAULTTUNE = "armv8-6a-crypto"
+require conf/machine/include/arm/arch-armv8-6a.inc
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
@@ -1,0 +1,22 @@
+DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm GLYMUR-CRD platform"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/software/chip/qualcomm_linux-spf-0-0/qualcomm-linux-spf-0-0_test_device_public"
+FW_BUILD_ID = "r0.0_${PV}/glymur-le-0-0"
+FW_BIN_PATH = "common/build/bin"
+BOOTBINARIES = "Glymur_bootbinaries"
+
+S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SC8480XP/cdt/sc8480xp-crd.zip;downloadfilename=sc8480xp-crd_${PV}.zip;name=sc8480xp-crd \
+    "
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
+SRC_URI[sc8480xp-crd.sha256sum] = "d694eedb0addcc5ee588d6993661cd23996fba1d1a43afc3b196dad12534bffc"
+
+QCOM_BOOT_IMG_SUBDIR = "glymur-crd/spinor"
+
+include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00009.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00009.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-glymur.inc
+
+SRC_URI[bootbinaries.sha256sum] = "79df8ab4cc3248472d819098d20829ab129828c19937525cfc16f089d65a7a42"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260221.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260221.bb
@@ -247,6 +247,8 @@ INSANE_SKIP:${PN}-thundercomm-rb5-cdsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:${PN}-thundercomm-rb5-sdsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:${PN}-thundercomm-rubikpi3-adsp = "arch libdir file-rdeps textrel"
 
+SKIP_FILEDEPS:${PN}-qcom-glymur-crd-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-glymur-crd-cdsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-hamoa-iot-evk-adsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-adsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-cdsp = "1"

--- a/recipes-bsp/packagegroups/packagegroup-glymur-crd.bb
+++ b/recipes-bsp/packagegroups/packagegroup-glymur-crd.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Packages for the GLYMUR-CRD platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g801 linux-firmware-qcom-glymur-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
+    linux-firmware-qcom-glymur-audio \
+    linux-firmware-qcom-glymur-compute \
+    linux-firmware-qcom-vpu \
+"
+
+RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-glymur-crd-adsp \
+    hexagon-dsp-binaries-qcom-glymur-crd-cdsp \
+"

--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "28c6e9792121cb1c4e8ba74ee3c61e5041b9f861"
+SRCREV = "386018c76d9b4f63141ad33905506e231cdc6f38"
 
 INHIBIT_DEFAULT_DEPS = "1"
 

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -17,8 +17,9 @@ UKI_CMDLINE += "${@d.getVar('KERNEL_CMDLINE_EXTRA') or ''}"
 
 # Remove 'upstream' dtb, rely on EFI provided one
 KERNEL_DEVICETREE = ""
-KERNEL_DEVICETREE:sm8750-mtp = "${QCOM_DTB_DEFAULT}.dtb"
+KERNEL_DEVICETREE:glymur-crd = "${QCOM_DTB_DEFAULT}.dtb"
 KERNEL_DEVICETREE:kaanapali-mtp = "${QCOM_DTB_DEFAULT}.dtb"
+KERNEL_DEVICETREE:sm8750-mtp = "${QCOM_DTB_DEFAULT}.dtb"
 
 IMAGE_FSTYPES = "vfat"
 IMAGE_FSTYPES_DEBUGFS = ""


### PR DESCRIPTION
Adding below changes for glymur-crd board:

- machine configuration
- set KERNEL_DEVICETREE with default dtb to pack DTB inside UKI
- adding linux-firmware and hexagon dsp packages
- add boot firmware recipe
- update SRCREV for qcom-partition-conf recipe to include partition conf
- KAS configuration file