### PR TITLE
workflows: use the repository owner instead of the name

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   kas-setup:
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - name: Update kas-container
@@ -48,7 +48,7 @@ jobs:
 
   yocto-run-checks:
     needs: kas-setup
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
 
   compile_warm_up:
     needs: [kas-setup, yocto-run-checks]
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:
       fail-fast: true
@@ -110,7 +110,7 @@ jobs:
 
   compile:
     needs: compile_warm_up
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     outputs:
       url: ${{ steps.compile_kas.outputs.url }}

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sstate-cache-cleanup:
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64-ssd]
     steps:
       - name: Clean up the persistant sstate-cache dir

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   repolinter:
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository_owner == 'qualcomm-linux'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
We don't need to specify the repository name and its owner also meets our requirements.