### PR TITLE
packagegroup-sm8750-mtp: add wifi and BT firmware package

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-sm8750-mtp.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8750-mtp.bb
@@ -9,6 +9,8 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g800 linux-firmware-qcom-sm8750-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     linux-firmware-qcom-sm8750-audio \
     linux-firmware-qcom-sm8750-compute \
     linux-firmware-qcom-vpu \


### PR DESCRIPTION
SM8750-MTP will use the HMT packages for wifi and BT. 
Adding both the packages in packagegroup-sm8750-mtp to include them in the image.