### PR TITLE
ci/base enable bitbake disk monitor

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -33,6 +33,17 @@ local_conf_header:
     INHERIT += "buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+  diskmon: |
+    BB_DISKMON_DIRS ??= "\
+      STOPTASKS,${TMPDIR},1G,100K \
+      STOPTASKS,${DL_DIR},1G,100K \
+      STOPTASKS,${SSTATE_DIR},1G,100K \
+      STOPTASKS,/tmp,100M,100K \
+      HALT,${TMPDIR},100M,1K \
+      HALT,${DL_DIR},100M,1K \
+      HALT,${SSTATE_DIR},100M,1K \
+      HALT,/tmp,10M,1K"
+
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |


### PR DESCRIPTION
Disk Space Monitoring during the build BB_DISKMON_DIRS [1]

Monitor the disk space during the build. If there is less that 1GB of space or less than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully shutdown the build. If there is less than 100MB or 1K inodes, perform a hard halt of the build. The reason for this is that running completely out of space can corrupt files and damages the build in ways which may not be easily recoverable. It's necessary to monitor /tmp, if there is no space left the build will fail with very exotic errors.

[1] meta-yocto/meta-poky/conf/templates/default/local.conf.sample