### PR TITLE
workflows: fix list-jobs action

### DIFF
--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -39,7 +39,7 @@ runs:
         for J in $JOBFILES
           do
               echo $J
-              NAME=$(basename "$J")
+              NAME=$(echo "$J" | cut --delimiter "/" --field 3)
               echo $NAME
               F_TMP="${J#*/}"
               RESULT_NAME="${F_TMP//\//-}"


### PR DESCRIPTION
The name of the job in list-jobs action was incorrectly set to the file name generated by lava-test-plans. This name should include board and distro name so test results can be properly assigned to a build configuration. This patch fixes the mistake.