### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260207

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260131
-SRCREV ?= "31b0beba567c5770bbc9e568f8a54f926914122b"
+# tag: qcom-6.18.y-20260207
+SRCREV ?= "93be04f5fe1314eafb3293abc558e8ade4e8d2bb"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260207

Changelog:

FROMLIST: arm64: defconfig: Enable Lontium LT8713sx driver
FROMLIST: arm64: dts: qcom: monaco: add lt8713sx bridge with displayport
FROMLIST: drm/bridge: add support for lontium lt8713sx bridge driver
FROMLIST: dt-bindings: bridge: lt8713sx: Add bindings
FROMLIST: Revert "dt-bindings: bridge: lt8713sx: Add bindings"
FROMLIST: Revert "drm/bridge: add support for lontium lt8713sx bridge driver"
FROMLIST: Revert "defconfig: qcom: Enable lt8713sx bridge driver"
FROMLIST: Revert "arm64: dts: qcom: monaco-evk: add lt8713sx bridge for iq8"
QCLINUX: arm64: dts: qcom: add camx overlay for talos evk
QCLINUX: arm64: dts: qcom: Add camx overlay fixes for KLM
FROMLIST: soc: qcom: qmi: Print error codes in failure paths
FROMLIST: soc: qcom: pd-mapper: Fix element length in servreg_loc_pfr_req_ei
QCLINUX: arm64: dts: qcom: change pil camera memory map
WORKAROUND: arm64: dts: qcom: Remove WCN6855 PMU node to bypass pwrseq flow
FROMGIT: arm64: dts: qcom: lemans: add QCrypto node
FROMLIST: arm64: dts: qcom: talos: Add EL2 overlay
FROMLIST: arm64: dts: qcom: monaco: Add EL2 overlay
FROMLIST: arm64: dts: qcom: lemans: disable zap-shader for EL2 configuration
FROMGIT: wifi: ath11k: Fix failure to connect to a 6 GHz AP
QCLINUX: prune.config: Enable backlight config for Hamoa/Purwa
FROMGIT: arm64: dts: qcom: x1e80100: add TRNG node
FROMGIT: dt-bindings: crypto: qcom,prng: document x1e80100
FROMGIT: arm64: dts: qcom: monaco: add QCrypto node