### PR TITLE
qcs615-ride.conf: migrate EXTRA_IMAGEDEPS to QCOM_BOOT_FIRMWARE

### DIFF
--- a/conf/machine/include/qcom-qcs615.inc
+++ b/conf/machine/include/qcom-qcs615.inc
@@ -14,5 +14,3 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 MACHINE_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-additional \
 "
-
-EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qcs615"

--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -21,3 +21,5 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_CDT_FILE = "cdt_adp_air_sa6155p"
 QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs615-ride/ufs"
+
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs615"


### PR DESCRIPTION
Update machine configuration to use QCOM_BOOT_FIRMWARE to be aligned with KLM.