### PR TITLE
Use CodeLinaro MIRRORS as a backup.

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -43,7 +43,12 @@ local_conf_header:
       HALT,${DL_DIR},100M,1K \
       HALT,${SSTATE_DIR},100M,1K \
       HALT,/tmp,10M,1K"
-
+  clo-mirrors: |
+    MIRRORS:append = " \
+    git://github.com git://git.codelinaro.org/clo/yocto-mirrors/github/ \
+    git://.*/.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
+    https://.*/.*/ https://codelinaro.jfrog.io/artifactory/codelinaro-le/ \
+    "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |


### PR DESCRIPTION
To reduce git repo fetch failures in builds, add CodeLinaro MIRRORS
as a backup to provide fallback Git sources.