### PR TITLE
workflows: add missing summary_id output to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       build_id:
         required: true
         type: string
+    outputs:
+      summary_id:
+        description: "ID of the test summary artifact"
+        value: ${{ jobs.publish-test-summary.outputs.summary_id }}
 
 jobs:
   prepare-boot-jobs:


### PR DESCRIPTION
Reporting workflow in PR requires an id of the uploaded summary file. The ID is generated by test workflow, but until now it was not presented in the outputs. Because of that instead of downloading a single file, all attachments were downloaded in the publishing action. This causes the PR comment step to fail. This patch fixes the issue by adding an output to test workflow.