### PR TITLE
recipes-bsp: update SRC_URI links for firmware

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard410c-sdcard_17.09.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard410c-sdcard_17.09.bb
@@ -3,7 +3,7 @@ SUMMARY = "Prebuilt bootlader images for Dragonboard 410c"
 LICENSE = "LICENSE.qcom"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4d087ee0965cb059f1b2f9429e166f64"
 
-SRC_URI = "https://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/17.09/dragonboard410c_bootloader_sd_linux-88.zip"
+SRC_URI = "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/dragonboard410c/linaro/rescue/17.09/dragonboard410c_bootloader_sd_linux-88.zip"
 SRC_URI[md5sum] = "e15da2a623442d66587aea506599fb69"
 SRC_URI[sha256sum] = "9885f915ebd4986432340cf1d03b8fd2bfdd97ad6a4a7466200fddbe41cdcf5c"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard410c_1036.1.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard410c_1036.1.bb
@@ -3,7 +3,7 @@ SUMMARY = "Prebuilt bootlader images for Dragonboard 410c"
 LICENSE = "LICENSE.qcom"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4d087ee0965cb059f1b2f9429e166f64"
 
-SRC_URI = "https://releases.linaro.org/96boards/dragonboard410c/qualcomm/firmware/linux-board-support-package-r${PV}.zip"
+SRC_URI = "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/dragonboard410c/qualcomm/firmware/linux-board-support-package-r${PV}.zip"
 SRC_URI[sha256sum] = "93070f58fa3aa6467baa881935c37c4da2df2a8af3248746931ce3d11a3a1200"
 
 BOOTBINARIES = "linux-board-support-package-r${PV}"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-dragonboard820c_01700.1.bb
@@ -3,7 +3,7 @@ SUMMARY = "Prebuilt bootlader images for Dragonboard 820c"
 LICENSE = "LICENSE.qcom"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4d087ee0965cb059f1b2f9429e166f64"
 
-SRC_URI = "https://releases.linaro.org/96boards/dragonboard820c/qualcomm/firmware/linux-board-support-package-r${PV}.zip"
+SRC_URI = "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/dragonboard820c/qualcomm/firmware/linux-board-support-package-r${PV}.zip"
 SRC_URI[sha256sum] = "6ee9c461b2b5dd2d3bd705bb5ea3f44b319ecb909b2772f305ce12439e089cd9"
 
 BOOTBINARIES = "linux-board-support-package-r${PV}"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
@@ -3,7 +3,7 @@ SUMMARY = "Prebuilt bootlader images for Qualcomm RB1"
 LICENSE = "LICENSE.qcom"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=cbbe399f2c983ad51768f4561587f000"
 
-SRC_URI = "https://releases.linaro.org/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"
+SRC_URI = "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"
 SRC_URI[sha256sum] = "c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d"
 
 BOOTBINARIES = "rb1-bootloader-emmc-linux-47528"


### PR DESCRIPTION
releases.linaro.org is down. Several of the firmware artifact used in meta-qcom are not accessible. Luckily there is a backup of these files available on CLO.