### PR TITLE
gstreamer1.0-plugins-bad: Add bbappend to apply Qualcomm patches

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
@@ -1,0 +1,118 @@
+From 3dd7f653cd03216302f3c3e1d5e567986c26f3bc Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Fri, 9 Jan 2026 15:04:05 +0530
+Subject: [PATCH] wayland: Add support for NV12_Q08C (compressed 8-bit)
+ format
+
+- Add NV12_Q08C to static caps
+- Update the modifier value in set_caps for NV12_Q08C
+- Add NV12_Q08C to shm formats if present in dmabuf formats
+
+Upstream-Status: Denied [Adding NV12_Q08C format is denied by upstream, for compatibility, need to maintain this patch. https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ ext/wayland/gstwaylandsink.c            | 34 +++++++++++++++++++++++++
+ gst-libs/gst/wayland/gstwlvideoformat.c |  1 +
+ gst-libs/gst/wayland/gstwlvideoformat.h |  6 +++--
+ 3 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 19a3e8c..030fe1b 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -568,11 +568,30 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+   if (self->display) {
+     GValue format_list = G_VALUE_INIT;
++    GValue value = G_VALUE_INIT;
++    gint j;
+ 
+     g_value_init (&format_list, GST_TYPE_LIST);
+ 
+     /* Add corresponding dmabuf formats */
+     gst_wl_display_fill_dmabuf_format_list (self->display, &format_list);
++
++    for (j = 0; j < gst_value_list_get_size (&format_list); j++) {
++      const GValue *vlist = gst_value_list_get_value (&format_list, j);
++      guint32 fourcc;
++      guint64 modifier;
++
++      fourcc = gst_video_dma_drm_fourcc_from_string (g_value_get_string (vlist),
++          &modifier);
++      if (fourcc == DRM_FORMAT_NV12 &&
++          modifier == DRM_FORMAT_MOD_QCOM_COMPRESSED) {
++        GST_DEBUG_OBJECT (self, "Found NV12_Q08C in DMAbuf format list");
++        g_value_init (&value, G_TYPE_STRING);
++        g_value_set_static_string (&value,
++            gst_video_format_to_string (GST_VIDEO_FORMAT_NV12_Q08C));
++      }
++    }
++
+     gst_structure_take_value (gst_caps_get_structure (caps, 0), "drm-format",
+         &format_list);
+ 
+@@ -580,6 +599,10 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+     /* Add corresponding shm formats */
+     gst_wl_display_fill_shm_format_list (self->display, &format_list);
++    if (G_VALUE_HOLDS_STRING (&value)) {
++      GST_DEBUG_OBJECT (self, "Adding NV12_Q08C to SHM format list");
++      gst_value_list_append_and_take_value (&format_list, &value);
++    }
+     gst_structure_take_value (gst_caps_get_structure (caps, 1), "format",
+         &format_list);
+ 
+@@ -706,6 +729,17 @@ gst_wayland_sink_set_caps (GstBaseSink * bsink, GstCaps * caps)
+     if (!gst_video_info_dma_drm_from_video_info (&self->drm_info,
+             &self->video_info, DRM_FORMAT_MOD_LINEAR))
+       gst_video_info_dma_drm_init (&self->drm_info);
++
++    if (GST_VIDEO_INFO_FORMAT (&self->video_info) == GST_VIDEO_FORMAT_NV12_Q08C) {
++      self->drm_info.vinfo = self->video_info;
++      self->drm_info.drm_fourcc = gst_video_dma_drm_fourcc_from_format (
++          GST_VIDEO_FORMAT_NV12);
++      self->drm_info.drm_modifier = DRM_FORMAT_MOD_QCOM_COMPRESSED;
++
++      GST_DEBUG_OBJECT (self, "DRM format %" GST_FOURCC_FORMAT " Modifier "
++          "0x%016" G_GINT64_MODIFIER "x", GST_FOURCC_ARGS (
++              self->drm_info.drm_fourcc), self->drm_info.drm_modifier);
++    }
+   }
+ 
+   self->video_info_changed = TRUE;
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.c b/gst-libs/gst/wayland/gstwlvideoformat.c
+index 1c0ea59..1800243 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.c
++++ b/gst-libs/gst/wayland/gstwlvideoformat.c
+@@ -94,6 +94,7 @@ static const wl_VideoFormat wl_formats[] = {
+   {WL_SHM_FORMAT_YVU420, DRM_FORMAT_YVU420, GST_VIDEO_FORMAT_YV12},
+   {WL_SHM_FORMAT_YUV422, DRM_FORMAT_YUV422, GST_VIDEO_FORMAT_Y42B},
+   {WL_SHM_FORMAT_YUV444, DRM_FORMAT_YUV444, GST_VIDEO_FORMAT_v308},
++  {WL_SHM_FORMAT_NV12, DRM_FORMAT_NV12, GST_VIDEO_FORMAT_NV12_Q08C},
+ };
+ 
+ enum wl_shm_format
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.h b/gst-libs/gst/wayland/gstwlvideoformat.h
+index 5d7eb7c..a07e110 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.h
++++ b/gst-libs/gst/wayland/gstwlvideoformat.h
+@@ -39,11 +39,13 @@ G_BEGIN_DECLS
+ #if G_BYTE_ORDER == G_BIG_ENDIAN
+ #define GST_WL_VIDEO_FORMATS "{ AYUV, RGBA, ARGB, BGRA, ABGR, P010_10LE, " \
+     "NV12_10LE40, v308, RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, " \
+-    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, " \
++    "NV12_Q08C }"
+ #elif G_BYTE_ORDER == G_LITTLE_ENDIAN
+ #define GST_WL_VIDEO_FORMATS "{ AYUV, RGBA, ARGB, BGRA, ABGR, P010_10LE, " \
+     "NV12_10LE40, v308, RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, " \
+-    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, " \
++    "NV12_Q08C }"
+ #endif
+ 
+ GST_WL_API
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch
@@ -1,0 +1,71 @@
+From 1ceb41fd9f93e3650edfeb581dd03c1118c7b519 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 9 Jan 2026 17:32:32 +0530
+Subject: [PATCH] waylandsink: Release pending buffers during PAUSED to
+ READY state change
+
+Add functionality to forcibly release any pending buffers in the
+wayland compositor at GST_STATE_CHANGE_PAUSED_TO_READY. This is
+needed because some live sources may require all buffers to be
+returned when transitioning to READY state.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10386 ]
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ ext/wayland/gstwaylandsink.c        |  1 +
+ gst-libs/gst/wayland/gstwldisplay.c | 16 ++++++++++++++++
+ gst-libs/gst/wayland/gstwldisplay.h |  3 +++
+ 3 files changed, 20 insertions(+)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 030fe1b..a7187c5 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -477,6 +477,7 @@ gst_wayland_sink_change_state (GstElement * element, GstStateChange transition)
+         }
+       }
+ 
++      gst_wl_display_force_release_buffers (self->display);
+       break;
+     case GST_STATE_CHANGE_READY_TO_NULL:
+       g_mutex_lock (&self->display_lock);
+diff --git a/gst-libs/gst/wayland/gstwldisplay.c b/gst-libs/gst/wayland/gstwldisplay.c
+index c580565..2542efb 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.c
++++ b/gst-libs/gst/wayland/gstwldisplay.c
+@@ -767,3 +767,19 @@ gst_wl_display_has_own_display (GstWlDisplay * self)
+ 
+   return priv->own_display;
+ }
++
++void
++gst_wl_display_force_release_buffers (GstWlDisplay * self)
++{
++  GstWlDisplayPrivate *priv = gst_wl_display_get_instance_private (self);
++
++  /* to avoid buffers being unregistered from another thread
++   * at the same time, take their ownership */
++  g_mutex_lock (&priv->buffers_mutex);
++  g_hash_table_foreach (priv->buffers, gst_wl_ref_wl_buffer, NULL);
++  g_mutex_unlock (&priv->buffers_mutex);
++
++  g_hash_table_foreach (priv->buffers,
++      (GHFunc) gst_wl_buffer_force_release_and_unref, NULL);
++  g_hash_table_remove_all (priv->buffers);
++}
+diff --git a/gst-libs/gst/wayland/gstwldisplay.h b/gst-libs/gst/wayland/gstwldisplay.h
+index b2f0ca3..a4b3803 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.h
++++ b/gst-libs/gst/wayland/gstwldisplay.h
+@@ -121,4 +121,7 @@ struct wp_single_pixel_buffer_manager_v1 * gst_wl_display_get_single_pixel_buffe
+ GST_WL_API
+ gboolean gst_wl_display_has_own_display (GstWlDisplay * self);
+ 
++GST_WL_API
++void gst_wl_display_force_release_buffers (GstWlDisplay * self);
++
+ G_END_DECLS
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0003-waylandsink-support-gap-buffers.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0003-waylandsink-support-gap-buffers.patch
@@ -1,0 +1,35 @@
+From f6d1928d09ff7aef2d64542930600a30934ab98b Mon Sep 17 00:00:00 2001
+From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
+Date: Thu, 18 May 2023 11:38:14 +0300
+Subject: [PATCH] waylandsink: support gap buffers
+
+- When a GAP buffer is received for rendering, simply drop it.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10275 ]
+
+Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
+---
+ ext/wayland/gstwaylandsink.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index a7187c5..b1bec1c 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -904,6 +904,13 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
+     }
+   }
+ 
++  /* GAP buffer, nothing further to do */
++  if (gst_buffer_get_size (buffer) == 0 &&
++      GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_GAP)) {
++    GST_LOG_OBJECT (self, "buffer %p dropped (gap in the stream)", buffer);
++    goto done;
++  }
++
+   /* make sure that the application has called set_render_rectangle() */
+   if (G_UNLIKELY (gst_wl_window_get_render_rectangle (self->window)->w == 0))
+     goto no_window_size;
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-waylandsink-make-sure-self-window-is-not-NULL-before.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-waylandsink-make-sure-self-window-is-not-NULL-before.patch
@@ -1,0 +1,50 @@
+From 15e8f4f0a5cf0fdc7ad4c087225b921f302a13f0 Mon Sep 17 00:00:00 2001
+From: Michael Olbrich <m.olbrich@pengutronix.de>
+Date: Wed, 25 Jun 2025 16:17:58 +0200
+Subject: [PATCH] waylandsink: make sure self->window is not NULL before using
+ it
+
+self->window is created with the first frame, so it is not available when
+properties are set during construction of the element.
+Skip calling gst_wl_window_ensure_fullscreen() in this case.
+
+The window is already constructed with the current configured fullscreen state,
+nothing else in needed here.
+
+Without this, running e.g. 'gst-launch-1.0 -v videotestsrc ! waylandsink
+fullscreen=true' will result in:
+
+GStreamer-Wayland-CRITICAL **: 14:11:19.921: gst_wl_window_ensure_fullscreen: assertion 'self' failed
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9283>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/96b800f82a3084eec8e4e970a7f5ce6743967e45 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ ext/wayland/gstwaylandsink.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index b1bec1c..a4c911d 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -209,10 +209,12 @@ gst_wayland_sink_set_fullscreen (GstWaylandSink * self, gboolean fullscreen)
+   if (fullscreen == self->fullscreen)
+     return;
+ 
+-  g_mutex_lock (&self->render_lock);
+   self->fullscreen = fullscreen;
+-  gst_wl_window_ensure_fullscreen (self->window, fullscreen);
+-  g_mutex_unlock (&self->render_lock);
++  if (self->window) {
++    g_mutex_lock (&self->render_lock);
++    gst_wl_window_ensure_fullscreen (self->window, fullscreen);
++    g_mutex_unlock (&self->render_lock);
++  }
+ }
+ 
+ static void
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,10 @@
+# To apply patches to support Qualcomm specific formats and fixes
+
+FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch \
+    file://0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch \
+    file://0003-waylandsink-support-gap-buffers.patch \
+    file://0004-waylandsink-make-sure-self-window-is-not-NULL-before.patch \
+"


