### PR TITLE
ci: add qcom-distro+linux-qcom-6.18 to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         distro:
           - name: poky-altcfg
           - name: qcom-distro
+          - name: qcom-distro+linux-qcom-6.18
     steps:
       - uses: actions/checkout@v4
         with:
@@ -146,6 +147,7 @@ jobs:
         distro:
           - name: poky-altcfg
           - name: qcom-distro
+          - name: qcom-distro+linux-qcom-6.18
     steps:
       - id: print-condition
         name: "Print condition"


### PR DESCRIPTION
Testing coverage is missing for the qcom-distro configuration with linux-qcom-6.18 kernel. Add this distro variant to both boot test and pre-merge test job matrices to ensure proper validation of the 6.18 kernel integration.

This enables automated testing of:
- Boot validation on qcom-distro+linux-qcom-6.18
- Pre-merge test execution on qcom-distro+linux-qcom-6.18

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>