### PR TITLE
Introduce a linux-qcom-rt 6.18 recipe

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -159,6 +159,14 @@ jobs:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro-prop-image.yml'
             kernel:
+                type: rt-6.18
+                dirname: "+linux-qcom-rt-6.18"
+                yamlfile: ":ci/linux-qcom-rt-6.18.yml"
+          - machine: iq-9075-evk
+            distro:
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro-prop-image.yml'
+            kernel:
                 type: qcom-next-rt
                 dirname: "+linux-qcom-next-rt"
                 yamlfile: ":ci/linux-qcom-next-rt.yml"

--- a/ci/linux-qcom-rt-6.18.yml
+++ b/ci/linux-qcom-rt-6.18.yml
@@ -1,0 +1,7 @@
+header:
+  version: 14
+
+local_conf_header:
+  kernelprovider: |
+    PREFERRED_PROVIDER_virtual/kernel = "linux-qcom-rt"
+    PREFERRED_VERSION_virtual/kernel = "6.18%"

--- a/recipes-kernel/linux/linux-qcom-rt_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom-rt_6.18.bb
@@ -1,0 +1,5 @@
+require linux-qcom_6.18.bb
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
+
+KBUILD_CONFIG_EXTRA:append:aarch64 = " ${S}/arch/arm64/configs/rt.config"


### PR DESCRIPTION
Introduce a new RT recipe based on Linux 6.18 and built from the 'qcom-6.18.y' branch of qualcomm-linux/kernel tree.

The kernel rt recipe is used to build a fully preemptible Linux kernel and used to ensure deterministic, low-latency performance for time-sensitive applications.