### PR TITLE
Update linux-qcom-next to tag qcom-next-6.19-rc5-20260120

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18+6.19-rc4"
+LINUX_VERSION ?= "6.18+6.19-rc5"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-6.19-rc4-20260112
-SRCREV ?= "65bb05266d477c9f7b06bc275bd622dbed08a53b"
+# tag: qcom-next-6.19-rc5-20260120
+SRCREV ?= "6658049e667c61cea2068380ce32b862dee7eb5d"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-6.19-rc5-20260120