### PR TITLE
sensors: switch to latest protobuf

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.0.7.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.0.7.bb
@@ -5,13 +5,13 @@ validate sensor services functionality through the Sensinghub Interface."
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom-2;md5=f33ba334514c4dfabc6ab7377babb377"
 
-PBT_BUILD_DATE = "260117"
+PBT_BUILD_DATE = "260209"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "766b31a4382524939ea6cbc9db23f2aebd94f2b1250b5d9a8114765652758770"
+SRC_URI[sha256sum] = "02a14811570b30464efb9d0dcdf709ce930bfc24bf95aa9ceedede66484abd61"
 
 S = "${UNPACKDIR}"
 
-DEPENDS = "glib-2.0 protobuf-camx sensinghub qmi-framework libdiag fastrpc"
+DEPENDS = "glib-2.0 protobuf sensinghub qmi-framework libdiag fastrpc"
 
 inherit systemd
 
@@ -33,12 +33,9 @@ do_install() {
     install -m 0755 ${S}/usr/bin/* ${D}${bindir}/
 
     # Install library
-    oe_libinstall -C ${S}/usr/lib -so libsnsutils ${D}${libdir}
-    oe_libinstall -C ${S}/usr/lib -so libsuidlookup ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsensinghubapiprop ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshQmiIDL ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshSession ${D}${libdir}
-    oe_libinstall -C ${S}/usr/lib -so libSensorTest ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsnsdiaglog ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libUSTANative ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libSEESalt ${D}${libdir}

--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_1.0.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_1.0.6.bb
@@ -4,11 +4,11 @@ HOMEPAGE = "https://github.com/qualcomm/sensinghub"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9701d0ef17353f1d05d7b74c8712ebbd"
 
-SRCREV = "5f07e63c010b4080e2a0bebdbed514eea9145b88"
+SRCREV = "c08dcfa05a39aaf7d9b7f3241f612d29a2df1073"
 
 SRC_URI = "git://github.com/qualcomm/sensinghub.git;protocol=https;branch=main;tag=v${PV}"
 
-DEPENDS = "protobuf-camx protobuf-camx-native"
+DEPENDS = "protobuf protobuf-native glib-2.0"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
Upgraded sensinghub from 1.0.4 to 1.0.5. Updated the code with new protobuf version and open-sourced utils code from qcom-sensors-binaries.