### PR DESCRIPTION
This change introduces a **.bbappend** file for **gstreamer1.0-plugins-bad** to incorporate Qualcomm patches that are not accepted upstream. 

### List of patches:
-   wayland: Add support for NV12_Q08C (compressed 8-bit) format
-   waylandsink: Release pending buffers during PAUSED to READY state change
-   waylandsink: support gap buffers
-   waylandsink: make sure self->window is not NULL before using it

### Patch Details:
**Compressed NV12 format support**
  Because upstream does not support Qualcomm’s compressed formats in the base plugins, the waylandsink plugin must also be updated to correctly recognize and handle NV12_Q08C.
**Pending buffer release during PAUSED -> READY**
  Qualcomm camera sources require releasing pending buffers during the PAUSED to READY state change to properly close the session with the Wayland server. This patch has been submitted upstream.
**Handling GAP buffers**
  Some elements emit zero‑sized GAP buffers to signal stream gaps. These should not be rendered, so the patch ensures they are safely dropped. This patch has been submitted upstream.
**Window validity check**
  A backported upstream patch adds a defensive check ensuring self->window is non‑NULL before attempting to set fullscreen mode.

### Merge Condition
This PR depends on #1349 .
Please review and merge the gstreamer1.0-plugins-base PR first.

Requires: #1349 