### PR TITLE
workflows: Update lava-test-plans ref for BT and Audio test support

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -24,7 +24,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: cdb8221de2a8f78533ef6b812fc4f5a2461c5525
+          ref: e5bc7469cf6f73157d9f533ab02a88d818446320
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Add separate pre-merge-bt job that runs BT specific tests (BT_FW_KMD_Service and BT_SCAN) in parallel with regular pre-merge tests. Jobs run only after boot tests pass successfully.

For iq-9075-evk, BT tests include 'pvt' tag to ensure proper device selection. Other targets run without tags.

Additionally, Audio Record and Audio Playback testcases have been merged in the lava-test-plans repository and are now available for testing.

Update to lava-test-plans version that includes:
- pre-merge-bt test plan with conditional tag logic: iq-9075-evk
  jobs get "pvt" tag for proper device selection, while other
  targets run without tags on any available device
- Audio Record and Audio Playback testcases support

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>