### PR TITLE
gstreamer1.0-plugins-good: Add bbappend to apply Qualcomm patches

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
@@ -1,0 +1,41 @@
+From dd51eaf49bb5732fb603af29a518d0d6c46118dd Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Tue, 13 Jan 2026 17:58:26 +0530
+Subject: [PATCH] v4l2: Add support for V4L2_PIX_FMT_QC08C format
+
+V4L2_PIX_FMT_QC08C is defined as equivalent to
+GST_VIDEO_FORMAT_NV12_Q08C gstreamer format
+
+Upstream-Status: Denied [Adding NV12_Q08C format is denied by upstream, for compatibility, need to maintain this patch. https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 99ed48b..ab37526 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -182,6 +182,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_FMT (NV12_16L16, UNKNOWN),               MAP_DRM (NV12, SAMSUNG_16_16_TILE), GST_V4L2_RAW},
+   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
+   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
++  {MAP_FMT (QC08C, NV12_Q08C),                  MAP_DRM (NV12, QCOM_COMPRESSED),    GST_V4L2_RAW},
+   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV21, NV21),                        KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+@@ -2003,6 +2004,11 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+       fourcc_nc = desc->v4l2_format;
+     if (fallback_desc)
+       fourcc = fallback_desc->v4l2_format;
++
++    if (fourcc_nc == V4L2_PIX_FMT_QC08C) {
++      fourcc_nc = 0;
++      fourcc = V4L2_PIX_FMT_QC08C;
++    }
+   } else if (g_str_equal (mimetype, "video/mpegts")) {
+     fourcc = V4L2_PIX_FMT_MPEG;
+   } else if (g_str_equal (mimetype, "video/x-dv")) {
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0002-v4l2videoenc-Set-format-on-capture-queue-before-enco.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0002-v4l2videoenc-Set-format-on-capture-queue-before-enco.patch
@@ -1,0 +1,168 @@
+From 48cbe6190a7ee3c006a5a4ff61d29e12ed670b2c Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Thu, 20 Nov 2025 12:07:32 +0530
+Subject: [PATCH 02/11] v4l2videoenc: Set format on capture queue before
+ encoder negotiate call
+
+- On encoder capture queue, if the pixformat to be set is different
+from what is already set by default, then call S_FMT with expected
+pixformat before calling gst_v4l2_video_enc_negotiate(). Otherwise
+G_CTRL call to get profile and level will fail for the expected format.
+(e.g. G_CTRL for hevc profile will fail if the format set on driver
+is AVC)
+
+- If the pixformat changes from what is already set by default on
+driver, then extracontrols which were already set are reset and needs
+to be set again.
+
+- S_FMT is called on CAPTURE port first and then later, on the OUTPUT
+port The width and height values set using S_FMT call are ignored by the
+driver and it returns default values.
+Later, when S_FMT is called on output port, video driver internally
+reconfigures the capture port with the desired width and height and
+updates the sizeimage of the capture buffers.
+But this updated sizeimage value is not updated in the Gstvideoinfo
+of v4l2object of capture side and the bufferpool created during
+decide_allocation remains with the older value.
+This is causing assertions when the encoded output is of bigger size
+than the gst buffers of v4l2bufferpool.
+So to resolve this issue call enc_negotiate after set_format on
+output port.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10146 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c   |  2 +-
+ sys/v4l2/gstv4l2object.h   |  3 +++
+ sys/v4l2/gstv4l2videoenc.c | 55 +++++++++++++++++++++++++++++++++++---
+ sys/v4l2/v4l2_calls.c      |  2 +-
+ 4 files changed, 57 insertions(+), 5 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index ab37526..8b030bc 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -1966,7 +1966,7 @@ gst_v4l2_object_probe_template_caps (const gchar * device, gint video_fd,
+  * @fps_n/@fps_d: location for framerate
+  * @size: location for expected size of the frame or 0 if unknown
+  */
+-static gboolean
++gboolean
+ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+     struct v4l2_fmtdesc **format, GstVideoInfoDmaDrm * info)
+ {
+diff --git a/sys/v4l2/gstv4l2object.h b/sys/v4l2/gstv4l2object.h
+index 4b14b7e..7747b4d 100644
+--- a/sys/v4l2/gstv4l2object.h
++++ b/sys/v4l2/gstv4l2object.h
+@@ -374,6 +374,9 @@ gboolean     gst_v4l2_set_controls    (GstV4l2Object * v4l2object, GstStructure
+ gboolean     gst_v4l2_subscribe_event (GstV4l2Object * v4l2object, guint32 event, guint32 id);
+ gboolean     gst_v4l2_dequeue_event   (GstV4l2Object * v4l2object, struct v4l2_event *event);
+ 
++gboolean     gst_v4l2_fill_lists (GstV4l2Object * v4l2object);
++gboolean     gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps, struct v4l2_fmtdesc **format, GstVideoInfoDmaDrm * info);
++
+ G_END_DECLS
+ 
+ #endif /* __GST_V4L2_OBJECT_H__ */
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index 8eedd46..f3697cd 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -106,6 +106,53 @@ gst_v4l2_video_enc_get_property (GObject * object,
+   }
+ }
+ 
++static void
++gst_v4l2_video_enc_set_cap_fmt (GstVideoEncoder * encoder)
++{
++  GstV4l2VideoEnc *self = GST_V4L2_VIDEO_ENC (encoder);
++  GstV4l2Object *v4l2capture = GST_V4L2_OBJECT (self->v4l2capture);
++  GstCaps *caps;
++  GstVideoInfoDmaDrm info;
++  struct v4l2_format format;
++  struct v4l2_fmtdesc *fmtdesc;
++
++  gst_video_info_dma_drm_init (&info);
++  caps = gst_caps_copy (gst_pad_get_pad_template_caps (encoder->srcpad));
++  caps = gst_caps_fixate (caps);
++  if (!gst_v4l2_object_get_caps_info (v4l2capture, caps, &fmtdesc, &info))
++    goto done;
++
++  memset (&format, 0x00, sizeof (struct v4l2_format));
++  format.type = v4l2capture->type;
++  if (v4l2capture->ioctl (v4l2capture->video_fd, VIDIOC_G_FMT, &format) < 0) {
++    GST_DEBUG_OBJECT (self, "Call to VIDIOC_G_FMT failed with error %s",
++        g_strerror (errno));
++    goto done;
++  }
++
++  if (format.fmt.pix.pixelformat != fmtdesc->pixelformat) {
++    format.fmt.pix.pixelformat = fmtdesc->pixelformat;
++    if (v4l2capture->ioctl (v4l2capture->video_fd, VIDIOC_S_FMT, &format) < 0) {
++      GST_DEBUG_OBJECT (self, "Call to VIDIOC_S_FMT failed for format %"
++          GST_FOURCC_FORMAT " with error %s",
++          GST_FOURCC_ARGS (format.fmt.pix.pixelformat), g_strerror (errno));
++      goto done;
++    }
++    GST_DEBUG_OBJECT (self, "pixelformat set to %" GST_FOURCC_FORMAT,
++        GST_FOURCC_ARGS (format.fmt.pix.pixelformat));
++
++    /* If the pixformat changes, we might have to set extra-controls again */
++    gst_v4l2_fill_lists (self->v4l2output);
++    if (self->v4l2output->extra_controls) {
++      gst_v4l2_set_controls (self->v4l2output,
++          self->v4l2output->extra_controls);
++    }
++  }
++
++done:
++  gst_caps_unref (caps);
++}
++
+ static gboolean
+ gst_v4l2_video_enc_open (GstVideoEncoder * encoder)
+ {
+@@ -121,6 +168,8 @@ gst_v4l2_video_enc_open (GstVideoEncoder * encoder)
+   if (!gst_v4l2_object_open_shared (self->v4l2capture, self->v4l2output))
+     goto failure;
+ 
++  gst_v4l2_video_enc_set_cap_fmt (encoder);
++
+   self->probed_sinkcaps = gst_v4l2_object_probe_caps (self->v4l2output,
+       gst_v4l2_object_get_raw_caps ());
+ 
+@@ -357,14 +406,14 @@ gst_v4l2_video_enc_set_format (GstVideoEncoder * encoder,
+   output = gst_video_encoder_set_output_state (encoder, outcaps, state);
+   gst_video_codec_state_unref (output);
+ 
+-  if (!gst_video_encoder_negotiate (encoder))
+-    return FALSE;
+-
+   if (!gst_v4l2_object_set_format (self->v4l2output, state->caps, &error)) {
+     gst_v4l2_error (self, &error);
+     return FALSE;
+   }
+ 
++  if (!gst_video_encoder_negotiate (encoder))
++    return FALSE;
++
+   /* best effort */
+   gst_v4l2_object_setup_padding (self->v4l2output);
+ 
+diff --git a/sys/v4l2/v4l2_calls.c b/sys/v4l2/v4l2_calls.c
+index a6527e4..8b84fdb 100644
+--- a/sys/v4l2/v4l2_calls.c
++++ b/sys/v4l2/v4l2_calls.c
+@@ -125,7 +125,7 @@ gst_v4l2_normalise_control_name (gchar * name)
+  *   fill/empty the lists of enumerations
+  * return value: TRUE on success, FALSE on error
+  ******************************************************/
+-static gboolean
++gboolean
+ gst_v4l2_fill_lists (GstV4l2Object * v4l2object)
+ {
+   gint n, next;
+-- 
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0003-v4l2-Add-v4l2av1dec-stateful-decoder-support.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0003-v4l2-Add-v4l2av1dec-stateful-decoder-support.patch
@@ -1,0 +1,363 @@
+From 06da3492fecda4777ee7cd121571da25b4a88624 Mon Sep 17 00:00:00 2001
+From: DEEPA GUTHYAPPA MADIVALARA <deepa.madivalara@oss.qualcomm.com>
+Date: Wed, 20 Aug 2025 14:23:51 -0700
+Subject: [PATCH 03/11] v4l2: Add v4l2av1dec stateful decoder support
+
+Introduce support for new pixelformat V4L2_PIX_FMT_AV1 which maps
+to V4l2 AV1 stateful decoder. Implement necessary changes to
+enable v4l2av1dec component.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9892>
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9892 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/ext/videodev2.h   |   1 +
+ sys/v4l2/gstv4l2av1codec.c | 201 +++++++++++++++++++++++++++++++++++++
+ sys/v4l2/gstv4l2av1codec.h |  36 +++++++
+ sys/v4l2/gstv4l2object.c   |   8 ++
+ sys/v4l2/gstv4l2videodec.c |   4 +
+ sys/v4l2/meson.build       |   2 +
+ 6 files changed, 252 insertions(+)
+ create mode 100644 sys/v4l2/gstv4l2av1codec.c
+ create mode 100644 sys/v4l2/gstv4l2av1codec.h
+
+diff --git a/sys/v4l2/ext/videodev2.h b/sys/v4l2/ext/videodev2.h
+index 2ceb1ca..8d94059 100644
+--- a/sys/v4l2/ext/videodev2.h
++++ b/sys/v4l2/ext/videodev2.h
+@@ -732,6 +732,7 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_FWHT_STATELESS     v4l2_fourcc('S', 'F', 'W', 'H') /* Stateless FWHT (vicodec) */
+ #define V4L2_PIX_FMT_H264_SLICE v4l2_fourcc('S', '2', '6', '4') /* H264 parsed slices */
+ #define V4L2_PIX_FMT_HEVC_SLICE v4l2_fourcc('S', '2', '6', '5') /* HEVC parsed slices */
++#define V4L2_PIX_FMT_AV1       v4l2_fourcc('A', 'V', '0', '1') /* AV1 */
+ #define V4L2_PIX_FMT_AV1_FRAME v4l2_fourcc('A', 'V', '1', 'F') /* AV1 parsed frame */
+ #define V4L2_PIX_FMT_SPK      v4l2_fourcc('S', 'P', 'K', '0') /* Sorenson Spark */
+ #define V4L2_PIX_FMT_RV30     v4l2_fourcc('R', 'V', '3', '0') /* RealVideo 8 */
+diff --git a/sys/v4l2/gstv4l2av1codec.c b/sys/v4l2/gstv4l2av1codec.c
+new file mode 100644
+index 0000000..4f2a5ee
+--- /dev/null
++++ b/sys/v4l2/gstv4l2av1codec.c
+@@ -0,0 +1,201 @@
++/*
++ * Copyright (C) 2022 Synaptics Incorporated
++ *    Author: Hsia-Jun(Randy) Li <randy.li@synaptics.com>
++ * Copyright (C) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
++ *    Author: Deepa Guthyappa Madivalara <deepa.madivalara@oss.qualcomm.com>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include "gstv4l2av1codec.h"
++
++#include <gst/gst.h>
++#include "ext/v4l2-controls.h"
++
++static gint
++v4l2_profile_from_string (const gchar * profile)
++{
++  gint v4l2_profile = -1;
++
++  if (g_str_equal (profile, "main"))
++    v4l2_profile = V4L2_MPEG_VIDEO_AV1_PROFILE_MAIN;
++  else if (g_str_equal (profile, "high"))
++    v4l2_profile = V4L2_MPEG_VIDEO_AV1_PROFILE_HIGH;
++  else if (g_str_equal (profile, "professional"))
++    v4l2_profile = V4L2_MPEG_VIDEO_AV1_PROFILE_PROFESSIONAL;
++  else
++    GST_WARNING ("Unsupported profile string '%s'", profile);
++
++  return v4l2_profile;
++}
++
++static const gchar *
++v4l2_profile_to_string (gint v4l2_profile)
++{
++  switch (v4l2_profile) {
++    case V4L2_MPEG_VIDEO_AV1_PROFILE_MAIN:
++      return "main";
++    case V4L2_MPEG_VIDEO_AV1_PROFILE_HIGH:
++      return "high";
++    case V4L2_MPEG_VIDEO_AV1_PROFILE_PROFESSIONAL:
++      return "professional";
++    default:
++      GST_WARNING ("Unsupported V4L2 profile %i", v4l2_profile);
++      break;
++  }
++
++  return NULL;
++}
++
++static gint
++v4l2_level_from_string (const gchar * level)
++{
++  gint v4l2_level = -1;
++
++  if (g_str_equal (level, "2.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_2_0;
++  else if (g_str_equal (level, "2.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_2_1;
++  else if (g_str_equal (level, "2.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_2_2;
++  else if (g_str_equal (level, "2.3"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_2_3;
++  else if (g_str_equal (level, "3.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_3_0;
++  else if (g_str_equal (level, "3.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_3_1;
++  else if (g_str_equal (level, "3.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_3_2;
++  else if (g_str_equal (level, "3.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_3_3;
++  else if (g_str_equal (level, "4.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_4_0;
++  else if (g_str_equal (level, "4.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_4_1;
++  else if (g_str_equal (level, "4.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_4_2;
++  else if (g_str_equal (level, "4.3"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_4_3;
++  else if (g_str_equal (level, "5.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_5_0;
++  else if (g_str_equal (level, "5.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_5_1;
++  else if (g_str_equal (level, "5.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_5_2;
++  else if (g_str_equal (level, "5.3"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_5_3;
++  else if (g_str_equal (level, "6.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_6_0;
++  else if (g_str_equal (level, "6.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_6_1;
++  else if (g_str_equal (level, "6.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_6_2;
++  else if (g_str_equal (level, "6.3"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_6_3;
++  else if (g_str_equal (level, "7.0"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_7_0;
++  else if (g_str_equal (level, "7.1"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_7_1;
++  else if (g_str_equal (level, "7.2"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_7_2;
++  else if (g_str_equal (level, "7.3"))
++    v4l2_level = V4L2_MPEG_VIDEO_AV1_LEVEL_7_3;
++  else
++    GST_WARNING ("Unsupported level '%s'", level);
++
++  return v4l2_level;
++}
++
++static const gchar *
++v4l2_level_to_string (gint v4l2_level)
++{
++  switch (v4l2_level) {
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_2_0:
++      return "2.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_2_1:
++      return "2.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_2_2:
++      return "2.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_2_3:
++      return "2.3";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_3_0:
++      return "3.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_3_1:
++      return "3.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_3_2:
++      return "3.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_3_3:
++      return "3.3";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_4_0:
++      return "4.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_4_1:
++      return "4.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_4_2:
++      return "4.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_4_3:
++      return "4.3";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_5_0:
++      return "5.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_5_1:
++      return "5.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_5_2:
++      return "5.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_5_3:
++      return "5.3";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_6_0:
++      return "6.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_6_1:
++      return "6.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_6_2:
++      return "6.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_6_3:
++      return "6.3";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_7_0:
++      return "7.0";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_7_1:
++      return "7.1";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_7_2:
++      return "7.2";
++    case V4L2_MPEG_VIDEO_AV1_LEVEL_7_3:
++      return "7.3";
++    default:
++      GST_WARNING ("Unsupported V4L2 level %i", v4l2_level);
++      break;
++  }
++
++  return NULL;
++}
++
++const GstV4l2Codec *
++gst_v4l2_av1_get_codec (void)
++{
++  static GstV4l2Codec *codec = NULL;
++  if (g_once_init_enter (&codec)) {
++    static GstV4l2Codec c;
++    c.profile_cid = V4L2_CID_MPEG_VIDEO_AV1_PROFILE;
++    c.profile_to_string = v4l2_profile_to_string;
++    c.profile_from_string = v4l2_profile_from_string;
++    c.level_cid = V4L2_CID_MPEG_VIDEO_AV1_LEVEL;
++    c.level_to_string = v4l2_level_to_string;
++    c.level_from_string = v4l2_level_from_string;
++    g_once_init_leave (&codec, &c);
++  }
++  return codec;
++}
+diff --git a/sys/v4l2/gstv4l2av1codec.h b/sys/v4l2/gstv4l2av1codec.h
+new file mode 100644
+index 0000000..b6cf236
+--- /dev/null
++++ b/sys/v4l2/gstv4l2av1codec.h
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (C) 2022 Synaptics Incorporated
++ *    Author: Hsia-Jun(Randy) Li <randy.li@synaptics.com>
++ * Copyright (C) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
++ *    Author: Deepa Guthyappa Madivalara <deepa.madivalara@oss.qualcomm.com>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++#pragma once
++
++#ifndef __GST_V4L2_AV1_CODEC_H__
++#define __GST_V4L2_AV1_CODEC_H__
++
++#include "gstv4l2codec.h"
++
++G_BEGIN_DECLS
++
++const GstV4l2Codec * gst_v4l2_av1_get_codec (void);
++
++G_END_DECLS
++
++#endif
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 8b030bc..d823337 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -236,6 +236,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_ENC_FMT (VC1_ANNEX_L, ENCODED),  GST_V4L2_CODEC},
+   {MAP_ENC_FMT (VP8, ENCODED),          GST_V4L2_CODEC | GST_V4L2_NO_PARSE},
+   {MAP_ENC_FMT (VP9, ENCODED),          GST_V4L2_CODEC | GST_V4L2_NO_PARSE},
++  {MAP_ENC_FMT (AV1, ENCODED),          GST_V4L2_CODEC},
+
+   /*  Vendor-specific formats   */
+   {MAP_ENC_FMT (WNVA, ENCODED),     GST_V4L2_CODEC | GST_V4L2_RESOLUTION_AND_RATE},
+@@ -1596,6 +1597,11 @@ gst_v4l2_object_v4l2fourcc_to_bare_struct (guint32 fourcc,
+     case V4L2_PIX_FMT_VP9:
+       structure = gst_structure_new_empty ("video/x-vp9");
+       break;
++    case V4L2_PIX_FMT_AV1:
++      structure = gst_structure_new ("video/x-av1",
++          "stream-format", G_TYPE_STRING, "obu-stream", "alignment",
++          G_TYPE_STRING, "tu", NULL);
++      break;
+     case V4L2_PIX_FMT_DV:
+       structure =
+           gst_structure_new ("video/x-dv", "systemstream", G_TYPE_BOOLEAN, TRUE,
+@@ -2058,6 +2064,8 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+     fourcc = V4L2_PIX_FMT_VP8;
+   } else if (g_str_equal (mimetype, "video/x-vp9")) {
+     fourcc = V4L2_PIX_FMT_VP9;
++  } else if (g_str_equal (mimetype, "video/x-av1")) {
++    fourcc = V4L2_PIX_FMT_AV1;
+   } else if (g_str_equal (mimetype, "video/x-bayer")) {
+     const gchar *format = gst_structure_get_string (structure, "format");
+     if (format) {
+diff --git a/sys/v4l2/gstv4l2videodec.c b/sys/v4l2/gstv4l2videodec.c
+index 071f8a4..d74f3e7 100644
+--- a/sys/v4l2/gstv4l2videodec.c
++++ b/sys/v4l2/gstv4l2videodec.c
+@@ -38,6 +38,7 @@
+ #include "gstv4l2mpeg4codec.h"
+ #include "gstv4l2vp8codec.h"
+ #include "gstv4l2vp9codec.h"
++#include "gstv4l2av1codec.h"
+
+ #include <string.h>
+ #include <glib/gi18n-lib.h>
+@@ -1455,6 +1456,9 @@ G_STMT_START { \
+   } else if (gst_structure_has_name (s, "video/x-vp9")) {
+     SET_META ("VP9");
+     cdata->codec = gst_v4l2_vp9_get_codec ();
++  } else if (gst_structure_has_name (s, "video/x-av1")) {
++    SET_META ("AV1");
++    cdata->codec = gst_v4l2_av1_get_codec ();
+   } else if (gst_structure_has_name (s, "video/x-bayer")) {
+     SET_META ("BAYER");
+   } else if (gst_structure_has_name (s, "video/x-sonix")) {
+diff --git a/sys/v4l2/meson.build b/sys/v4l2/meson.build
+index 61a6f05..2d6cbb3 100644
+--- a/sys/v4l2/meson.build
++++ b/sys/v4l2/meson.build
+@@ -29,6 +29,7 @@ v4l2_sources = [
+   'gstv4l2vp8enc.c',
+   'gstv4l2vp9codec.c',
+   'gstv4l2vp9enc.c',
++  'gstv4l2av1codec.c',
+   'v4l2_calls.c',
+   'v4l2-utils.c',
+   'tuner.c',
+@@ -64,6 +65,7 @@ v4l2_headers = [
+   'tunerchannel.h',
+   'gstv4l2videoenc.h',
+   'gstv4l2h264codec.h',
++  'gstv4l2av1codec.h',
+   'gstv4l2src.h',
+   'tuner.h',
+   'gstv4l2mpeg4codec.h',
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0004-v4l2videodec-Prefer-colorimetry-from-acquired-caps.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0004-v4l2videodec-Prefer-colorimetry-from-acquired-caps.patch
@@ -1,0 +1,58 @@
+From 89f8cfc6e594e4620f2b38b1914fb37a618020ca Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Tue, 25 Nov 2025 20:47:41 +0530
+Subject: [PATCH 04/11] v4l2videodec: Prefer colorimetry from acquired caps
+
+By default, the caps fixation is taking the first value from the
+supported colorimetries. This is not being accepted by video driver.
+Due to which set_format is failing.
+So, prefer colorimetry from acquired caps from the driver for fixate.
+
+Upstream-Status: Denied [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10193 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videodec.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2videodec.c b/sys/v4l2/gstv4l2videodec.c
+index d74f3e7..9a28e81 100644
+--- a/sys/v4l2/gstv4l2videodec.c
++++ b/sys/v4l2/gstv4l2videodec.c
+@@ -415,6 +415,7 @@ gst_v4l2_video_dec_negotiate (GstVideoDecoder * decoder)
+   GstVideoCodecState *output_state;
+   GstCaps *acquired_caps, *acquired_drm_caps;
+   GstCaps *fixation_caps, *available_caps, *caps, *filter;
++  GstStructure *st;
+   gboolean active;
+   GstBufferPool *cpool;
+   gboolean ret;
+@@ -508,6 +509,26 @@ gst_v4l2_video_dec_negotiate (GstVideoDecoder * decoder)
+   if (gst_caps_is_subset (acquired_caps, caps))
+     goto use_acquired_caps;
+ 
++  /* Prefer colorimetry from acquired caps for fixate */
++  {
++    const gchar *output_cl, *capture_cl;
++
++    output_cl =
++        gst_structure_get_string (gst_caps_get_structure (self->
++            input_state->caps, 0), "colorimetry");
++    capture_cl =
++        gst_structure_get_string (gst_caps_get_structure (acquired_caps, 0),
++        "colorimetry");
++
++    if (output_cl && g_strcmp0 (output_cl, capture_cl))
++      GST_WARNING_OBJECT (self,
++          "Output colorimetry %s and capture colorimetry %s are different",
++          output_cl, capture_cl);
++
++    st = gst_caps_get_structure (caps, 0);
++    gst_structure_fixate_field_string (st, "colorimetry", capture_cl);
++  }
++
+   /* Fixate pixel format */
+   caps = gst_caps_fixate (caps);
+ 
+-- 
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0005-v4l2object-Provide-padding-requirements-during-propo.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0005-v4l2object-Provide-padding-requirements-during-propo.patch
@@ -1,0 +1,66 @@
+From 0a9dc3ddad2d10865f1fd7d6159a5737851ff71c Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Mon, 12 May 2025 18:09:06 +0530
+Subject: [PATCH] v4l2object: Provide padding requirements during propose
+ allocation
+
+If the driver has size alignment requirement, suggest the
+difference between aligned size required by diver and the actual
+size of the frame as padding requirement to the upstream element.
+
+This will ensure that the buffer size allocation is as per the
+driver requirement.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8971>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/8b12aea4c7bb50d1bb85e6c90f16489f262187db ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index d823337..58634a9 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -6060,10 +6060,11 @@ gst_v4l2_object_propose_allocation (GstV4l2Object * obj, GstQuery * query)
+ {
+   GstBufferPool *pool = NULL;
+   /* we need at least 2 buffers to operate */
+-  guint size, min, max;
++  guint size, min, max, aligned_size = 0;
+   GstCaps *caps;
+   gboolean need_pool;
+   GstStructure *allocation_meta = NULL;
++  GstAllocationParams allocation_params;
+
+   /* Set defaults allocation parameters */
+   size = GST_V4L2_SIZE (obj);
+@@ -6113,6 +6114,24 @@ gst_v4l2_object_propose_allocation (GstV4l2Object * obj, GstQuery * query)
+
+   min = MAX (obj->min_buffers, GST_V4L2_MIN_BUFFERS (obj));
+
++  /* If the driver has any size alignment requirements, suggest the difference
++   * between aligned size and actual size as extra padding to the upstream
++   * element */
++  if (V4L2_TYPE_IS_MULTIPLANAR (obj->type)) {
++    /* FIXME */
++  } else {
++    aligned_size = obj->format.fmt.pix.sizeimage;
++  }
++
++  gst_allocation_params_init (&allocation_params);
++  allocation_params.padding = aligned_size - size;
++
++  if (allocation_params.padding) {
++    gst_query_add_allocation_param (query, NULL, &allocation_params);
++    /* Update size to aligned size required by driver */
++    size = aligned_size;
++  }
++
+   gst_query_add_allocation_pool (query, pool, size, min, max);
+
+   if (obj->align.padding_top || obj->align.padding_bottom ||
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0006-v4l2object-providing-aligned-size-when-propose-alloc.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0006-v4l2object-providing-aligned-size-when-propose-alloc.patch
@@ -1,0 +1,44 @@
+From 1e46f2cf2195e8c09acc95ea492cb7bce95f819a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Qian=20Hu=20=28=E8=83=A1=E9=AA=9E=29?=
+ <qian.hu@mediatek.com>
+Date: Thu, 27 Nov 2025 15:32:24 +0800
+Subject: [PATCH] v4l2object: providing aligned size when propose
+ allocation
+
+for multiplane, we also calculate aligned size. otherwise size = 0, and
+upstream gst_v4l2_object_match_buffer_layout_from_struct will fail.
+
+and, since we pass driver align size for upstream element, upstream element
+should not just return when this size not match with calculated one
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10214 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 58634a9..c744028 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -5746,7 +5746,6 @@ gst_v4l2_object_match_buffer_layout_from_struct (GstV4l2Object * obj,
+     GST_WARNING_OBJECT (obj->dbg_obj,
+         "Requested buffer size (%d) doesn't match video info size (%"
+         G_GSIZE_FORMAT ")", buffer_size, GST_VIDEO_INFO_SIZE (&info));
+-    return FALSE;
+   }
+
+   GST_DEBUG_OBJECT (obj->dbg_obj,
+@@ -6118,7 +6117,8 @@ gst_v4l2_object_propose_allocation (GstV4l2Object * obj, GstQuery * query)
+    * between aligned size and actual size as extra padding to the upstream
+    * element */
+   if (V4L2_TYPE_IS_MULTIPLANAR (obj->type)) {
+-    /* FIXME */
++    for (guint i = 0; i < obj->format.fmt.pix_mp.num_planes; i++)
++      aligned_size += obj->format.fmt.pix_mp.plane_fmt[i].sizeimage;
+   } else {
+     aligned_size = obj->format.fmt.pix.sizeimage;
+   }
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0007-v4l2-Drop-empty-bytesused-0-buffers.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0007-v4l2-Drop-empty-bytesused-0-buffers.patch
@@ -1,0 +1,66 @@
+From 1e110fc4aafe2b8f6e77e5cc7826d1092d2b72a9 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:18:53 +0000
+Subject: [PATCH] v4l2: Drop empty (bytesused 0) buffers
+
+Upstream-Status: Inappropriate [upstream ticket <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4392>]
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2bufferpool.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2bufferpool.c b/sys/v4l2/gstv4l2bufferpool.c
+index 4e59743..4b1fc28 100644
+--- a/sys/v4l2/gstv4l2bufferpool.c
++++ b/sys/v4l2/gstv4l2bufferpool.c
+@@ -1352,6 +1352,9 @@ gst_v4l2_buffer_pool_dqbuf (GstV4l2BufferPool * pool, GstBuffer ** buffer,
+         group->planes[i].bytesused, i, group->buffer.flags,
+         GST_TIME_ARGS (timestamp), pool->num_queued, outbuf, old_buffer_state);
+
++    if (group->planes[i].bytesused == 0)
++      GST_BUFFER_FLAG_SET (outbuf, GST_BUFFER_FLAG_DROPPABLE);
++
+     if (GST_VIDEO_INFO_FORMAT (&pool->caps_info.vinfo) ==
+         GST_VIDEO_FORMAT_ENCODED)
+       break;
+@@ -1985,6 +1988,11 @@ gst_v4l2_buffer_pool_process (GstV4l2BufferPool * pool, GstBuffer ** buf,
+                 GST_VIDEO_FORMAT_ENCODED && size < pool->size)
+               goto buffer_truncated;
+
++            if (GST_BUFFER_FLAG_IS_SET (*buf, GST_BUFFER_FLAG_DROPPABLE)) {
++              GST_BUFFER_FLAG_UNSET (*buf, GST_BUFFER_FLAG_DROPPABLE);
++              goto drop_buffer;
++            }
++
+             num_queued = g_atomic_int_get (&pool->num_queued);
+             GST_TRACE_OBJECT (pool, "Only %i buffer left in the capture queue.",
+                 num_queued);
+@@ -2046,6 +2054,11 @@ gst_v4l2_buffer_pool_process (GstV4l2BufferPool * pool, GstBuffer ** buf,
+           /* an queue the buffer again after the copy */
+           gst_v4l2_buffer_pool_complete_release_buffer (bpool, tmp, FALSE);
+
++          if (GST_BUFFER_FLAG_IS_SET (tmp, GST_BUFFER_FLAG_DROPPABLE)) {
++            GST_BUFFER_FLAG_UNSET (tmp, GST_BUFFER_FLAG_DROPPABLE);
++            goto drop_buffer;
++          }
++
+           if (ret != GST_FLOW_OK)
+             goto copy_failed;
+           break;
+@@ -2289,6 +2302,13 @@ start_failed:
+     GST_ERROR_OBJECT (pool, "failed to start streaming");
+     return GST_FLOW_ERROR;
+   }
++drop_buffer:
++  {
++    GST_WARNING_OBJECT (pool, "dropping 0 length buffer");
++    gst_buffer_unref (*buf);
++    *buf = NULL;
++    return GST_V4L2_FLOW_CORRUPTED_BUFFER;
++  }
+ }
+
+ void
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0008-v4l2-Handle-GAP-buffer-in-encoder.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0008-v4l2-Handle-GAP-buffer-in-encoder.patch
@@ -1,0 +1,28 @@
+From 427ccc7975d3e18b21e5982e8c3041f976f40c2d Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:30:39 +0000
+Subject: [PATCH] v4l2: Handle GAP buffer in encoder
+
+Upstream-Status: Inappropriate [upstream ticket <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4404>]
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videoenc.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index f3697cd..f6e2783 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -806,6 +806,9 @@ gst_v4l2_video_enc_handle_frame (GstVideoEncoder * encoder,
+   if (G_UNLIKELY (!g_atomic_int_get (&self->active)))
+     goto flushing;
+
++  if (GST_BUFFER_FLAG_IS_SET (frame->input_buffer, GST_BUFFER_FLAG_GAP))
++    goto drop;
++
+   task_state = gst_pad_get_task_state (GST_VIDEO_ENCODER_SRC_PAD (self));
+   if (task_state == GST_TASK_STOPPED || task_state == GST_TASK_PAUSED) {
+     /* It is possible that the processing thread stopped due to an error or
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0009-v4l2object-Make-extra-controls-property-mutable-in-p.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0009-v4l2object-Make-extra-controls-property-mutable-in-p.patch
@@ -1,0 +1,38 @@
+From dc768d4f30fa8f39a1bac79ad8cf027824f763f1 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Tue, 3 Jun 2025 16:38:49 +0530
+Subject: [PATCH] v4l2object: Make extra-controls property mutable in
+ playing state
+
+Certain encoder user controls as well as codec controls can be
+changed while the pipeline is in playing state.
+e.g. Codec controls like video_bitrate, frame_ltr_index,
+use_ltr_frames, etc. and user controls like horizontal_flip,
+vertical_flip can be changed while the pipeline is running.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9168>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/0e78a6c5aa58ffccb74f2f2a8fa1c44059eed60d ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index c744028..692f152 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -513,7 +513,9 @@ gst_v4l2_object_install_m2m_properties_helper (GObjectClass * gobject_class)
+   g_object_class_install_property (gobject_class, PROP_EXTRA_CONTROLS,
+       g_param_spec_boxed ("extra-controls", "Extra Controls",
+           "Extra v4l2 controls (CIDs) for the device",
+-          GST_TYPE_STRUCTURE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
++          GST_TYPE_STRUCTURE,
++          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
++          GST_PARAM_MUTABLE_PLAYING));
+ }
+
+ /* Support for 32bit off_t, this wrapper is casting off_t to gint64 */
+--
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch
@@ -1,0 +1,53 @@
+From e816852afe4bc190154f091f6cad017a0661eb1b Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Mon, 19 Jan 2026 14:55:27 +0530
+Subject: [PATCH] v4l2: Add support for V4L2_PIX_FMT_QC10C format
+
+V4L2_PIX_FMT_QC10C is defined as equivalent to
+GST_VIDEO_FORMAT_NV12_Q10LE32C gstreamer format
+
+Upstream-Status: Denied [Same reason as 8-bit compressed format, denied by upstream, for compatibility, need to maintain this patch. https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712 ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 692f152..58ecd59 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -183,6 +183,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
+   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
+   {MAP_FMT (QC08C, NV12_Q08C),                  MAP_DRM (NV12, QCOM_COMPRESSED),    GST_V4L2_RAW},
++  {MAP_FMT (QC10C, NV12_Q10LE32C),              KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV21, NV21),                        KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+@@ -2017,6 +2018,11 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+       fourcc_nc = 0;
+       fourcc = V4L2_PIX_FMT_QC08C;
+     }
++
++    if (fourcc_nc == V4L2_PIX_FMT_QC10C) {
++      fourcc_nc = 0;
++      fourcc = V4L2_PIX_FMT_QC10C;
++    }
+   } else if (g_str_equal (mimetype, "video/mpegts")) {
+     fourcc = V4L2_PIX_FMT_MPEG;
+   } else if (g_str_equal (mimetype, "video/x-dv")) {
+@@ -3632,6 +3638,10 @@ gst_v4l2_object_save_format (GstV4l2Object * v4l2object,
+     padded_width = format->fmt.pix.width;
+   }
+
++  /* For Q10C format, padded width should be represented in pixels */
++  if (GST_VIDEO_INFO_FORMAT (&info->vinfo) == GST_VIDEO_FORMAT_NV12_Q10LE32C)
++    padded_width = (padded_width * 3) / 4;
++
+   if (padded_width < format->fmt.pix.width)
+     GST_WARNING_OBJECT (v4l2object->dbg_obj,
+         "Driver bug detected, stride (%d) is too small for the width (%d)",
+--
+2.34.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0011-v4l2object-Add-support-for-colorimetry-1-4-16-3.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0011-v4l2object-Add-support-for-colorimetry-1-4-16-3.patch
@@ -1,0 +1,239 @@
+From 9039ceac19dc3ca3af867cd758fba55912bf7df4 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Thu, 20 Nov 2025 15:38:28 +0530
+Subject: [PATCH] v4l2object: Add support for colorimetry 1:4:16:3
+
+Colorimetry 1:4:16:3, also known as SMPTE170M / ITU-R BT1358 525
+or 625 / ITU-R BT1700 NTSC
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10151>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/21e5c0bca09a8999303adea48e0b938a91189dfe ]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 176 ++++++++++++++++++++++++---------------
+ 1 file changed, 108 insertions(+), 68 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 58ecd59..23db722 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -103,6 +103,47 @@ typedef struct
+ #define MAP_ENC_FMT(v4l2_format, gst_format) \
+   V4L2_PIX_FMT_##v4l2_format, GST_VIDEO_FORMAT_##gst_format, DRM_FORMAT_INVALID, DRM_FORMAT_MOD_INVALID
+ 
++typedef struct
++{
++  enum v4l2_colorspace colorspace;
++  enum v4l2_quantization quantization;
++  enum v4l2_xfer_func xfer_func;
++  GstVideoColorPrimaries primaries;
++} GstV4l2ColorspaceVariant;
++
++/* Colorspace variant definitions */
++static const GstV4l2ColorspaceVariant rec709_full_range = {
++  .colorspace = V4L2_COLORSPACE_REC709,
++  .quantization = V4L2_QUANTIZATION_FULL_RANGE,
++  .xfer_func = 0,
++  .primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN
++};
++
++static const GstV4l2ColorspaceVariant bt470bg_full_range = {
++  .colorspace = V4L2_COLORSPACE_470_SYSTEM_BG,
++  .quantization = V4L2_QUANTIZATION_FULL_RANGE,
++  .xfer_func = 0,
++  .primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN
++};
++
++static const GstV4l2ColorspaceVariant bt2020_pq = {
++  .colorspace = V4L2_COLORSPACE_BT2020,
++  .quantization = 0,
++  .xfer_func = V4L2_XFER_FUNC_SMPTE2084,
++  .primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN
++};
++
++static const GstV4l2ColorspaceVariant smpte170m_full_range = {
++  .colorspace = V4L2_COLORSPACE_SMPTE170M,
++  .quantization = V4L2_QUANTIZATION_FULL_RANGE,
++  .xfer_func = 0,
++  .primaries = GST_VIDEO_COLOR_PRIMARIES_BT470BG
++};
++
++static const GstV4l2ColorspaceVariant colorspace_variants[] = {
++  rec709_full_range, bt470bg_full_range, bt2020_pq, smpte170m_full_range
++};
++
+ /* *INDENT-OFF* */
+ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   /* RGB formats */
+@@ -247,6 +288,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+ };
+ #undef MAP_FMT
+ /* *INDENT-ON* */
++
+ #define GST_V4L2_FORMAT_COUNT (G_N_ELEMENTS (gst_v4l2_formats))
+ 
+ static GSList *gst_v4l2_object_get_format_list (GstV4l2Object * v4l2object);
+@@ -2582,6 +2624,54 @@ gst_v4l2_object_fill_colorimetry_list (GValue * list,
+     g_value_unset (&colorimetry);
+ }
+ 
++static gboolean
++gst_v4l2_object_try_colorspace_variant (GstV4l2Object * v4l2object,
++    struct v4l2_format *fmt, const GstV4l2ColorspaceVariant * variant,
++    GValue * list)
++{
++  struct v4l2_format alt_fmt;
++  enum v4l2_colorspace colorspace;
++  enum v4l2_quantization quantization;
++  enum v4l2_xfer_func xfer_func;
++  GstVideoColorimetry cinfo;
++
++  memcpy (&alt_fmt, fmt, sizeof (alt_fmt));
++
++  if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type)) {
++    alt_fmt.fmt.pix_mp.quantization = variant->quantization;
++    alt_fmt.fmt.pix_mp.xfer_func = variant->xfer_func;
++  } else {
++    alt_fmt.fmt.pix.quantization = variant->quantization;
++    alt_fmt.fmt.pix.xfer_func = variant->xfer_func;
++  }
++
++  if (gst_v4l2_object_try_fmt (v4l2object, &alt_fmt) < 0)
++    return FALSE;
++
++  if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type)) {
++    colorspace = alt_fmt.fmt.pix_mp.colorspace;
++    quantization = alt_fmt.fmt.pix_mp.quantization;
++    xfer_func = alt_fmt.fmt.pix_mp.xfer_func;
++  } else {
++    colorspace = alt_fmt.fmt.pix.colorspace;
++    quantization = alt_fmt.fmt.pix.quantization;
++    xfer_func = alt_fmt.fmt.pix.xfer_func;
++  }
++
++  if (colorspace != variant->colorspace ||
++      quantization != variant->quantization || xfer_func != variant->xfer_func)
++    return FALSE;
++
++  if (!gst_v4l2_object_get_colorspace (v4l2object, &alt_fmt, &cinfo))
++    return FALSE;
++
++  if (variant->primaries != GST_VIDEO_COLOR_PRIMARIES_UNKNOWN)
++    cinfo.primaries = variant->primaries;
++
++  gst_v4l2_object_fill_colorimetry_list (list, &cinfo);
++  return TRUE;
++}
++
+ static void
+ gst_v4l2_object_add_colorspace (GstV4l2Object * v4l2object, GstStructure * s,
+     guint32 width, guint32 height, guint32 pixelformat)
+@@ -2612,6 +2702,8 @@ gst_v4l2_object_add_colorspace (GstV4l2Object * v4l2object, GstStructure * s,
+    * with low-speed devices (UVC...) */
+   for (req_cspace = V4L2_COLORSPACE_SMPTE170M;
+       req_cspace <= V4L2_COLORSPACE_RAW; req_cspace++) {
++    enum v4l2_colorspace colorspace;
++
+     /* V4L2_COLORSPACE_BT878 is deprecated and shall not be used, so skip */
+     if (req_cspace == V4L2_COLORSPACE_BT878)
+       continue;
+@@ -2621,79 +2713,27 @@ gst_v4l2_object_add_colorspace (GstV4l2Object * v4l2object, GstStructure * s,
+     else
+       fmt.fmt.pix.colorspace = req_cspace;
+ 
+-    if (gst_v4l2_object_try_fmt (v4l2object, &fmt) == 0) {
+-      enum v4l2_colorspace colorspace;
+-
+-      if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type))
+-        colorspace = fmt.fmt.pix_mp.colorspace;
+-      else
+-        colorspace = fmt.fmt.pix.colorspace;
+-
+-      if (colorspace != req_cspace)
+-        continue;
+-
+-      if (gst_v4l2_object_get_colorspace (v4l2object, &fmt, &cinfo))
+-        gst_v4l2_object_fill_colorimetry_list (&list, &cinfo);
+-
+-      if (colorspace == V4L2_COLORSPACE_REC709 ||
+-          colorspace == V4L2_COLORSPACE_470_SYSTEM_BG) {
+-        /* support for full-range variants of colorspaces V4L2_COLORSPACE_REC709
+-         * (such as Apple's full-range bt709 variant 1:3:5:1) and colorspace
+-         * V4L2_COLORSPACE_470_SYSTEM_BG */
+-        struct v4l2_format alt_fmt;
+-        enum v4l2_quantization quantization;
+-        memcpy (&alt_fmt, &fmt, sizeof (alt_fmt));
++    if (gst_v4l2_object_try_fmt (v4l2object, &fmt) < 0)
++      continue;
+ 
+-        if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type))
+-          alt_fmt.fmt.pix_mp.quantization = V4L2_QUANTIZATION_FULL_RANGE;
+-        else
+-          alt_fmt.fmt.pix.quantization = V4L2_QUANTIZATION_FULL_RANGE;
+-
+-        if (gst_v4l2_object_try_fmt (v4l2object, &alt_fmt) == 0) {
+-          if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type)) {
+-            colorspace = alt_fmt.fmt.pix_mp.colorspace;
+-            quantization = alt_fmt.fmt.pix_mp.quantization;
+-          } else {
+-            colorspace = alt_fmt.fmt.pix.colorspace;
+-            quantization = alt_fmt.fmt.pix.quantization;
+-          }
++    if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type))
++      colorspace = fmt.fmt.pix_mp.colorspace;
++    else
++      colorspace = fmt.fmt.pix.colorspace;
+ 
+-          if (colorspace != req_cspace
+-              || quantization != V4L2_QUANTIZATION_FULL_RANGE)
+-            continue;
++    if (colorspace != req_cspace)
++      continue;
+ 
+-          if (gst_v4l2_object_get_colorspace (v4l2object, &alt_fmt, &cinfo))
+-            gst_v4l2_object_fill_colorimetry_list (&list, &cinfo);
+-        }
+-      }
+-      if (colorspace == V4L2_COLORSPACE_BT2020) {
+-        /* support for colorimetry bt2100-pq, variant of colorspace
+-         * V4L2_COLORSPACE_BT2020 */
+-        struct v4l2_format alt_fmt;
+-        enum v4l2_xfer_func xfer_func;
+-        memcpy (&alt_fmt, &fmt, sizeof (alt_fmt));
+-
+-        if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type))
+-          alt_fmt.fmt.pix_mp.xfer_func = V4L2_XFER_FUNC_SMPTE2084;
+-        else
+-          alt_fmt.fmt.pix.xfer_func = V4L2_XFER_FUNC_SMPTE2084;
+-
+-        if (gst_v4l2_object_try_fmt (v4l2object, &alt_fmt) == 0) {
+-          if (V4L2_TYPE_IS_MULTIPLANAR (v4l2object->type)) {
+-            colorspace = alt_fmt.fmt.pix_mp.colorspace;
+-            xfer_func = alt_fmt.fmt.pix_mp.xfer_func;
+-          } else {
+-            colorspace = alt_fmt.fmt.pix.colorspace;
+-            xfer_func = alt_fmt.fmt.pix.xfer_func;
+-          }
++    if (gst_v4l2_object_get_colorspace (v4l2object, &fmt, &cinfo))
++      gst_v4l2_object_fill_colorimetry_list (&list, &cinfo);
+ 
+-          if (colorspace != req_cspace || xfer_func != V4L2_XFER_FUNC_SMPTE2084)
+-            continue;
++    /* Try variants of this colorspace */
++    for (guint i = 0; i < G_N_ELEMENTS (colorspace_variants); i++) {
++      if (colorspace_variants[i].colorspace != req_cspace)
++        continue;
+ 
+-          if (gst_v4l2_object_get_colorspace (v4l2object, &alt_fmt, &cinfo))
+-            gst_v4l2_object_fill_colorimetry_list (&list, &cinfo);
+-        }
+-      }
++      gst_v4l2_object_try_colorspace_variant (v4l2object, &fmt,
++          &colorspace_variants[i], &list);
+     }
+   }
+ 
+-- 
+2.34.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,17 @@
+# To apply patches to support Qualcomm specific formats and fixes
+
+FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch \
+    file://0002-v4l2videoenc-Set-format-on-capture-queue-before-enco.patch \
+    file://0003-v4l2-Add-v4l2av1dec-stateful-decoder-support.patch \
+    file://0004-v4l2videodec-Prefer-colorimetry-from-acquired-caps.patch \
+    file://0005-v4l2object-Provide-padding-requirements-during-propo.patch \
+    file://0006-v4l2object-providing-aligned-size-when-propose-alloc.patch \
+    file://0007-v4l2-Drop-empty-bytesused-0-buffers.patch \
+    file://0008-v4l2-Handle-GAP-buffer-in-encoder.patch \
+    file://0009-v4l2object-Make-extra-controls-property-mutable-in-p.patch \
+    file://0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch \
+    file://0011-v4l2object-Add-support-for-colorimetry-1-4-16-3.patch \
+"


### PR DESCRIPTION
This change introduces a .bbappend file to incorporate Qualcomm patches that are either backported, submitted or denied in upstream.

### Submitted patches:
**v4l2: For HEVC, Fix format negotiation and stability issues**
  - Modifies HEVC caps negotiation sequences as per downstream video driver requirement
  - Resolves crashes and stream instability in stateful HEVC decode paths. 

**v4l2: Add v4l2av1dec stateful decoder support**
  - Adds AV1 stateful decoder integration using V4L2 codec APIs. 

**v4l2: decoder: Prefer colorimetry from acquired caps for fixate**
  - Prefer driver-acquired colorimetry during caps fixation to avoid set_format failures.

**v4l2object: providing aligned size when propose allocation**
  - Adds handling for multiplanar case 

**v4l2: Drop empty (bytesused 0) buffers**
  - Avoids pushing invalid frames downstream. 

**v4l2: Handle GAP buffer in encoder**
  - Drops GAP buffers while encoding

### Denied patches:
**v4l2: Add support for V4L2_PIX_FMT_QC08C format**
  - Introduces handling for Qualcomm 8‑bit compressed format.

**v4l2: Add support for V4L2_PIX_FMT_QC10C format**
  - Introduces handling for Qualcomm 10‑bit compressed format.

### Backported patches:
**v4l2object: Provide padding requirements during propose allocation**
**v4l2object: Make extra-controls property mutable in playing state**
**v4l2object: Add support for colorimetry 1:4:16:3**