### PR TITLE
ci: Use GitHub Actions concurrency to cancel outdated PR workflow runs

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -12,6 +12,11 @@ on:
         description: "URL to retrieve build artifacts"
         value: ${{ jobs.create-output.outputs.url }}
 
+# Concurrency is used to prevent multiple workflows from running for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_REPO_REF_DIR: /efs/qli/meta-qcom/kas-mirrors


### PR DESCRIPTION
**Background**

By default, GitHub Actions allows multiple workflow runs to execute concurrently, including multiple runs triggered for the same pull request. While this can be beneficial in some cases, our workflows are relatively extensive and resource‑intensive.
We’ve observed that developers often trigger multiple workflow runs on the same PR due to force pushes or rapid successive updates. This results in several outdated runs executing in parallel, even though only the latest commit state is relevant.

**Problem**

Running multiple workflows in parallel for the same PR:

    - Consumes unnecessary CI resources
    - Executes jobs against outdated code that will never be merged
    - Increases noise and wait times without providing additional value

Without context, parallel execution may seem beneficial, but in our case it does not improve feedback quality and instead creates inefficiency.

**Proposed Change**

This PR introduces GitHub Actions concurrency to ensure that only the most recent workflow run for a given PR is executed. When a new commit is pushed to the PR, any in‑progress or queued runs for previous commits are automatically canceled.

**Benefits**

Ensures CI runs are always aligned with the latest PR state
Reduces wasted compute and execution time
Improves signal‑to‑noise ratio for developers and reviewers
Provides faster, more relevant feedback on active changes

This change is intended to make our CI behavior more predictable and efficient, given how our workflows are currently used.