### PR TITLE
gpsd: use override when appending SRC_URI

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd_%.bbappend
@@ -7,6 +7,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}-${gpsPV}:${THISDIR}/${BPN}:"
 gpsPV = "${PV}"
 
-SRC_URI += " \
+SRC_URI:append:qcom = " \
     file://0001-Introduce-Qualcomm-PDS-service-support.patch \
 "


### PR DESCRIPTION
Append to SRC_URI only when using a qcom machine; skip otherwise.