### PR TITLE
Disable uninative

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -54,6 +54,8 @@ local_conf_header:
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
     WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
+  uninative: |
+    INHERIT:remove = "uninative"
 
 machine: unset
 


### PR DESCRIPTION
Uninative is an attempts to isolate the build system from the host distribution's
C library in order to make re-use of native shared state artifacts across different
host distributions practical.

We are running on some build issue with clang/rust and we belive which are caused
by the uninative glibc. To unlock the CI, we'll temporarily disable the uninative.