### PR TITLE
ci: actions/workflows: set concurrency only for pull requests

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -14,7 +14,7 @@ on:
 
 # Concurrency is used to prevent multiple workflows from running for the same PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
We should have separate builds for each merge, and only cancel PR build requests if they occur during an ongoing build.