### PR TITLE
workflows: lava-test-plans: Add pvt tag for iq-9075-evk target

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -59,6 +59,10 @@ runs:
           echo "AUTH_HEADER_TOKEN=Q_GITHUB_TOKEN" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "FLASHER_DEVICE_TYPE=qcs" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          # Add pvt tag for iq-9075-evk
+          if [ "${{ inputs.machine }}" = "iq-9075-evk" ]; then
+            echo "TAGS=pvt" >> gh-variables.ini
+          fi
           IMAGE_TYPE="core-image-base"
           if [ "${{ inputs.distro_name }}" = "qcom-distro" ]; then
               IMAGE_TYPE="qcom-multimedia-image"


### PR DESCRIPTION
workflows: lava-test-plans: Fix device selection for iq-9075-evk

LAVA jobs for iq-9075-evk fail when scheduled on incompatible devices.
Lab devices are tagged with "pvt" but job definitions lack this tag.

Add "pvt" tag to iq-9075-evk job definitions to ensure correct device
selection by LAVA scheduler.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>