### PR TITLE
workflows: prevent creating commit check with no results

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -42,9 +42,14 @@ jobs:
             github-token: ${{ github.token }}
 
       - name: "List files"
+        id: listfiles
         run: |
           echo $GITHUB_WORKSPACE
           ls -R $GITHUB_WORKSPACE
+          if ! find "${{ github.workspace }}/artifacts/" -name '*.xml' -print -quit | grep -q .; then
+            echo "Error: no .xml files found"
+            exit 1
+          fi
 
       - id: app_token
         uses: actions/create-github-app-token@v2
@@ -55,7 +60,9 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+        if: |
+          always()
+          && contains(steps.listfiles.outcome, 'success')
         with:
           commit: ${{ inputs.commit }}
           event_file: ${{ inputs.event_file}}


### PR DESCRIPTION
When there are no test results publish-results workflow will create a "pass" check on the commit. This is a limitation of the result publishing action. This patch prevents publishing action from running when there are no test results available. The check is not added. Since the check is on the list of expected, missing check will raise alarm and prevent auto-merging of patches.