### PR TITLE
gst-plugins-imsdk: Add recipe for IMSDK GStreamer plugin suite

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/imsdk/gst-plugins-imsdk_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/imsdk/gst-plugins-imsdk_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " ml messaging"

--- a/recipes-multimedia/imsdk/gst-plugins-imsdk-packaging.inc
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk-packaging.inc
@@ -1,0 +1,62 @@
+# Extends the GStreamer packaging to handle IMSDK plugins.
+# For plugins that provide runtime modules, all module .so files under
+# <plugin>/modules/ are grouped into a separate per-plugin modules package.
+
+require recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
+
+PACKAGESPLITFUNCS =+ "split_imsdk_module_packages"
+PACKAGESPLITFUNCS += "set_imsdk_oss_metapkg_rdepends"
+
+python split_imsdk_module_packages () {
+    imsdk_root = d.expand('${libdir}/imsdk')
+
+    # Qualcomm runtime modules for plugin
+    do_split_packages(d, imsdk_root, r'([^/]+)/modules/[^/]+\.so', d.expand('${PN}-%s-modules'), 'IMSDK runtime modules for %s plugin', recursive=True, extra_depends='', match_path=True)
+}
+
+# List of plugin packages to exclude from OSS meta package
+# Add package names (without version/architecture suffix) to this list
+# Example: to exclude gst-plugins-imsdk-qtimlqnn, add 'qtimlqnn' to the list
+IMSDK_OSS_METAPKG_EXCLUDE ?= "qtimlqnn qtimlsnpe qtismartvencbin"
+
+python set_imsdk_oss_metapkg_rdepends () {
+    import os
+    import oe.utils
+
+    # Go through all generated packages (excluding the main package and
+    # the -meta package itself) and add them to the -meta package as RDEPENDS.
+    # Also exclude packages specified in IMSDK_OSS_METAPKG_EXCLUDE.
+
+    pn = d.getVar('PN')
+    metapkg =  pn + '-oss-meta'
+    d.setVar('ALLOW_EMPTY:' + metapkg, "1")
+    d.setVar('FILES:' + metapkg, "")
+    exclude = [ pn, pn + '-meta', pn + '-oss-meta' ]
+
+    # Add user-defined plugin exclusions to the exclude list
+    exclude_plugins = d.getVar('IMSDK_OSS_METAPKG_EXCLUDE') or ""
+    if exclude_plugins:
+        for plugin in exclude_plugins.split():
+            # Add packages like gst-plugins-imsdk-<plugin>
+            exclude.append(pn + '-' + plugin)
+
+    metapkg_rdepends = []
+    pkgdest = d.getVar('PKGDEST')
+    for pkg in oe.utils.packages_filter_out_system(d):
+        if pkg not in exclude and pkg not in metapkg_rdepends:
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory.
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS:' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION:' + metapkg, pn + ' meta package')
+}
+
+PACKAGES += "${PN}-oss-meta"

--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_git.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_git.bb
@@ -1,0 +1,37 @@
+require gst-plugins-imsdk-packaging.inc
+
+SUMMARY = "Qualcomm IMSDK GStreamer Plugins (QTI OSS)"
+DESCRIPTION = "Open-source Qualcomm IMSDK GStreamer multimedia, CV, ML, and messaging plugins"
+SECTION = "multimedia"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+inherit cmake features_check pkgconfig
+
+REQUIRED_DISTRO_FEATURES = "opengl"
+
+SRC_URI = "git://github.com/qualcomm/gst-plugins-imsdk;branch=main;protocol=https"
+
+SRCREV = "6ad888f79403ce91092dd49eed3dc3b4242957ca"
+PV = "0.0+git"
+
+DEPENDS += "\
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    virtual/egl \
+    virtual/libgbm \
+    virtual/libgles2 \
+    virtual/libgles3 \
+"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+PACKAGECONFIG ??= "videoproc sw"
+
+PACKAGECONFIG[ml]           = "-DENABLE_GST_ML_PLUGINS=1, -DENABLE_GST_ML_PLUGINS=0, cairo json-glib opencv qairt-sdk, qairt-sdk"
+PACKAGECONFIG[messaging]    = "-DENABLE_GST_MESSAGING_PLUGINS=1, -DENABLE_GST_MESSAGING_PLUGINS=0, librdkafka mosquitto"
+PACKAGECONFIG[sw]           = "-DENABLE_GST_SOFTWARE_PLUGINS=1, -DENABLE_GST_SOFTWARE_PLUGINS=0, gstreamer1.0-rtsp-server smart-venc-ctrl-algo"
+PACKAGECONFIG[videoproc]    = "-DENABLE_GST_VIDEOPROC_PLUGINS=1, -DENABLE_GST_VIDEOPROC_PLUGINS=0, cairo"


### PR DESCRIPTION
The recipe fetches IMSDK GStreamer plugins source code from git repository and compiles plugins. The repository contains various GStreamer plugins across several functional domains:
  - Multimedia
  - Computer Vision
  - Machine Learning
  - Messaging and IPC

Plugin enablement and feature selection are fully configurable through PACKAGECONFIG.