### PR TITLE
initramfs-test-image: update alsa-utils-speaker-test package name

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -9,7 +9,7 @@ PACKAGE_INSTALL += " \
     alsa-utils-alsaucm \
     alsa-utils-amixer \
     alsa-utils-aplay \
-    alsa-utils-speakertest \
+    alsa-utils-speaker-test \
     bluez5 \
     bootrr \
     dhcpcd \


### PR DESCRIPTION
OE-Core [1] change to dynamically split the packages caused a change to the alsa-utils-speakertest package name, which is now alsa-utils-speaker-test.

[1]
https://git.openembedded.org/openembedded-core/commit/?id=26a28ee7935091250a8c52f223a7a954d9e29d34