### PR TITLE
msm-gbm-backend: switch SRC_URI from git to https

### DIFF
--- a/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
+++ b/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://src/gbm_msm.h;md5=8c54773149e04ded5c0c3e293bb13509"
 PV = "0.1+git"
 SRCREV = "d2f771e8c80698a18b16f14ea60d5d55abede683"
 
-SRC_URI = "git://git.codelinaro.org/clo/le/display/libgbm.git;branch=display.qclinux.1.0.r1-rel \
+SRC_URI = "git://git.codelinaro.org/clo/le/display/libgbm.git;protocol=https;branch=display.qclinux.1.0.r1-rel \
            file://0002-QCOM-libgbm-use-sysconfdir-to-install-configuration-.patch \
            file://0003-QCOM-libgbm-set-install-paths-for-backend-library-co.patch "
 


### PR DESCRIPTION
Use https instead of unauthenticated git:// protocol which may not work for some working behind firewalls.