### PR TITLE
Use CodeLinaro.org domain for MIRROR configuration.

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -47,7 +47,7 @@ local_conf_header:
     MIRRORS:append = " \
     git://github.com git://git.codelinaro.org/clo/yocto-mirrors/github/ \
     git://.*/.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
-    https://.*/.*/ https://codelinaro.jfrog.io/artifactory/codelinaro-le/ \
+    https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"


### PR DESCRIPTION
Use  artifacts.codelinaro.org URL instead of jrog.io URL to avoid depending on the underlying service provider of the current implementation.

Update changes in #1423 