### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260120

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -12,8 +12,8 @@ LINUX_VERSION ?= "6.18"
 
 PV = "${LINUX_VERSION}"
 
-# tag: qcom-6.18.y-20251217
-SRCREV ?= "27507852413bd8ba6205a95a4a1df15e62b88009"
+# tag: qcom-6.18.y-20260120
+SRCREV ?= "b588875924316e2f73aa987cec342e624147f87c"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260120

Changelog : 
BACKPORT: FROM GIT: arm64: dts: qcom: qcs615: Add OSM l3 interconnect provider node and CPU OPP tables to scale DDR/L3
QCLINUX: arm64: configs: Added new rt.config for RT kernel
QCLINUX: defconfig: Enable Remoteproc cooling feature
FROMLIST: arm64: dts: qcom: Enable cdsp qmi tmd devices for talos
FROMLIST: arm64: dts: qcom: Enable cdsp qmi tmd devices for kodiak
FROMLIST: arm64: dts: qcom: Enable cdsp qmi tmd devices for monaco
FROMLIST: arm64: dts: qcom: Enable cdsp qmi tmd devices for lemans
FROMLIST: remoteproc: qcom: probe all child devices
FROMLIST: thermal: qcom: add qmi-cooling driver
FROMLIST: dt-bindings: thermal: Add qcom,qmi-cooling yaml bindings
FROMLIST: thermal: Add Remote Proc cooling driver
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Adjust tsens thermal zone configuration
QCLINUX: arm64: configs: qcom.config: Enable UINPUT
FROMLIST: arm64: dts: qcom: lemans: Enable cpufreq cooling devices
QCLINUX: defconfig: enable EMC2305 defconfig on qcom.config