### PR TITLE
Include Firmware and Hexagon DSP binary for Multiple Boards

### DIFF
--- a/conf/machine/kaanapali-mtp.conf
+++ b/conf/machine/kaanapali-mtp.conf
@@ -16,4 +16,5 @@ KERNEL_DEVICETREE ?= " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-kaanapali-mtp-firmware \
+    packagegroup-kaanapali-mtp-hexagon-dsp-binaries \
 "

--- a/conf/machine/sm8750-mtp.conf
+++ b/conf/machine/sm8750-mtp.conf
@@ -13,3 +13,8 @@ ABL_SIGNATURE_VERSION ?= "v7"
 KERNEL_DEVICETREE ?= " \
                       qcom/sm8750-mtp.dtb \
                       "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-sm8750-mtp-firmware \
+    packagegroup-sm8750-mtp-hexagon-dsp-binaries \
+"

--- a/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
@@ -17,5 +17,6 @@ RRECOMMENDS:${PN}-firmware = " \
 "
 
 RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-hamoa-iot-evk-adsp \
     hexagon-dsp-binaries-qcom-hamoa-iot-evk-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-kaanapali-mtp.bb
+++ b/recipes-bsp/packagegroups/packagegroup-kaanapali-mtp.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
 "
 
 RRECOMMENDS:${PN}-firmware = " \
@@ -14,4 +15,9 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-kaanapali-compute \
     linux-firmware-qcom-kaanapali-soccp \
     linux-firmware-qcom-vpu \
+"
+
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-kaanapali-mtp-adsp \
+    hexagon-dsp-binaries-qcom-kaanapali-mtp-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8750-mtp.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8750-mtp.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Packages for the SM8750-MTP platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g800 linux-firmware-qcom-sm8750-adreno', '', d)} \
+    linux-firmware-qcom-sm8750-audio \
+    linux-firmware-qcom-sm8750-compute \
+    linux-firmware-qcom-vpu \
+"
+
+RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-sm8750-mtp-adsp \
+    hexagon-dsp-binaries-qcom-sm8750-mtp-cdsp \
+"


### PR DESCRIPTION
1) Include Firmware packagegroup for SM8750-MTP Board.
2) 20260110 hexagon-dsp-binaries release provide packages for SM8750-MTP and Kaanapali-mtp Board, and ADSP binary is available for hamoa-iot-evk.