### PR TITLE
firmware-qcom-boot-iq-x7181: upgrade to 00006.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00004.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00004.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6dd565b0e481e32c416db05277143d52c4088683feb70c3a0c365f594bda9552"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00006.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00006.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "00213d5f0c6325aaa25dbb67834285ccdeee9e15c4f76e12c66cf37cf26aaafa"


### PR DESCRIPTION
Known changes:
    - Fixed fan non-working issue with EC enabled in UEFI
    - Support FIT dtb

External link:
https://softwarecenter.qualcomm.com/nexus/generic/software/chip/ubuntu_qualcomm_iot-spf-1-0/ubuntu-qualcomm-iot-spf-1-0_test_device_public/r1.0.r1_00006.0