### PR TITLE
ci: append test plan filename to job name for uniqueness

### DIFF
--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -39,7 +39,9 @@ runs:
         for J in $JOBFILES
           do
               echo $J
-              NAME=$(echo "$J" | cut --delimiter "/" --field 3)
+              BASE_NAME=$(echo "$J" | cut --delimiter "/" --field 3)
+              TEST_PLAN=$(basename "$J" .yaml)
+              NAME="${BASE_NAME}-${TEST_PLAN}"
               echo $NAME
               F_TMP="${J#*/}"
               RESULT_NAME="${F_TMP//\//-}"


### PR DESCRIPTION
Job names collide when multiple test plans exist in the same directory.

Append the test plan filename (without extension) to the base directory name to ensure each test plan gets a unique name in the job matrix.

Signed-off-by: Anil Yadav [anilyada@qti.qualcomm.com](mailto:anilyada@qti.qualcomm.com)