### PR TITLE
ci: actions/compile: : retain OSTree commit artifacts

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -89,7 +89,7 @@ runs:
         uploads_dir=./uploads/${{ inputs.distro_name }}${{ inputs.kernel_dirname }}/${{ inputs.machine }}
         mkdir -p $uploads_dir
         find $deploy_dir/ -maxdepth 1 -type f -exec cp {} $uploads_dir/ \;
-        find $deploy_dir/ -maxdepth 1 -type l \( -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz \) -exec cp -d {} $uploads_dir/ \;
+        find $deploy_dir/ -maxdepth 1 -type l \( -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz -o -name *.rootfs.ostreecommit.tar.xz \) -exec cp -d {} $uploads_dir/ \;
         cp buildchart.svg kas-build.yml $uploads_dir/
         if [ -d $deploy_dir/../../sdk ]; then
           cp $deploy_dir/../../sdk/* $uploads_dir/


### PR DESCRIPTION
Include *.rootfs.ostreecommit.tar.xz files in the artifact staging and upload process for nightly builds. This ensures OSTree commit archives are preserved alongside other build artifacts.

The find command pattern is added to the symbolic link copy operation, which will gracefully handle cases where ostreecommit files are not present for certain machine configurations.

Files matching this pattern will be:
- Copied to the uploads directory
- Uploaded as private artifacts
- Published to the S3 bucket for build artifact storage