### PR TITLE
Allow manual triggering of nightly-build in CI

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -5,6 +5,7 @@ on:
   # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
   # so that build notification emails will be sent out properly.
   - cron: "23 23 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
+  workflow_dispatch:
 
 permissions:
   checks: write


### PR DESCRIPTION
Enable the `workflow_dispatch` trigger to allow manually starting
the nightly build workflow in addition to the scheduled cron runs. 
This is useful for on-demand testing, validation, or re-running failed
builds without waiting for the next nightly cycle.