### PR TITLE
camx-dlkm: Install UAPI headers for camx userspace

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_git.bb
+++ b/recipes-multimedia/camx/camx-dlkm_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Qualcomm Camera driver (CAMX)"
 HOMEPAGE = "https://github.com/qualcomm-linux/camera-driver"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-with-Linux-syscall-note"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0"


### PR DESCRIPTION
Install the camera UAPI headers from the camx driver to allow camx userspace components to build against them without needing the kernel source trees.