### PR TITLE
actions/compile: temporarily disable the world build

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -41,13 +41,6 @@ runs:
         ${{inputs.kas}} dump --resolve-env --resolve-local --resolve-refs \
           ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }} > kas-build.yml
 
-    - name: Kas qcom world build
-      shell: bash
-      run: |
-        ${{inputs.kas}} build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}:ci/world.yml
-        ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
-        mv $KAS_WORK_DIR/build/buildchart.svg buildchart-world.svg
-
     - name: Kas build images
       shell: bash
       run: |


### PR DESCRIPTION
We are running out of space on the runner and the world build is what takes up most of our space.
To unlock the CI, we'll temporarily disable these builds until the problem is resolved and we have more space on the runners.