### PR TITLE
ci: also include linux-qcom-6.18 into tests

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -10,6 +10,9 @@ inputs:
   gh_token:
     description: "Github token. It's required to download artifacts from the workflow"
     required: true
+  kernel:
+    description: "Extra strings for the kernel part of the build URL"
+    required: true
   prefix:
     description: "Prefix for the compressed file that is uploaded as workflow artifact"
     default: testjobs
@@ -67,7 +70,7 @@ runs:
           fi
           echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
           export BUILD_URL=""
-          export BUILD_URL_FILE="$GITHUB_WORKSPACE/build-url_${{ inputs.machine }}_${{ inputs.distro_name }}/build-url_${{ inputs.machine }}_${{ inputs.distro_name }}"
+          export BUILD_URL_FILE="$GITHUB_WORKSPACE/build-url_${{ inputs.machine }}_${{ inputs.distro_name }}${{ inputs.kernel }}/build-url_${{ inputs.machine }}_${{ inputs.distro_name }}${{ inputs.kernel }}"
           echo "${BUILD_URL_FILE}"
           if [ -f "$BUILD_URL_FILE" ]; then
               export BUILD_URL=$(cat "${BUILD_URL_FILE}")
@@ -79,7 +82,7 @@ runs:
           fi
           echo "BUILD_DOWNLOAD_URL=${BUILD_URL}/" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
-          echo "ROOTFS_URL=${BUILD_URL}/${{ inputs.distro_name }}/${{ inputs.machine }}/${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "ROOTFS_URL=${BUILD_URL}/${{ inputs.distro_name }}${{ inputs.kernel }}/${{ inputs.machine }}/${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
           if [ "${{ inputs.machine }}" = "qcom-armv8a" ]; then
               echo "ROOTFS_IMG_FILE=core-image-base-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
@@ -87,18 +90,18 @@ runs:
               echo "DEVICE_TYPE=dragonboard-410c" >> dragonboard-410c.ini
               echo "BOOT_IMG_FILE=boot-apq8016-sbc-qcom-armv8a.img" >> dragonboard-410c.ini
               cat dragonboard-410c.ini
-              lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${{ inputs.distro_name }}-${{ inputs.testplan }}" || true
+              lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
               cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-820c.ini
               echo "BOOT_IMG_FILE=boot-apq8096-db820c-qcom-armv8a.img" >> dragonboard-820c.ini
               echo "DEVICE_TYPE=dragonboard-820c" >> dragonboard-820c.ini
               cat dragonboard-820c.ini
-              lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${{ inputs.distro_name }}-${{ inputs.testplan }}" || true
+              lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
               echo "MACHINE=dragonboard" >> $GITHUB_ENV
           else
               echo "DEVICE_TYPE=${{ inputs.machine }}" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
               cat "${VARS_OUT_PATH}/gh-variables.ini"
-              lava-test-plans --dry-run --variables "${VARS_OUT_PATH}/gh-variables.ini" --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "${{ inputs.machine }}" --dry-run-path "${JOBS_OUT_PATH}/${{ inputs.machine }}-${{ inputs.distro_name }}-${{ inputs.testplan }}" || true
+              lava-test-plans --dry-run --variables "${VARS_OUT_PATH}/gh-variables.ini" --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "${{ inputs.machine }}" --dry-run-path "${JOBS_OUT_PATH}/${{ inputs.machine }}-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
               echo "MACHINE=${{ inputs.machine }}" >> $GITHUB_ENV
           fi
 
@@ -111,6 +114,6 @@ runs:
       - name: 'Upload test jobs'
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ inputs.prefix }}-${{ inputs.machine }}-${{ inputs.distro_name }}
+          name: ${{ inputs.prefix }}-${{ inputs.machine }}-${{ inputs.distro_name }}${{ inputs.kernel }}
           path: ${{ env.JOBS_OUT_PATH }}/**
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
         distro:
           - name: poky-altcfg
           - name: qcom-distro
+        kernel:
+          - ""
+          - +linux-qcom-6.18
+        exclude:
+          - distro: poky-altcfg
+            kernel: +linux-qcom-6.18
+          - machine: qcom-armv7a
+            kernel: +linux-qcom-6.18
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,6 +48,7 @@ jobs:
         with:
           machine: ${{ matrix.machine }}
           distro_name: ${{ matrix.distro.name }}
+          kernel: ${{ matrix.kernel }}
           build_id: ${{ inputs.build_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: boottest
@@ -146,6 +155,12 @@ jobs:
         distro:
           - name: poky-altcfg
           - name: qcom-distro
+        kernel:
+          - ""
+          - +linux-qcom-6.18
+        exclude:
+          - distro: poky-altcfg
+            kernel: +linux-qcom-6.18
     steps:
       - id: print-condition
         name: "Print condition"
@@ -163,6 +178,7 @@ jobs:
         with:
           machine: ${{ matrix.machine }}
           distro_name: ${{ matrix.distro.name }}
+          kernel: ${{ matrix.kernel }}
           build_id: ${{ inputs.build_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: premerge


### PR DESCRIPTION
Validate that there are no regressions with the LTS (6.18) branch of the Linux kernel recipe.