### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260128

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -12,8 +12,8 @@ LINUX_VERSION ?= "6.18"
 
 PV = "${LINUX_VERSION}"
 
-# tag: qcom-6.18.y-20260120
-SRCREV ?= "b588875924316e2f73aa987cec342e624147f87c"
+# tag: qcom-6.18.y-20260128
+SRCREV ?= "cdc4617fae333fe78b4375c00f48f047a6129f81"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260128

Changelog:
Workaround: PCI: Disable L1ss through quirk for Qualcomm SA8775P
FROMLIST: media: i2c: imx412: Extend the power-on waiting time
FROMLIST: media: i2c: imx412: Assert reset GPIO during probe
UPSTREAM: media: i2c: imx412: Use %pe format specifier
FROMLIST: arm64: dts: qcom: talos-evk-camera: Add DT overlay
FROMLIST: arm64: dts: qcom: talos: Add camera MCLK pinctrl
FROMLIST: arm64: dts: qcom: talos: Add CCI definitions
FROMLIST: dt-bindings: i2c: qcom-cci: Document sm6150 compatible
FROMLIST: arm64: dts: qcom: talos: Add camss node
FROMGIT: media: qcom: camss: add support for SM6150 camss
FROMGIT: media: dt-bindings: Add qcom,sm6150-camss
FROMGIT: media: qcom: camss: use a handy v4l2_async_nf_add_fwnode_remote() function
FROMGIT: media: qcom: camss: change internals of endpoint parsing to fwnode handling
FROMGIT: media: qcom: camss: vfe: Fix out-of-bounds access in vfe_isr_reg_update()
FROMGIT: media: qcom: camss: csid-340: Fix unused variables
FROMGIT: media: qcom: camss: Do not enable cpas fast ahb clock for SM8550 VFE lite
FROMGIT: media: qcom: camss: Add support for regulator init_load_uA in CSIPHY
FROMGIT: media: camss: csiphy: Make CSIPHY status macro cross-platform
UPSTREAM: media: qcom: camss: Add support for MSM8939
UPSTREAM: media: qcom: camss: vfe: Add VBIF setting support
UPSTREAM: media: qcom: camss: Add CSIPHY 2.2.0 lane configuration for SM8650
UPSTREAM: media: qcom: camss: Add Qualcomm SM8650 CAMSS support
UPSTREAM: media: qcom: camss: Enable setting the rate to camnoc_rt_axi clock
UPSTREAM: media: qcom: camss: Use a macro to specify the initial buffer count
UPSTREAM: dt-bindings: i2c: qcom-cci: Document SM8750 compatible
UPSTREAM: dt-bindings: i2c: qcom-cci: Document msm8953 compatible
UPSTREAM: media: dt-bindings: Add qcom,msm8939-camss
UPSTREAM: dt-bindings: media: Describe Qualcomm SM8650 CAMSS IP
FROMGIT: arm64: dts: qcom: talos: switch to interrupt-cells 4 to add PPI partitions
FROMLIST: arm64: dts: qcom: talos: add ETR device
WORKAROUND: drivers: increase deferred probe timeout
FROMLIST: arm64: dts: qcom: talos-evk: Add support for QCS615 talos evk board
FROMLIST: arm64: dts: qcom: talos/qcs615-ride: Fix inconsistent USB PHY node naming
FROMLIST: dt-bindings: arm: qcom: talos-evk: Add QCS615 Talos EVK SMARC platform
UPSTREAM: wifi: ath12k: Fix timeout error during beacon stats retrieval
UPSTREAM: wifi: ath12k: Make firmware stats reset caller-driven
FROMLIST: drm/msm/a6xx: fix bogus hwcg register updates
FROMLIST: arm64: dts: qcom: qcs615-ride: Enable Adreno 612 GPU
FROMLIST: arm64: dts: qcom: talos: Add GPU cooling
FROMLIST: arm64: dts: qcom: talos: Add gpu and rgmu nodes
FROMLIST: arm64: dts: qcom: talos: add the GPU SMMU node
FROMLIST: dt-bindings: display/msm/rgmu: Document A612 RGMU
FROMLIST: dt-bindings: display/msm: gpu: Document A612 GPU
FROMLIST: dt-bindings: display/msm: gpu: Simplify conditional schema logic
FROMLIST: drm/msm/a6xx: Retrieve gmu core range by index
FROMGIT: drm/msm/a6xx: Rebase GMU register offsets
