### PR TITLE
initramfs-firmware-mega-image: remove empty linux-firmware package

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -1,7 +1,6 @@
 DESCRIPTION = "Huge image with all firmware files. This is intended to check for possible conflicts, etc."
 
 PACKAGE_INSTALL = " \
-    linux-firmware \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "
 


### PR DESCRIPTION
linux-firmware is just an empty package since oe-core [1], remove from initramfs-firmware-mega-image as an attempt to avoid bug https://bugzilla.yoctoproject.org/show_bug.cgi?id=16010, which started to happen after the above oe-core commit.

[1]
https://git.openembedded.org/openembedded-core/commit/?id=9b883aa6f3cf881bfd60442b9ec193ae191b4cbe