### PR TITLE
Revert "rb3gen2-core-kit.conf: stop setting QCOM_DTB_DEFAULT"

### DIFF
--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -6,6 +6,8 @@ require conf/machine/include/qcom-qcs6490.inc
 
 MACHINE_FEATURES += "efi pci"
 
+QCOM_DTB_DEFAULT ?= "qcs6490-rb3gen2"
+
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       qcom/qcs6490-rb3gen2-vision-mezzanine.dtb \


### PR DESCRIPTION
This reverts commit 712366a1ecc23e4bfc2753319fae2e14fc973c45.

The transition to multi-DTB broke support for rb3gen2 lite (5430), which is supposed to be fully compatible with the standard rb3gen2 image.