### PR TITLE
fit-dtb-compatible: add additional compatible for IQ-X7181

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -6,7 +6,10 @@
 
 FIT_DTB_COMPATIBLE[apq8016-sbc] = "qcom,apq8016-sbc"
 FIT_DTB_COMPATIBLE[apq8096-db820c] = "qcom,apq8096-sbc"
-FIT_DTB_COMPATIBLE[hamoa-iot-evk] = "qcom,hamoa-evk"
+FIT_DTB_COMPATIBLE[hamoa-iot-evk] = " \
+                                      qcom,hamoa-evk \
+                                      qcom,hamoav2.1-evk \
+"
 FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
 FIT_DTB_COMPATIBLE[lemans-evk] = " \
                                    qcom,qcs9075-iot \


### PR DESCRIPTION
Add "qcom,hamoav2.1-evk" as an additional compatible string for hamoa-iot-evk.dtb to ensure correct DTB is selected for hamoav2.1-evk boards.