### PR TITLE
workflows/stales: remove misleading comment

### DIFF
--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
+        stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity. Please add a comment and close if it is resolved or if it is no longer relevant.'
         stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
         exempt-issue-labels: bug,enhancement
         exempt-pr-labels: bug,enhancement


### PR DESCRIPTION
Since commit 43bcad8 (workflow: stales: stop closing stalled issues automatically), inactive issues are marked as stale but are not closed automatically.

Replace the comment referencing auto closure of stalled issues with a nudge to close or update the issue if it's no longer relevant.