### PR TITLE
iris-video-dlkm: switch iris driver to new branch video.qclinux.main

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV = "0.0+git"
 
-SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.0.0"
-SRCREV  = "c70ab433d51dc5d12c5e7e1810e5c9c4b2661201"
+SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.main"
+SRCREV  = "0e0fe75fb1910e011358485b078ea207a5c5f3e7"
 
 inherit module
 


### PR DESCRIPTION
Switch the iris driver source from video.qclinux.0.0 to the
video.qclinux.main branch.

This migration is necessary for the following reasons:
- The new branch aligns with the codebase currently used by the
  Handset and Auto BUs.
- Upcoming QLI SoCs (Hamoa, Kaanapali, Pakala etc.) are already
  supported in this codebase.
- This change maintains status quo for existing platforms (Kodiak,
  Lemans, Monaco) while enabling the path for future SoCs.

To leverage enablement of those SOCs from other BUs (handset/Auto
segment), the branch is being switched.