### PR TITLE
refpolicy: Introduce SELinux domain and policies for pd-mapper service

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0057-pd-mapper-Introduce-SELinux-domain-for-pd-mapper.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0057-pd-mapper-Introduce-SELinux-domain-for-pd-mapper.patch
@@ -1,0 +1,73 @@
+From 29630f1034ebaaccdf10366f23616367ae138f1e Mon Sep 17 00:00:00 2001
+From: Gangabhavani Yenugula <gyenugul@qti.qualcomm.com>
+Date: Thu, 22 Jan 2026 16:14:50 +0530
+Subject: [PATCH] pd-mapper: Introduce SELinux domain for pd-mapper
+
+Define a dedicated domain (`pd_mapper_t`) to confine pd-mapper service, ensuring
+it operates in a restricted environment isolated from other init processes.
+
+Grant the necessary permissions to resolve AVC denials observed during
+the transition to enforcing mode:
+
+ - Filesystem: Authorize read access to `/sys`.
+ - Socket: Allow creation and basic use of qipcrtr_socket
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/commit/c8aef7c55e8768378c6adeda7e8edfaeecb9fa28]
+
+Signed-off-by: Gangabhavani Yenugula <gyenugul@qti.qualcomm.com>
+---
+ policy/modules/services/pd_mapper.fc |  1 +
+ policy/modules/services/pd_mapper.if | 10 ++++++++++
+ policy/modules/services/pd_mapper.te | 15 +++++++++++++++
+ 3 files changed, 26 insertions(+)
+ create mode 100644 policy/modules/services/pd_mapper.fc
+ create mode 100644 policy/modules/services/pd_mapper.if
+ create mode 100644 policy/modules/services/pd_mapper.te
+
+diff --git a/policy/modules/services/pd_mapper.fc b/policy/modules/services/pd_mapper.fc
+new file mode 100644
+index 000000000..3d83d46b1
+--- /dev/null
++++ b/policy/modules/services/pd_mapper.fc
+@@ -0,0 +1 @@
++/usr/bin/pd-mapper      --      gen_context(system_u:object_r:pd_mapper_exec_t,s0)
+diff --git a/policy/modules/services/pd_mapper.if b/policy/modules/services/pd_mapper.if
+new file mode 100644
+index 000000000..34da5143f
+--- /dev/null
++++ b/policy/modules/services/pd_mapper.if
+@@ -0,0 +1,10 @@
++## <summary>pd-mapper</summary>
++#
++## <desc>
++## Qualcomm’s pd‑mapper service is the userspace Protection Domain mapper
++## that enables applications to access remote processors
++## (Wi‑Fi, modem, sensors, etc.)
++## on Qualcomm SoCs via the QRTR protocol.
++##
++## https://github.com/linux-msm/pd-mapper
++## </desc>
+diff --git a/policy/modules/services/pd_mapper.te b/policy/modules/services/pd_mapper.te
+new file mode 100644
+index 000000000..34a8d6bcc
+--- /dev/null
++++ b/policy/modules/services/pd_mapper.te
+@@ -0,0 +1,15 @@
++policy_module(pd_mapper)
++
++########################################
++#
++# Declarations
++#
++
++type pd_mapper_t;
++type pd_mapper_exec_t;
++init_daemon_domain(pd_mapper_t, pd_mapper_exec_t)
++
++allow pd_mapper_t self:qipcrtr_socket connected_socket_perms;
++
++# Read /sys/devices/platform/soc@0/2a300000.remoteproc/remoteproc/remoteproc2/firmware
++dev_read_sysfs(pd_mapper_t)
+-- 
+2.34.1
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom =  " \
+	file://0057-pd-mapper-Introduce-SELinux-domain-for-pd-mapper.patch \
+	"	


### PR DESCRIPTION
Introduce a new SELinux domain for the Qualcomm pd-mapper service to ensure proper labeling, isolation, and access control under the targeted refpolicy.

To ensure functionality for QCOM platforms, carry this backport patch locally in meta-qcom until the next meta-selinux release integrates the upstream change.
