### PR TITLE
qcom-armv8a: Unify KERNEL_DEVICETREE across kernels

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -28,7 +28,10 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 KERNEL_DEVICETREE ?= " \
     qcom/apq8016-sbc.dtb \
     qcom/apq8096-db820c.dtb \
+    qcom/hamoa-iot-evk.dtb \
     qcom/lemans-evk.dtb \
+    qcom/lemans-evk-camera-csi1-imx577.dtb \
+    qcom/monaco-evk.dtb \
     qcom/qcm6490-idp.dtb \
     qcom/qcs404-evb-4000.dtb \
     qcom/qcs615-ride.dtb \
@@ -41,8 +44,10 @@ KERNEL_DEVICETREE ?= " \
     qcom/qrb4210-rb2.dtb \
     qcom/qrb5165-rb5.dtb \
     qcom/sa8775p-ride.dtb \
+    qcom/sa8775p-ride-r3.dtb \
     qcom/sdm845-db845c.dtb \
     qcom/sm8450-hdk.dtb \
+    qcom/sm8750-mtp.dtb \
 "
 
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] ?= "2048"


### PR DESCRIPTION
Both linux-qcom and linux-yocto-dev kernels now share the same LTS version
eliminating the need for separate device tree lists. Unified list ensures
a consistent set of DTBs is built for all kernels.