### PR TITLE
camxlib-kodiak: remove camx headers from -dev

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.6.bb
@@ -43,7 +43,6 @@ do_install() {
 
     cp -r ${S}/usr/lib/* ${D}${libdir}
     cp -r ${S}/usr/bin/* ${D}${bindir}
-    cp -r ${S}/usr/include/* ${D}${includedir}
 
     # Remove unnecessary development symlinks (.so) from the staged image
     rm -f ${D}${libdir}/camx/kodiak/*${SOLIBSDEV}


### PR DESCRIPTION
More recent headers are also available via camxlib-lemans-dev, so avoid the package conflict by removing the headers provided by the kodiak version (older implementation).

We need a proper camx implementation that provides a common headers for all -dev packages (shared via a common package / recipe) which is compatible with all architecture-based implementation.