### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260131

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,12 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18"
+LINUX_VERSION ?= "6.18.7"
 
 PV = "${LINUX_VERSION}"
 
-# tag: qcom-6.18.y-20260128
-SRCREV ?= "cdc4617fae333fe78b4375c00f48f047a6129f81"
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
+
+# tag: qcom-6.18.y-20260131
+SRCREV ?= "31b0beba567c5770bbc9e568f8a54f926914122b"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260131

Changelog:
(tag: v6.18.7, trovalds-lts/linux-6.18.y) Linux 6.18.7 
FROMLIST: arm64: qcom: pd-mapper: Add QCS615 power domain mappings 
Revert "QCLINUX: Revert "arm64: dts: qcom: sm8750-mtp: Add WiFi and Bluetooth"" 
FROMLIST: arm64: dts: qcom: talos-evk: Add sound card support with DA7212 codec 
FROMLIST: arm64: dts: qcom: talos: Add GPR node, audio services, and MI2S1 TLMM pins