### PR TITLE
Add systemd unit to mount `persist` partition

### DIFF
--- a/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
+++ b/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
@@ -1,0 +1,16 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+[Unit]
+Description=Mount persist partition at /var/lib/tee
+Before=local-fs.target
+
+[Mount]
+DirectoryMode=0755
+What=/dev/disk/by-partlabel/persist
+Where=/var/lib/tee
+Type=ext4
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-bsp/partition/mount-tee-partition_1.0.bb
+++ b/recipes-bsp/partition/mount-tee-partition_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Systemd unit to mount persist parition at /var/lib/tee"
+DESCRIPTION  = "Mount persist partition at /var/lib/tee to store \
+encryped data and support security functions"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
+
+SRC_URI = "file://var-lib-tee.mount"
+
+inherit allarch features_check systemd
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+S = "${UNPACKDIR}"
+
+do_compile[noexec] = "1"
+
+do_install() {
+    install -Dm 0644 ${UNPACKDIR}/var-lib-tee.mount \
+            ${D}${systemd_unitdir}/system/var-lib-tee.mount
+}
+
+PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE:${PN} = "var-lib-tee.mount"


### PR DESCRIPTION
Add a systemd .mount unit to mount `persist` partition at /var/lib/tee. 
This directory is used by QTEE to store encrypted data.