### PR TITLE
Revert "qcs615-ride.conf: stop setting QCOM_DTB_DEFAULT"

### DIFF
--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -6,6 +6,8 @@ require conf/machine/include/qcom-qcs615.inc
 
 MACHINE_FEATURES += "efi pci"
 
+QCOM_DTB_DEFAULT ?= "qcs615-ride"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs615-ride.dtb \
                       "


### PR DESCRIPTION
This reverts commit b6d483f9f6032b9d5e20d608f53251a90bc298ee as the QCS615 Ride boards are not yet supported by the multi-DTB image.