### PR TITLE
conf: switch to support UFS build by default for IQ-X7181

### DIFF
--- a/conf/machine/include/qcom-hamoa.inc
+++ b/conf/machine/include/qcom-hamoa.inc
@@ -4,8 +4,6 @@ SOC_FAMILY = "hamoa"
 require conf/machine/include/qcom-base.inc
 require conf/machine/include/qcom-common.inc
 
-QCOM_VFAT_SECTOR_SIZE = "512"
-
 DEFAULTTUNE = "armv8-6a-crypto"
 require conf/machine/include/arm/arch-armv8-6a.inc
 

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -19,7 +19,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "IQ_X_EVK_CDT"
 QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/nvme"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"


### PR DESCRIPTION
Support UFS build by default, considerations behind this include:
1. After dtb.bin moved to spinor, there will sector size mismatch issue reported by PCAT tool.
    For NVMe build, the sector size for spinor flash is 4096, sector size of dtb.bin is set as 512 by QCOM_VFAT_SECTOR_SIZE.
    For UFS build, the sector size of dtb.bin will be 4096, which is align with spinor sector size.
2. M.2 NVMe card need to be inserted on board to boot up from NVMe, while UFS storage is always available.
3. UFS build is more stable than NVMe, NVMe caused kernel panic could be reproduced about 3% still under check by storage team.