### PR TITLE
hexagon-dspso-*: add required SKIP_FILEDEPS

### DIFF
--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
@@ -12,3 +12,6 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
@@ -12,3 +12,5 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
@@ -12,3 +12,5 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
@@ -12,3 +12,6 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
@@ -12,3 +12,6 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
@@ -12,3 +12,6 @@ DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
 require hexagon-dspso.inc
+
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
+SKIP_FILEDEPS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"


### PR DESCRIPTION
When dspso.bin are provided by the build environment, the resulting packages contain Hexagon libraries which depend on the libgcc.so, libc.so and libc++abi.so.1 which are provided by the DSP itself, however OE / RPM don't have that knowledge, rendering the packages uninstallable. Add respective SKIP_FILEDEPS variables to make it possible to install those packages.