### PR TITLE
camx-dlkm: Update to the latest revision

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_git.bb
+++ b/recipes-multimedia/camx/camx-dlkm_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SRC_URI = "git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0"
 
 PV = "0.0+git"
-SRCREV = "ebf3a6a5c83d200eac437d90fdee44ee41889ae5"
+SRCREV = "3db4525b96d9d7730dedcae7ae50b9a89669d1cf"
 
 inherit module
 


### PR DESCRIPTION
This change includes the following updates:

- Fix CSID, CAMIF, and VFE header handling for QCS615 platforms.
- Add handling for component overwrite error on VFE bus.
- Ignore primary SOF timestamp address read for QCS615.
- Support RDI‑only context configuration on non‑EPOCH targets.
- Correct a conditional branch that was always evaluating false.
- Enable sysfs utility configuration flags for QCS615.
- Fix overflow in I²C write time‑delay variable.
- Correct DMA reset sequencing logic.
- Enable Talos camera support.