### PR TITLE
Firmware update for LEMANS and MONACO

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware/0001-linux-firmware-qcom-sync-audioreach-firmwares-from-v.patch
+++ b/recipes-kernel/linux-firmware/linux-firmware/0001-linux-firmware-qcom-sync-audioreach-firmwares-from-v.patch
@@ -1,0 +1,244 @@
+From 822ba35b15b1adb506320ecfecd55f4696c8d6cf Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Sat, 28 Feb 2026 09:29:35 +0000
+Subject: [PATCH] linux-firmware: qcom: sync audioreach firmwares from v1.0.2
+ build
+
+Update audioreach tplg firmwares to latest builds from v1.0.2 of
+https://github.com/linux-msm/audioreach-topology
+
+Upstream-Status: Backport
+[https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=822ba35b15b1adb506320ecfecd55f4696c8d6cf]
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ WHENCE                                        |  33 ++++++++++++------
+ qcom/kaanapali/Kaanapali-MTP-tplg.bin         | Bin 0 -> 29264 bytes
+ qcom/qcm6490/QCM6490-IDP-tplg.bin             | Bin 22492 -> 22492 bytes
+ qcom/qcs615/TALOS-EVK-tplg.bin                | Bin 10892 -> 10892 bytes
+ qcom/qcs6490/QCS6490-RB3Gen2-tplg.bin         | Bin 22880 -> 22880 bytes
+ .../QCS6490-Thundercomm-RubikPi3-tplg.bin     | Bin 16720 -> 16720 bytes
+ qcom/qcs8300/MONACO-EVK-tplg.bin              | Bin 10892 -> 10892 bytes
+ qcom/sa8775p/LEMANS-EVK-tplg.bin              | Bin 10892 -> 10892 bytes
+ qcom/sm8450/SM8450-HDK-tplg.bin               | Bin 27124 -> 27124 bytes
+ 9 files changed, 22 insertions(+), 11 deletions(-)
+ create mode 100644 qcom/kaanapali/Kaanapali-MTP-tplg.bin
+
+diff --git a/WHENCE b/WHENCE
+index 3f8455a5..68aa01a1 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -8958,14 +8958,24 @@ License: Redistributable. See LICENSE.powervr for details
+ 
+ --------------------------------------------------------------------------
+ 
++Driver: qcom-kaanapali - Qualcomm ASoC tplg Firmware
++File: qcom/kaanapali/Kaanapali-MTP-tplg.bin
++Version: v1.0.2
++Info: DATE=28.02.2026
++
++Licence: Redistributable. See LICENCE.linaro for details
++Originates from https://github.com/linux-msm/audioreach-topology.git
++
++--------------------------------------------------------------------------
++
+ Driver: qcom-qcs6490 - Qualcomm ASoC topology
+ File: qcom/qcs6490/radxa/dragon-q6a/QCS6490-Radxa-Dragon-Q6A-tplg.bin
+ Link: qcom/qcs6490/QCS6490-Radxa-Dragon-Q6A-tplg.bin -> radxa/dragon-q6a/QCS6490-Radxa-Dragon-Q6A-tplg.bin
+ File: qcom/qcs6490/Thundercomm/RubikPi3/QCS6490-Thundercomm-RubikPi3-tplg.bin
+ Link: qcom/qcs6490/QCS6490-Thundercomm-RubikPi3-tplg.bin -> Thundercomm/RubikPi3/QCS6490-Thundercomm-RubikPi3-tplg.bin
+ File: qcom/qcs6490/QCS6490-RB3Gen2-tplg.bin
+-Version: v1.0.1
+-Info: DATE=10.01.2026
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+@@ -8974,7 +8984,8 @@ Originates from https://github.com/linux-msm/audioreach-topology.git
+ 
+ Driver: qcom-qcs8300 - Qualcomm ASoC topology
+ File: qcom/qcs8300/MONACO-EVK-tplg.bin
+-Version: v0.1.0
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+@@ -8984,8 +8995,8 @@ Originates from https://github.com/linux-msm/audioreach-topology.git
+ Driver: qcom-qcs9100 - Qualcomm ASoC topology
+ File: qcom/sa8775p/LEMANS-EVK-tplg.bin
+ Link: qcom/qcs9100/LEMANS-EVK-tplg.bin -> ../sa8775p/LEMANS-EVK-tplg.bin
+-Version: v1.0.1
+-Info: DATE=10.01.2026
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+@@ -9517,8 +9528,8 @@ Licence: Redistributable. See LICENCE.r8a779g_pcie_phy for details.
+ 
+ Driver: qcm6490 - Qualcomm ASoC tplg Firmware
+ File: qcom/qcm6490/QCM6490-IDP-tplg.bin
+-Version: v1.0.1
+-Info: DATE=10.01.2026
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+@@ -9526,8 +9537,8 @@ Originates from https://github.com/linux-msm/audioreach-topology.git
+ 
+ Driver: qcs615 - Qualcomm ASoC tplg Firmware
+ File: qcom/qcs615/TALOS-EVK-tplg.bin
+-Version: v1.0.1
+-Info: DATE=10.01.2026
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+@@ -9535,8 +9546,8 @@ Originates from https://github.com/linux-msm/audioreach-topology.git
+ 
+ Driver: sm8450 - Qualcomm ASoC tplg Firmware
+ File: qcom/sm8450/SM8450-HDK-tplg.bin
+-Version: v1.0.1
+-Info: DATE=10.01.2026
++Version: v1.0.2
++Info: DATE=28.02.2026
+ 
+ Licence: Redistributable. See LICENCE.linaro for details
+ Originates from https://github.com/linux-msm/audioreach-topology.git
+diff --git a/qcom/kaanapali/Kaanapali-MTP-tplg.bin b/qcom/kaanapali/Kaanapali-MTP-tplg.bin
+new file mode 100644
+index 0000000000000000000000000000000000000000..2c2156afe2507fa5c556f05078676a974fdc9b05
+GIT binary patch
+literal 29264
+zcmeI5&vP6{6~|XA3I9l{5Q&o%a1mG+4pC_(`94C<EiOXh3f#0pyRlSAmb{UTxrHhp
+zIOO2ma?G6rm)yu75FiE4f5Mp`1@E&xPu)Aex_dRF9aGz`)|(%%dtQJ0{hHpH@$Tsd
+zJIftYt_xX9x6e|#Ae3#+{Y2`zROOe=M#`=u6W3CizUZ3EA=5LdOHw~R9}V|UHrAh<
+z9`7BTkB&DC%ccMRSBiFWQ#XWux3eJsI-M`2Zc9Z5WJI)uM5<8AqEwD?9tscV+%^M_
+zC7sR?y3%>&BcYwuPUivpQV*rl_Fbv;!yNpX?S7~8wa_1~bgunHD7=47>EBZNccHX>
+zAr<~_g)R&IMkxIE9v`0{-5U;$_Is=E9q<44SNjLQUj6X&`0)wSOqSPWcR?DBt8D+C
+z{gj0<%&HuwLfDxyV_tCtVjkRmaHP2N+r)mE4uAf(!S1$P^qJIGq^b`8X7usl-ter4
+zJY}V5-pY90F}gae{Ik^Ig}%{YnVhi>BU6<Q!;cPkg@W5#QWdwegOk0%@ZfYX993c`
+zO@fLKx38oZ*N(9>>{x9Ao#Pm~2EB~!-%tCwAr#wZ{Mi0-pzXsCZi_<yEfg8S@0L^-
+zzk}0<PlluOS`chAev5sB-(nzs@Pi*d6#SUmEPf{+9n_+C()GCb@SCOG5<}3xHv;j4
+zAN;-}6x{H|s&~hy4<6K_aMCBmha0i)s_b?k*IJT_f5&baKe+uM5I6Y2jj||4`^WD~
+ze?qa}W&TJ3Pa8ja>v8d8^CIq#J1h9(!?Q>ayNQtz5kvhTZHB@hlLM{v4W6O#1Ag%Q
+zo=|YJ@uRoihWOD<n!)Y9j1@i9_`&#N;s^ZT_L|V*_+jvyb^PciSA!oofM00*fFJx`
+z7wX0j=EV5H-o?F3Pma}5%Ivo4-ldx~gJ1UE1suRH^xg%2@Vg~6fA3;_*!<o_KuU`{
+z{~U_l$3NbZs`}Z6{HB{+jeeqM=x1nt13&uthEQ;``Au)V4f#zsX$H4}j1?cI`3>U-
+zx6u3sesH5y<u?}3%~s&Km>4{{uXFR8ab70JIPT_{;6$6E{096ErP3yg=W0I=Px!&}
+zM?$Ocw06C@-UhpF3eRlZ0hbuNh95kCEcBUB7dP_7S?4=V;dWofie75I$oRo6G~a<A
+z+-?hX^Tjvin29Hw<9vJgaJK6;SA`!qfZtN!eINYbw<grZ?^QXb_>BfJ>x5gYyZdM7
+zk4Jc*;^O89q3eWA;g_{rZ~#BKH=J1OW+d)fH~TN7!Vi8F?AFGQtyaX3rNqP!Vn=BF
+zpiON2*ytPFLgO*~;MNlw7C*LH5kH#3GpmQ-5)(h*2hUBRlksC~?EhvRKbpcV8$TF-
+zO#FZ!+_r?e{?En_gWs&<$5r764l(fqe(>AQ;Ai8<)_Pq0*lr|#G=*Q*ZowfYe!vfY
+z6ztZnuWm=Kuij~7ef4Hy;s-gJ8$Y;*SeCjVbz3Uu*&j%yO;P-S_fRTrv$!RFgInnO
+zD*WKKBNW`;l4|mm?e(+c{e$7*>9PDiSIh5ozI^2?xweY|<7*1HtiNOYU(5AwWbzfT
+zcJmcvdLb2laQmrH*WcZeV;A_f;C|z(@B;_%3%%cfAN+QOf*&@4{;fz={MxV%(-eN#
+z_mWgyhq>D~_=V<u@T<S8%KN}`Fnn@!FzjvIsX3GO+4DDY?W{d7C&t$u$vM{#VrON3
+zkTyO)n8owGejJ|ggXhnMg6AJfez(KEEuQtR#Q5<1Qm%bfcxK}YxM1I*>#OjC=lepj
+zYxLaW#u~!G-r!_^Z}hY$XY%D2AMEVy{_O5MyL)%<?d-k(%e{^Au<XNamU_te!R>Y?
+zt}tRZuCPyBf&W`}r2I=N@#ddWv5)_x6g(Zf?$v#VJPn@L5+maykuB7&X%lPLXZ<+4
+zh95j12@SMs!E^R@-4vc#y9SpSyM`Y;M?y1pEx7sZS}Zx#tS5f|Dq7zvvg@XB%f=VR
+zA7j_>gBu0A#-5Ap`c*le`pMpggXejPpZw5ullO6x<*SC%*!A_q$of#^Dza<*lN*!3
+zi8e)cy(H%jrP3yg=O=xG=UVC~g{AVjLioY+cS6Av*^2OV{p3aq@}H~16I{^G(0mep
+z)z2zF>FDQXh<=JnT6>qBs#Wc2^z%ky^z*5VHB>)o6RV%k1t0JX)lc}r^E08Yy<-C<
+zaa{1M_l~E{c!Eoee!}n5&$4H?{~?Nj&%x(DlZu|$=drg|?;SlIj^tP!#l<|^A2Q%8
+zU4O~3#l*-q-j;nRdV;*m={~WJ{hU3?v9iKA$Bm>RZQD}x`F~d?w(-@9-&l5MUuD<x
+zP3#xVO^AQdxyi+16|#WN=f=*p!c#T3MROApORIbWbAaCEeZuz4eL~1OyXxKCC%A7C
+z#pxBg7pr%3pJ42!jsE&FKH&=qyc&1$32f_Hw7#c^AF89cI(O6Qu<BXgn~A|4x$s?@
+zCqT&)@MUgpF_3-Q6y>_`9!jO{yHe@%x>VkI*zKF#Ec97l_{q&!lUAQ(^DFy%+Wc8x
+z0Vyr+{BtOFzbvkODvH3`x*OLD)>3yK4~|YR8|1Pwr$ZYP^s^{thphh>=#blW;r2YA
+ziqoN@xe4(v`MKFFoDcWld~Pm3H{Hb8G<IF)`}1?tbElzjdp<XppPPkrZUDG!ZmRtC
+zBWdUQ>--vdE$%uOV~|%1au@l8Yl)E!8QrlVujU+iy}Ki4s|$UN2Q3}ZS6j-<v^FvK
+z*G6~RcpuVDF4TL%ZrofwZ#Q#)jUUM7m6zEs@@Wg{+;A<|r@3?E`s-`Lw+6G6=VQlZ
+z=9X=HpJTtrVmR}EV|cZ7n|!0nG^Z~w0^IY*=ppL@T0Z$xr$fa~sBJ4%Hj5omCvDcg
+zhg>!mi<O^OuQ9jTGBoGMr$J!SX8n5j|6;TFn7qwaJwag5wKnVLb$!{~Zl}@Cd7D`x
+zFzFlo`d;K4(EFHpUKM9akMlO`e;3Kxte=-_q-l7o)(&Q=2lH#cJP1tMtY6=owpsem
+z+pPWFt_)dgvwmK#q1U0md8{o%b$&bsfk|5m(?jk5WxAimcGgnCpTB18hkf&W!ba`i
+z!qa|3zD=mSb$?&Q?br96Smo8{G&XdSFG;oEkg+Lmy>E}$ISv_{%24l<#8!rou^Aca
+z|30Jk8?KY}f8$VP2>JG;^6I?#SNFq|Rr?Ls$zIKGG^sv>eFIVDZAK@<#%5%w|661>
+z2l78ht}=w!P?#ndF6}o2U*!$aooQqU8JjCZo!<j-`}KXNMR`NMsWA->;OiTkk)iIl
+zH{JDp|8vYLL&&_v;}AABm7y7(411f?mBBY})8G&?HkF|noecZ_j*+4MZ+~dN;jvp}
+zsQLRDDnrP3O_Wz-H@_p-QMBKXu_<qeUyqSZ`wbbJeP_R3DPo>UwKCM}rEI_cu~}aK
+zJI*n4Vf*!utpGFqFJNLWnd7xG_{Wy=*8a_bm}lOs41UaVgRMAV`wiBIpm*LYE}1)J
+zW$=$Jk6A71aPj_m$ou>%Z^*mAxxrQ($h}Kf@m{-?!9Q;mm&~2A{aU*ydk;V54SFX!
+zccF>{xp%w#IMn_gam?7<--g^ZtLw7htG~6z+%x6IUxAgC)2|0HGURm8FN1u$!7oD<
+zR{XvNURF+jF5f&>ei^PBt4~F*^jlH|@v-#5X^X4>S!K<a{4?6=Oecf?9SS2u*thAY
+vlfl0_Wn>7^Y<Y*w`M&^NKfrwHv*h{sRXSac9n?Et)5%cpd`%}qz4P@ym8w-U
+
+literal 0
+HcmV?d00001
+
+diff --git a/qcom/qcm6490/QCM6490-IDP-tplg.bin b/qcom/qcm6490/QCM6490-IDP-tplg.bin
+index 5f07eaf961c373a147029f6629607564c77cdbea..2716767c773b76001e573642d464e66c06d3c48b 100644
+GIT binary patch
+delta 13
+Vcmcb!p7G9l#tqxTC(HS$0RS*+1^EB~
+
+delta 13
+Vcmcb!p7G9l#tqxTC!gX}0{}7T24VmJ
+
+diff --git a/qcom/qcs615/TALOS-EVK-tplg.bin b/qcom/qcs615/TALOS-EVK-tplg.bin
+index 0c217d42b241eea41af7782dcca3cb8f022d5b2a..bcfec8e6bc6e7e1fa7aa914a8d0ab3a0bebeee6d 100644
+GIT binary patch
+delta 37
+scmeAP?Frq`AUJu02JhrHLHW&V1a%mJ9G%H)1WhJS5Q*44LHLgt02Lt)bN~PV
+
+delta 36
+ucmV+<0NekJRg6`zfDx11CoHq95i9|d-x4K}PzRH&5j2yK6j-y66Z{qtHx6z9
+
+diff --git a/qcom/qcs6490/QCS6490-RB3Gen2-tplg.bin b/qcom/qcs6490/QCS6490-RB3Gen2-tplg.bin
+index 66b79014a0b012d3266de329385eeb9c3d28d614..e4273805ce34456a1461b993cab51c4f21c21974 100644
+GIT binary patch
+delta 22
+ecmaE`iSfZE#tk<VC!Yz{nS6&?VY7;ojX3~;0|~4E
+
+delta 25
+hcmaE`iSfZE#tk<VCqGnFo*2M6`3|$fW)&qHa{!&K3UB}b
+
+diff --git a/qcom/qcs6490/Thundercomm/RubikPi3/QCS6490-Thundercomm-RubikPi3-tplg.bin b/qcom/qcs6490/Thundercomm/RubikPi3/QCS6490-Thundercomm-RubikPi3-tplg.bin
+index a70c70ebe58ad6919abe7a10f6481b555fc6a0a3..b8ab8f77e6dd1463be526a5584437c6b976a4d70 100644
+GIT binary patch
+delta 60
+zcmcc6#CV~JaYKUCWCt6a$rqG)COgP#Y(606!8G}dEm&Z)gRBB0P?mRcnw&gBh1>)s
+E0H>Z6R{#J2
+
+delta 77
+zcmcc6#CV~JaYKR>tAekmQSjt^4aJE8Y?Ci2^GtS-)!2MM%7Y0*X0wB=0^{WMcB&Ht
+L*byq_CMW>_<7gRk
+
+diff --git a/qcom/qcs8300/MONACO-EVK-tplg.bin b/qcom/qcs8300/MONACO-EVK-tplg.bin
+index ecb5db48b7053d740487d0152f6ce49f33dd94f4..c302575ca64c71d3db78b65c9ab098c0a05e1842 100644
+GIT binary patch
+delta 41
+zcmV+^0M`GERg6`zfDx0_CoHq95i9|duqZ5(tPwPmkQ7+6kQ2lWku)r`fFTSCUgr;n
+
+delta 46
+zcmV+}0MY-9Rg6`zfDx11CoHq95i9|d;SwW}PzjT)5j2yK6j-y66T}Sx0g*u~vw$HC
+E39K6smjD0&
+
+diff --git a/qcom/sa8775p/LEMANS-EVK-tplg.bin b/qcom/sa8775p/LEMANS-EVK-tplg.bin
+index b92404bda704a4a134bcc1ae223db26c0d8d8e33..a308def4ef61a0e1cc4bd063f3ec52d90b3fc0ac 100644
+GIT binary patch
+delta 41
+zcmV+^0M`GERg6`zfDx0_CoHq95i9|duqZ5(tPwPmkQ7+6kQ2lWku)r`fFTSCUgr;n
+
+delta 46
+zcmV+}0MY-9Rg6`zfDx11CoHq95i9|d;1VQ}PzaN(5j2yK6j-y66T}Sx0g*u~vw$HC
+E39JDSmH+?%
+
+diff --git a/qcom/sm8450/SM8450-HDK-tplg.bin b/qcom/sm8450/SM8450-HDK-tplg.bin
+index 66c22987174e71f4b09d7242b5beb5a518aea27c..3f637d25c50b5c67234a74fb31b4da352c3f89cd 100644
+GIT binary patch
+delta 22
+ecmexzneoeI#tjuJlS|@tCMTHlY~G;a;tBwNlnJ!}
+
+delta 25
+hcmexzneoeI#tjuJlj~JfCkC)jPB7=$yg|jq6#$xZ3T6NR
+
+-- 
+2.34.1
+

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -3,6 +3,25 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 ALTERNATIVES_CLASS = ""
 ALTERNATIVES_CLASS:qcom = "update-alternatives"
 
+WHENCE_CHKSUM:qcom = "633ca1cad82a881056299e9ae7c43c0a"
+PATCHTOOL:qcom = "git"
+
+SRC_URI:append:qcom = " \
+    file://0001-linux-firmware-qcom-sync-audioreach-firmwares-from-v.patch \
+"
+
+PACKAGES:append:qcom = " \
+    ${PN}-qcom-kaanapali-audio-tplg \
+"
+
+LICENSE:${PN}-qcom-kaanapali-audio-tplg:qcom = "Firmware-linaro"
+
+FILES:${PN}-qcom-kaanapali-audio:append:qcom = " \
+    ${nonarch_base_libdir}/firmware/qcom/kaanapali/Kaanapali-MTP-tplg.bin* \
+"
+
+RDEPENDS:${PN}-qcom-kaanapali-audio-tplg:qcom = "${PN}-linaro-license"
+
 inherit ${ALTERNATIVES_CLASS}
 
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo


### PR DESCRIPTION
linux-firmware: Update audio topology for LEMANS and MONACO
Update LEMANS and MONACO EVK audio topology to support stereo channel audio capture.
Link: https://gitlab.com/kernel-firmware/linux-firmware/-/merge_requests/880
