### PR TITLE
kgsl-dlkm: update KGSL tip

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
 PV = "0.0+git"
-SRCREV = "40ed596f3e5fe26dcf939b6d7eda836530c73cb0"
+SRCREV = "bee216cab43c97ca8e68b9d294244ab770e2c6ee"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https \
     file://kgsl.rules \


### PR DESCRIPTION
Update the SRCREV to point to the latest commit in the KGSL source code repository. This update brings in few improvements and fixes:

- Fix error for kernel 6.19+ due to governor.h relocation.
- Add support for A612 GPU with standard DT bindings.
- rgmu: Update flag check in suspend resume path.
- Catchup from gfx-kernel.lnx.16.0, which introduce Gen7/8 support.