### PR TITLE
camxfirmware: Remove architecture compatibility restrictions

### DIFF
--- a/recipes-multimedia/camx/camxfirmware-kodiak_1.0.4.bb
+++ b/recipes-multimedia/camx/camxfirmware-kodiak_1.0.4.bb
@@ -11,11 +11,6 @@ S = "${UNPACKDIR}"
 
 inherit allarch
 
-# This package is currently only used and tested on ARMv8 (aarch64) machines.
-# Therefore, builds for other architectures are not necessary and are explicitly excluded.
-COMPATIBLE_MACHINE = "^$"
-COMPATIBLE_MACHINE:aarch64 = "(.*)"
-
 # Disable configure and compile steps since this recipe uses prebuilt binaries.
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-multimedia/camx/camxfirmware-lemans_1.0.4.bb
+++ b/recipes-multimedia/camx/camxfirmware-lemans_1.0.4.bb
@@ -11,11 +11,6 @@ S = "${UNPACKDIR}"
 
 inherit allarch
 
-# This package is currently only used and tested on ARMv8 (aarch64) machines.
-# Therefore, builds for other architectures are not necessary and are explicitly excluded.
-COMPATIBLE_MACHINE = "^$"
-COMPATIBLE_MACHINE:aarch64 = "(.*)"
-
 # Disable configure and compile steps since this recipe uses prebuilt binaries.
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"


### PR DESCRIPTION
Firmware is architecture-agnostic. The aarch64-only COMPATIBLE_MACHINE
blocked builds on other MACHINEs and caused "package not found" failures.
Removing the restriction enables builds across supported architectures.