### PR TITLE
linux-qcom-next: backport DT changes for talos-evk from qcom-next

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next/qcs615.inc
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615.inc
@@ -1,0 +1,22 @@
+# qcs615 DT/Driver patches
+SRC_URI:append = " \
+    file://qcs615/0001-dt-bindings-arm-qcom-talos-evk-Add-QCS615-Talos-EVK-.patch \
+    file://qcs615/0002-arm64-dts-qcom-talos-qcs615-ride-Fix-inconsistent-US.patch \
+    file://qcs615/0003-arm64-dts-qcom-talos-evk-Add-support-for-QCS615-talo.patch \
+    file://qcs615/0004-media-camss-csiphy-Make-CSIPHY-status-macro-cross-pl.patch \
+    file://qcs615/0005-media-qcom-camss-Add-support-for-regulator-init_load.patch \
+    file://qcs615/0006-media-qcom-camss-Do-not-enable-cpas-fast-ahb-clock-f.patch \
+    file://qcs615/0007-media-qcom-camss-csid-340-Fix-unused-variables.patch \
+    file://qcs615/0008-media-qcom-camss-vfe-Fix-out-of-bounds-access-in-vfe.patch \
+    file://qcs615/0009-media-qcom-camss-change-internals-of-endpoint-parsin.patch \
+    file://qcs615/0010-media-qcom-camss-use-a-handy-v4l2_async_nf_add_fwnod.patch \
+    file://qcs615/0011-media-dt-bindings-Add-qcom-sm6150-camss.patch \
+    file://qcs615/0012-media-qcom-camss-add-support-for-SM6150-camss.patch \
+    file://qcs615/0013-dt-bindings-i2c-qcom-cci-Document-sm6150-compatible.patch \
+    file://qcs615/0014-media-i2c-imx412-Assert-reset-GPIO-during-probe.patch \
+    file://qcs615/0015-media-i2c-imx412-Extend-the-power-on-waiting-time.patch \
+    file://qcs615/0016-arm64-dts-qcom-talos-Add-camss-node.patch \
+    file://qcs615/0017-arm64-dts-qcom-talos-Add-CCI-definitions.patch \
+    file://qcs615/0018-arm64-dts-qcom-talos-Add-camera-MCLK-pinctrl.patch \
+    file://qcs615/0019-arm64-dts-qcom-talos-evk-camera-Add-DT-overlay.patch \
+"

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0001-dt-bindings-arm-qcom-talos-evk-Add-QCS615-Talos-EVK-.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0001-dt-bindings-arm-qcom-talos-evk-Add-QCS615-Talos-EVK-.patch
@@ -1,0 +1,33 @@
+From 3c116481de2fca334c25294ab54d8f47b8552d36 Mon Sep 17 00:00:00 2001
+From: Sudarshan Shetty <tessolveupstream@gmail.com>
+Date: Wed, 14 Jan 2026 15:30:41 +0530
+Subject: [PATCH 01/19] dt-bindings: arm: qcom: talos-evk: Add QCS615 Talos EVK
+ SMARC platform
+
+Add binding support for the Qualcomm Technologies, Inc. Talos EVK
+SMARC platform based on the QCS615 SoC.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260114100043.1310164-2-tessolveupstream@gmail.com]
+Link: https://lore.kernel.org/all/20260114100043.1310164-2-tessolveupstream@gmail.com/
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Sudarshan Shetty <tessolveupstream@gmail.com>
+Signed-off-by: Jie Gan <jie.gan@oss.qualcomm.com>
+---
+ Documentation/devicetree/bindings/arm/qcom.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/arm/qcom.yaml b/Documentation/devicetree/bindings/arm/qcom.yaml
+index 41a6492bdf3b..9b6a5ef90bad 100644
+--- a/Documentation/devicetree/bindings/arm/qcom.yaml
++++ b/Documentation/devicetree/bindings/arm/qcom.yaml
+@@ -881,6 +881,7 @@ properties:
+       - items:
+           - enum:
+               - qcom,qcs615-ride
++              - qcom,talos-evk
+           - const: qcom,qcs615
+           - const: qcom,sm6150
+ 
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0002-arm64-dts-qcom-talos-qcs615-ride-Fix-inconsistent-US.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0002-arm64-dts-qcom-talos-qcs615-ride-Fix-inconsistent-US.patch
@@ -1,0 +1,61 @@
+From f7668bbcbe8a8fe3338a4f27e54018a8a5401ad7 Mon Sep 17 00:00:00 2001
+From: Sudarshan Shetty <tessolveupstream@gmail.com>
+Date: Wed, 14 Jan 2026 15:30:42 +0530
+Subject: [PATCH 02/19] arm64: dts: qcom: talos/qcs615-ride: Fix inconsistent
+ USB PHY node naming
+
+The USB PHY nodes has inconsistent labels as 'usb_1_hspy'
+and 'usb_hsphy_2' across talos.dtsi and qcs615-ride.dts.
+This patch renames them to follow a consistent naming
+scheme.
+
+No functional changes, only label renaming.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260114100043.1310164-3-tessolveupstream@gmail.com]
+Link: https://lore.kernel.org/all/20260114100043.1310164-3-tessolveupstream@gmail.com/
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Signed-off-by: Sudarshan Shetty <tessolveupstream@gmail.com>
+Signed-off-by: Jie Gan <jie.gan@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/qcs615-ride.dts | 2 +-
+ arch/arm64/boot/dts/qcom/talos.dtsi      | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs615-ride.dts b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+index f061ae156e0c..e28dabac0a7d 100644
+--- a/arch/arm64/boot/dts/qcom/qcs615-ride.dts
++++ b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+@@ -647,7 +647,7 @@ bluetooth {
+ 	};
+ };
+ 
+-&usb_1_hsphy {
++&usb_hsphy_1 {
+ 	vdd-supply = <&vreg_l5a>;
+ 	vdda-pll-supply = <&vreg_l12a>;
+ 	vdda-phy-dpdm-supply = <&vreg_l13a>;
+diff --git a/arch/arm64/boot/dts/qcom/talos.dtsi b/arch/arm64/boot/dts/qcom/talos.dtsi
+index bad8dbb68d1d..008dcced46a9 100644
+--- a/arch/arm64/boot/dts/qcom/talos.dtsi
++++ b/arch/arm64/boot/dts/qcom/talos.dtsi
+@@ -4548,7 +4548,7 @@ osm_l3: interconnect@18321000 {
+ 			#interconnect-cells = <1>;
+ 		};
+ 
+-		usb_1_hsphy: phy@88e2000 {
++		usb_hsphy_1: phy@88e2000 {
+ 			compatible = "qcom,qcs615-qusb2-phy";
+ 			reg = <0x0 0x88e2000 0x0 0x180>;
+ 
+@@ -4682,7 +4682,7 @@ usb_1_dwc3: usb@a600000 {
+ 				iommus = <&apps_smmu 0x140 0x0>;
+ 				interrupts = <GIC_SPI 133 IRQ_TYPE_LEVEL_HIGH>;
+ 
+-				phys = <&usb_1_hsphy>, <&usb_qmpphy>;
++				phys = <&usb_hsphy_1>, <&usb_qmpphy>;
+ 				phy-names = "usb2-phy", "usb3-phy";
+ 
+ 				snps,dis-u1-entry-quirk;
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0003-arm64-dts-qcom-talos-evk-Add-support-for-QCS615-talo.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0003-arm64-dts-qcom-talos-evk-Add-support-for-QCS615-talo.patch
@@ -1,0 +1,969 @@
+From 2a59557aebfab5be58b942ddc031bbdf0f2c0237 Mon Sep 17 00:00:00 2001
+From: Sudarshan Shetty <tessolveupstream@gmail.com>
+Date: Wed, 14 Jan 2026 15:30:43 +0530
+Subject: [PATCH 03/19] arm64: dts: qcom: talos-evk: Add support for QCS615
+ talos evk board
+
+Add the device tree for the QCS615-based Talos EVK platform. The
+platform is composed of a System-on-Module following the SMARC
+standard, and a Carrier Board.
+
+The Carrier Board supports several display configurations, HDMI and
+LVDS. Both configurations use the same base hardware, with the display
+selection controlled by a DIP switch.
+
+Use a DTBO file, talos-evk-lvds-auo,g133han01.dtso, which defines an
+overlay that disables HDMI and adds LVDS. The DTs file talos-evk
+can describe the HDMI display configurations.
+
+The initial device tree includes support for:
+- CPU and memory
+- UART
+- GPIOs
+- Regulators
+- PMIC
+- Early console
+- AT24MAC602 EEPROM
+- MCP2515 SPI to CAN
+- ADV7535 DSI-to-HDMI bridge
+- DisplayPort interface
+- SN65DSI84ZXHR DSI-to-LVDS bridge
+- Wi-Fi/BT
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260114100043.1310164-4-tessolveupstream@gmail.com]
+Link: https://lore.kernel.org/all/20260114100043.1310164-4-tessolveupstream@gmail.com/
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Signed-off-by: Sudarshan Shetty <tessolveupstream@gmail.com>
+Signed-off-by: Jie Gan <jie.gan@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/Makefile             |   4 +
+ .../qcom/talos-evk-lvds-auo,g133han01.dtso    | 131 ++++
+ arch/arm64/boot/dts/qcom/talos-evk-som.dtsi   | 616 ++++++++++++++++++
+ arch/arm64/boot/dts/qcom/talos-evk.dts        | 139 ++++
+ 4 files changed, 890 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/qcom/talos-evk-lvds-auo,g133han01.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/talos-evk-som.dtsi
+ create mode 100644 arch/arm64/boot/dts/qcom/talos-evk.dts
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index 5cd2a67c6fd6..76ab65939023 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -378,6 +378,10 @@ dtb-$(CONFIG_ARCH_QCOM)	+= sm8650-mtp.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8650-qrd.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8750-mtp.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8750-qrd.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk.dtb
++talos-evk-lvds-auo,g133han01-dtbs	:= \
++	talos-evk.dtb talos-evk-lvds-auo,g133han01.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-lvds-auo,g133han01.dtb
+ x1e001de-devkit-el2-dtbs	:= x1e001de-devkit.dtb x1-el2.dtbo
+ dtb-$(CONFIG_ARCH_QCOM)	+= x1e001de-devkit.dtb x1e001de-devkit-el2.dtb
+ x1e78100-lenovo-thinkpad-t14s-el2-dtbs	:= x1e78100-lenovo-thinkpad-t14s.dtb x1-el2.dtbo
+diff --git a/arch/arm64/boot/dts/qcom/talos-evk-lvds-auo,g133han01.dtso b/arch/arm64/boot/dts/qcom/talos-evk-lvds-auo,g133han01.dtso
+new file mode 100644
+index 000000000000..fc2296e346b8
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/talos-evk-lvds-auo,g133han01.dtso
+@@ -0,0 +1,131 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++
++&{/} {
++	backlight: backlight {
++		compatible = "gpio-backlight";
++		gpios = <&tlmm 59 GPIO_ACTIVE_HIGH>,
++			<&tlmm 115 GPIO_ACTIVE_HIGH>;
++		default-on;
++	};
++
++	panel-lvds {
++		compatible = "auo,g133han01";
++		power-supply = <&vreg_v3p3>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			/* LVDS A (Odd pixels) */
++			port@0 {
++				reg = <0>;
++				dual-lvds-odd-pixels;
++
++				lvds_panel_out_a: endpoint {
++					remote-endpoint = <&sn65dsi84_out_a>;
++				};
++			};
++
++			/* LVDS B (Even pixels) */
++			port@1 {
++				reg = <1>;
++				dual-lvds-even-pixels;
++
++				lvds_panel_out_b: endpoint {
++					remote-endpoint = <&sn65dsi84_out_b>;
++				};
++			};
++		};
++	};
++
++	vreg_v3p3: regulator-v3p3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++};
++
++&hdmi_connector {
++	status = "disabled";
++};
++
++&i2c1 {
++	clock-frequency = <400000>;
++
++	status = "okay";
++
++	hdmi_bridge: bridge@3d {
++		status = "disabled";
++	};
++
++	lvds_bridge: bridge@2c {
++		compatible = "ti,sn65dsi84";
++		reg = <0x2c>;
++		enable-gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				sn65dsi84_in: endpoint {
++					data-lanes = <1 2 3 4>;
++					remote-endpoint = <&mdss_dsi0_out>;
++				};
++			};
++
++			port@2 {
++				reg = <2>;
++
++				sn65dsi84_out_a: endpoint {
++					data-lanes = <1 2 3 4>;
++					remote-endpoint = <&lvds_panel_out_a>;
++				};
++			};
++
++			port@3 {
++				reg = <3>;
++
++				sn65dsi84_out_b: endpoint {
++					data-lanes = <1 2 3 4>;
++					remote-endpoint = <&lvds_panel_out_b>;
++				};
++			};
++		};
++	};
++};
++
++&mdss_dsi0 {
++	vdda-supply = <&vreg_l11a>;
++
++	status = "okay";
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&sn65dsi84_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&tlmm {
++	lcd_bklt_en: lcd-bklt-en-state {
++		pins = "gpio115";
++		function = "gpio";
++		bias-disable;
++	};
++
++	lcd_bklt_pwm: lcd-bklt-pwm-state {
++		pins = "gpio59";
++		function = "gpio";
++		bias-disable;
++	};
++};
+diff --git a/arch/arm64/boot/dts/qcom/talos-evk-som.dtsi b/arch/arm64/boot/dts/qcom/talos-evk-som.dtsi
+new file mode 100644
+index 000000000000..e63f88da8ff6
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/talos-evk-som.dtsi
+@@ -0,0 +1,616 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
++#include "talos.dtsi"
++#include "pm8150.dtsi"
++/ {
++	aliases {
++		mmc0 = &sdhc_1;
++		serial0 = &uart0;
++		serial1 = &uart7;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	clocks {
++		can_osc: can-oscillator {
++			compatible = "fixed-clock";
++			clock-frequency = <20000000>;
++			#clock-cells = <0>;
++		};
++
++		sleep_clk: sleep-clk {
++			compatible = "fixed-clock";
++			clock-frequency = <32764>;
++			#clock-cells = <0>;
++		};
++
++		xo_board_clk: xo-board-clk {
++			compatible = "fixed-clock";
++			clock-frequency = <38400000>;
++			#clock-cells = <0>;
++		};
++	};
++
++	regulator-usb2-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "USB2_VBUS";
++		gpio = <&pm8150_gpios 10 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&usb2_en>;
++		pinctrl-names = "default";
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	vreg_conn_1p8: regulator-conn-1p8 {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg_conn_1p8";
++		startup-delay-us = <4000>;
++		enable-active-high;
++		gpio = <&pm8150_gpios 1 GPIO_ACTIVE_HIGH>;
++	};
++
++	vreg_conn_pa: regulator-conn-pa {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg_conn_pa";
++		startup-delay-us = <4000>;
++		enable-active-high;
++		gpio = <&pm8150_gpios 6 GPIO_ACTIVE_HIGH>;
++	};
++
++	vreg_v3p3_can: regulator-v3p3-can {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg-v3p3-can";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vreg_v5p0_can: regulator-v5p0-can {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg-v5p0-can";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	wcn6855-pmu {
++		compatible = "qcom,wcn6855-pmu";
++
++		pinctrl-0 = <&bt_en_state>, <&wlan_en_state>;
++		pinctrl-names = "default";
++
++		bt-enable-gpios = <&tlmm 85 GPIO_ACTIVE_HIGH>;
++		wlan-enable-gpios = <&tlmm 84 GPIO_ACTIVE_HIGH>;
++
++		vddio-supply = <&vreg_conn_pa>;
++		vddaon-supply = <&vreg_s5a>;
++		vddpmu-supply = <&vreg_conn_1p8>;
++		vddpmumx-supply = <&vreg_conn_1p8>;
++		vddpmucx-supply = <&vreg_conn_pa>;
++		vddrfa0p95-supply = <&vreg_s5a>;
++		vddrfa1p3-supply = <&vreg_s6a>;
++		vddrfa1p9-supply = <&vreg_l15a>;
++		vddpcie1p3-supply = <&vreg_s6a>;
++		vddpcie1p9-supply = <&vreg_l15a>;
++
++		regulators {
++			vreg_pmu_rfa_cmn: ldo0 {
++				regulator-name = "vreg_pmu_rfa_cmn";
++			};
++
++			vreg_pmu_aon_0p59: ldo1 {
++				regulator-name = "vreg_pmu_aon_0p59";
++			};
++
++			vreg_pmu_wlcx_0p8: ldo2 {
++				regulator-name = "vreg_pmu_wlcx_0p8";
++			};
++
++			vreg_pmu_wlmx_0p85: ldo3 {
++				regulator-name = "vreg_pmu_wlmx_0p85";
++			};
++
++			vreg_pmu_btcmx_0p85: ldo4 {
++				regulator-name = "vreg_pmu_btcmx_0p85";
++			};
++
++			vreg_pmu_rfa_0p8: ldo5 {
++				regulator-name = "vreg_pmu_rfa_0p8";
++			};
++
++			vreg_pmu_rfa_1p2: ldo6 {
++				regulator-name = "vreg_pmu_rfa_1p2";
++			};
++
++			vreg_pmu_rfa_1p7: ldo7 {
++				regulator-name = "vreg_pmu_rfa_1p7";
++			};
++
++			vreg_pmu_pcie_0p9: ldo8 {
++				regulator-name = "vreg_pmu_pcie_0p9";
++			};
++
++			vreg_pmu_pcie_1p8: ldo9 {
++				regulator-name = "vreg_pmu_pcie_1p8";
++			};
++		};
++	};
++
++	wifi_1p8v: regulator-wifi-1p8v {
++		compatible = "regulator-fixed";
++		regulator-name = "wifi_1p8v";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		gpio = <&tlmm 91 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		pinctrl-0 = <&wifi_reg_en_pins_state>;
++		pinctrl-names = "default";
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	wifi_3p85v: regulator-wifi-3p85v {
++		compatible = "regulator-fixed";
++		regulator-name = "wifi_3p85v";
++		regulator-min-microvolt = <3850000>;
++		regulator-max-microvolt = <3850000>;
++		gpio = <&tlmm 91 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		pinctrl-0 = <&wifi_reg_en_pins_state>;
++		pinctrl-names = "default";
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
++&apps_rsc {
++	regulators-0 {
++		compatible = "qcom,pm8150-rpmh-regulators";
++		qcom,pmic-id = "a";
++
++		vreg_s3a: smps3 {
++			regulator-name = "vreg_s3a";
++			regulator-min-microvolt = <600000>;
++			regulator-max-microvolt = <650000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s4a: smps4 {
++			regulator-name = "vreg_s4a";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1829000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s5a: smps5 {
++			regulator-name = "vreg_s5a";
++			regulator-min-microvolt = <1896000>;
++			regulator-max-microvolt = <2040000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s6a: smps6 {
++			regulator-name = "vreg_s6a";
++			regulator-min-microvolt = <1304000>;
++			regulator-max-microvolt = <1404000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1a: ldo1 {
++			regulator-name = "vreg_l1a";
++			regulator-min-microvolt = <488000>;
++			regulator-max-microvolt = <852000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2a: ldo2 {
++			regulator-name = "vreg_l2a";
++			regulator-min-microvolt = <1650000>;
++			regulator-max-microvolt = <3100000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3a: ldo3 {
++			regulator-name = "vreg_l3a";
++			regulator-min-microvolt = <1000000>;
++			regulator-max-microvolt = <1248000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l5a: ldo5 {
++			regulator-name = "vreg_l5a";
++			regulator-min-microvolt = <875000>;
++			regulator-max-microvolt = <975000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l7a: ldo7 {
++			regulator-name = "vreg_l7a";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1900000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l8a: ldo8 {
++			regulator-name = "vreg_l8a";
++			regulator-min-microvolt = <1150000>;
++			regulator-max-microvolt = <1350000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l10a: ldo10 {
++			regulator-name = "vreg_l10a";
++			regulator-min-microvolt = <2950000>;
++			regulator-max-microvolt = <3312000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l11a: ldo11 {
++			regulator-name = "vreg_l11a";
++			regulator-min-microvolt = <1232000>;
++			regulator-max-microvolt = <1260000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l12a: ldo12 {
++			regulator-name = "vreg_l12a";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1890000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l13a: ldo13 {
++			regulator-name = "vreg_l13a";
++			regulator-min-microvolt = <3000000>;
++			regulator-max-microvolt = <3230000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l15a: ldo15 {
++			regulator-name = "vreg_l15a";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1904000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l16a: ldo16 {
++			regulator-name = "vreg_l16a";
++			regulator-min-microvolt = <3000000>;
++			regulator-max-microvolt = <3312000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l17a: ldo17 {
++			regulator-name = "vreg_l17a";
++			regulator-min-microvolt = <2950000>;
++			regulator-max-microvolt = <3312000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++};
++
++&gpi_dma0 {
++	status = "okay";
++};
++
++&gpi_dma1 {
++	status = "okay";
++};
++
++&i2c5 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	eeprom@57 {
++		compatible = "atmel,24c02";
++		reg = <0x57>;
++		pagesize = <16>;
++	};
++
++	eeprom@5f {
++		compatible = "atmel,24mac602";
++		reg = <0x5f>;
++		pagesize = <16>;
++	};
++};
++
++&mdss {
++	status = "okay";
++};
++
++&mdss_dp0 {
++	status = "okay";
++};
++
++&mdss_dp0_out {
++	link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000>;
++	remote-endpoint = <&dp0_connector_in>;
++};
++
++&mdss_dsi0 {
++	vdda-supply = <&vreg_l11a>;
++	status = "okay";
++};
++
++&mdss_dsi0_phy {
++	vcca-supply = <&vreg_l5a>;
++	status = "okay";
++};
++
++&pcie {
++	perst-gpios = <&tlmm 89 GPIO_ACTIVE_LOW>;
++	wake-gpios = <&tlmm 100 GPIO_ACTIVE_HIGH>;
++
++	pinctrl-0 = <&pcie_default_state>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&pcie_phy {
++	vdda-phy-supply = <&vreg_l5a>;
++	vdda-pll-supply = <&vreg_l12a>;
++
++	status = "okay";
++};
++
++&pcie_port0 {
++	wifi@0 {
++		compatible = "pci17cb,1103";
++		reg = <0x10000 0x0 0x0 0x0 0x0>;
++
++		qcom,calibration-variant = "QC_QCS615_Ride";
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p7>;
++		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
++		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
++	};
++};
++
++&pm8150_gpios {
++	usb2_en: usb2-en-state {
++		pins = "gpio10";
++		function = "normal";
++		output-enable;
++		power-source = <0>;
++	};
++};
++
++&qupv3_id_0 {
++	status = "okay";
++};
++
++&qupv3_id_1 {
++	status = "okay";
++};
++
++&remoteproc_adsp {
++	firmware-name = "qcom/qcs615/adsp.mbn";
++
++	status = "okay";
++};
++
++&remoteproc_cdsp {
++	firmware-name = "qcom/qcs615/cdsp.mbn";
++
++	status = "okay";
++};
++
++&sdhc_1 {
++	pinctrl-0 = <&sdc1_state_on>;
++	pinctrl-1 = <&sdc1_state_off>;
++	pinctrl-names = "default", "sleep";
++
++	bus-width = <8>;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	vmmc-supply = <&vreg_l17a>;
++	vqmmc-supply = <&vreg_s4a>;
++
++	non-removable;
++	no-sd;
++	no-sdio;
++
++	status = "okay";
++};
++
++&spi6 {
++	status = "okay";
++
++	can@0 {
++		compatible = "microchip,mcp2515";
++		reg = <0>;
++		clocks = <&can_osc>;
++		interrupts-extended = <&tlmm 87 IRQ_TYPE_LEVEL_LOW>;
++		spi-max-frequency = <10000000>;
++		vdd-supply = <&vreg_v3p3_can>;
++		xceiver-supply = <&vreg_v5p0_can>;
++	};
++};
++
++&tlmm {
++	bt_en_state: bt-en-state {
++		pins = "gpio85";
++		function = "gpio";
++		bias-pull-down;
++	};
++
++	pcie_default_state: pcie-default-state {
++		clkreq-pins {
++			pins = "gpio90";
++			function = "pcie_clk_req";
++			drive-strength = <2>;
++			bias-pull-up;
++		};
++
++		perst-pins {
++			pins = "gpio89";
++			function = "gpio";
++			drive-strength = <2>;
++			bias-disable;
++		};
++
++		wake-pins {
++			pins = "gpio100";
++			function = "gpio";
++			drive-strength = <2>;
++			bias-pull-up;
++		};
++	};
++
++	wifi_reg_en_pins_state: wifi-reg-en-pins-state {
++		pins = "gpio91";
++		function = "gpio";
++		drive-strength = <8>;
++		output-high;
++		bias-pull-up;
++	};
++
++	wlan_en_state: wlan-en-state {
++		pins = "gpio84";
++		function = "gpio";
++		drive-strength = <16>;
++		bias-pull-down;
++		output-low;
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&uart7 {
++	status = "okay";
++
++	bluetooth {
++		compatible = "qcom,wcn6855-bt";
++		firmware-name = "QCA6698/hpnv21", "QCA6698/hpbtfw21.tlv";
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddbtcmx-supply = <&vreg_pmu_btcmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p7>;
++	};
++};
++
++&usb_1 {
++	status = "okay";
++};
++
++&usb_1_dwc3 {
++	dr_mode = "host";
++};
++
++&usb_hsphy_1 {
++	vdd-supply = <&vreg_l5a>;
++	vdda-pll-supply = <&vreg_l12a>;
++	vdda-phy-dpdm-supply = <&vreg_l13a>;
++
++	status = "okay";
++};
++
++&usb_2 {
++	status = "okay";
++};
++
++&usb_2_dwc3 {
++	dr_mode = "host";
++};
++
++&usb_hsphy_2 {
++	vdd-supply = <&vreg_l5a>;
++	vdda-pll-supply = <&vreg_l12a>;
++	vdda-phy-dpdm-supply = <&vreg_l13a>;
++
++	status = "okay";
++};
++
++&usb_qmpphy {
++	vdda-phy-supply = <&vreg_l5a>;
++	vdda-pll-supply = <&vreg_l12a>;
++
++	status = "okay";
++};
++
++&usb_qmpphy_2 {
++	vdda-phy-supply = <&vreg_l11a>;
++	vdda-pll-supply = <&vreg_l5a>;
++
++	status = "okay";
++};
++
++&ufs_mem_hc {
++	reset-gpios = <&tlmm 123 GPIO_ACTIVE_LOW>;
++	vcc-supply = <&vreg_l17a>;
++	vcc-max-microamp = <600000>;
++	vccq2-supply = <&vreg_s4a>;
++	vccq2-max-microamp = <600000>;
++
++	status = "okay";
++};
++
++&ufs_mem_phy {
++	vdda-phy-supply = <&vreg_l5a>;
++	vdda-pll-supply = <&vreg_l12a>;
++
++	status = "okay";
++};
++
++&venus {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/qcom/talos-evk.dts b/arch/arm64/boot/dts/qcom/talos-evk.dts
+new file mode 100644
+index 000000000000..af100e22beee
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/talos-evk.dts
+@@ -0,0 +1,139 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++/dts-v1/;
++
++#include "talos-evk-som.dtsi"
++
++/ {
++	model = "Qualcomm QCS615 IQ 615 EVK";
++	compatible = "qcom,talos-evk", "qcom,qcs615", "qcom,sm6150";
++	chassis-type = "embedded";
++
++	aliases {
++		mmc1 = &sdhc_2;
++	};
++
++	dp0-connector {
++		compatible = "dp-connector";
++		label = "DP0";
++		type = "full-size";
++
++		hpd-gpios = <&tlmm 104 GPIO_ACTIVE_HIGH>;
++
++		port {
++			dp0_connector_in: endpoint {
++				remote-endpoint = <&mdss_dp0_out>;
++			};
++		};
++	};
++
++	hdmi_connector: hdmi-out {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_out: endpoint {
++			remote-endpoint = <&adv7535_out>;
++			};
++		};
++	};
++
++	vreg_v1p8_out: regulator-v1p8-out {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg-v1p8-out";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vreg_v5p0_out>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vreg_v3p3_out: regulator-v3p3-out {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg-v3p3-out";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vreg_v5p0_out>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vreg_v5p0_out: regulator-v5p0-out {
++		compatible = "regulator-fixed";
++		regulator-name = "vreg-v5p0-out";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		regulator-always-on;
++		/* Powered by system 20V rail (USBC_VBUS_IN) */
++	};
++};
++
++&i2c1 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	hdmi_bridge: bridge@3d {
++		compatible = "adi,adv7535";
++		reg = <0x3d>;
++		avdd-supply = <&vreg_v1p8_out>;
++		dvdd-supply = <&vreg_v1p8_out>;
++		pvdd-supply = <&vreg_v1p8_out>;
++		a2vdd-supply = <&vreg_v1p8_out>;
++		v3p3-supply = <&vreg_v3p3_out>;
++		interrupts-extended = <&tlmm 26 IRQ_TYPE_LEVEL_LOW>;
++		adi,dsi-lanes = <4>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				adv7535_in: endpoint {
++					remote-endpoint = <&mdss_dsi0_out>;
++				};
++			};
++
++			port@1 {
++				reg = <1>;
++
++				adv7535_out: endpoint {
++					remote-endpoint = <&hdmi_con_out>;
++				};
++			};
++		};
++	};
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&adv7535_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&pon_pwrkey {
++	status = "okay";
++};
++
++&pon_resin {
++	linux,code = <KEY_VOLUMEDOWN>;
++
++	status = "okay";
++};
++
++&sdhc_2 {
++	pinctrl-0 = <&sdc2_state_on>;
++	pinctrl-1 = <&sdc2_state_off>;
++	pinctrl-names = "default", "sleep";
++
++	bus-width = <4>;
++	cd-gpios = <&tlmm 99 GPIO_ACTIVE_LOW>;
++
++	vmmc-supply = <&vreg_l10a>;
++	vqmmc-supply = <&vreg_s4a>;
++
++	status = "okay";
++};
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0004-media-camss-csiphy-Make-CSIPHY-status-macro-cross-pl.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0004-media-camss-csiphy-Make-CSIPHY-status-macro-cross-pl.patch
@@ -1,0 +1,86 @@
+From e132999399cd60093fdcb1091ffc0aaa9ffd5f01 Mon Sep 17 00:00:00 2001
+From: Hangxiang Ma <hangxiang.ma@oss.qualcomm.com>
+Date: Mon, 12 Jan 2026 00:11:09 -0800
+Subject: [PATCH] media: camss: csiphy: Make CSIPHY status macro cross-platform
+
+The current value of '0xb0' that represents the offset to the status
+registers within the common registers of the CSIPHY has been changed on
+the newer SOCs and it requires generalizing the macro using a new
+variable 'common_status_offset'. This variable is initialized in the
+csiphy_init() function.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260112-camss-extended-csiphy-macro-v2-1-ee7342f2aaf5@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260112-camss-extended-csiphy-macro-v2-1-ee7342f2aaf5@oss.qualcomm.com/
+Signed-off-by: Hangxiang Ma <hangxiang.ma@oss.qualcomm.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+ .../qcom/camss/camss-csiphy-3ph-1-0.c         | 19 +++++++++++++------
+ .../media/platform/qcom/camss/camss-csiphy.h  |  1 +
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c b/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
+index 619abbf60781..d70d4f611798 100644
+--- a/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
++++ b/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
+@@ -46,7 +46,8 @@
+ #define CSIPHY_3PH_CMN_CSI_COMMON_CTRL5_CLK_ENABLE	BIT(7)
+ #define CSIPHY_3PH_CMN_CSI_COMMON_CTRL6_COMMON_PWRDN_B	BIT(0)
+ #define CSIPHY_3PH_CMN_CSI_COMMON_CTRL6_SHOW_REV_ID	BIT(1)
+-#define CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(offset, n)	((offset) + 0xb0 + 0x4 * (n))
++#define CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(offset, common_status_offset, n) \
++	((offset) + (common_status_offset) + 0x4 * (n))
+ 
+ #define CSIPHY_DEFAULT_PARAMS		0
+ #define CSIPHY_LANE_ENABLE		1
+@@ -810,13 +811,17 @@ static void csiphy_hw_version_read(struct csiphy_device *csiphy,
+ 	       CSIPHY_3PH_CMN_CSI_COMMON_CTRLn(regs->offset, 6));
+ 
+ 	hw_version = readl_relaxed(csiphy->base +
+-				   CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset, 12));
++		CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset,
++						  regs->common_status_offset, 12));
+ 	hw_version |= readl_relaxed(csiphy->base +
+-				   CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset, 13)) << 8;
++		CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset,
++						  regs->common_status_offset, 13)) << 8;
+ 	hw_version |= readl_relaxed(csiphy->base +
+-				   CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset, 14)) << 16;
++		CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset,
++						  regs->common_status_offset, 14)) << 16;
+ 	hw_version |= readl_relaxed(csiphy->base +
+-				   CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset, 15)) << 24;
++		CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset,
++						  regs->common_status_offset, 15)) << 24;
+ 
+ 	dev_dbg(dev, "CSIPHY 3PH HW Version = 0x%08x\n", hw_version);
+ }
+@@ -845,7 +850,8 @@ static irqreturn_t csiphy_isr(int irq, void *dev)
+ 	for (i = 0; i < 11; i++) {
+ 		int c = i + 22;
+ 		u8 val = readl_relaxed(csiphy->base +
+-				       CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset, i));
++			CSIPHY_3PH_CMN_CSI_COMMON_STATUSn(regs->offset,
++							  regs->common_status_offset, i));
+ 
+ 		writel_relaxed(val, csiphy->base +
+ 			       CSIPHY_3PH_CMN_CSI_COMMON_CTRLn(regs->offset, c));
+@@ -1086,6 +1092,7 @@ static int csiphy_init(struct csiphy_device *csiphy)
+ 
+ 	csiphy->regs = regs;
+ 	regs->offset = 0x800;
++	regs->common_status_offset = 0xb0;
+ 
+ 	switch (csiphy->camss->res->version) {
+ 	case CAMSS_845:
+diff --git a/drivers/media/platform/qcom/camss/camss-csiphy.h b/drivers/media/platform/qcom/camss/camss-csiphy.h
+index 895f80003c44..2d5054819df7 100644
+--- a/drivers/media/platform/qcom/camss/camss-csiphy.h
++++ b/drivers/media/platform/qcom/camss/camss-csiphy.h
+@@ -90,6 +90,7 @@ struct csiphy_device_regs {
+ 	const struct csiphy_lane_regs *lane_regs;
+ 	int lane_array_size;
+ 	u32 offset;
++	u32 common_status_offset;
+ };
+ 
+ struct csiphy_device {

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0005-media-qcom-camss-Add-support-for-regulator-init_load.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0005-media-qcom-camss-Add-support-for-regulator-init_load.patch
@@ -1,0 +1,915 @@
+From a59b05ae3fd95836a507f7151af690825ba887cd Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Fri, 14 Nov 2025 16:26:49 +0800
+Subject: [PATCH] media: qcom: camss: Add support for regulator init_load_uA in
+ CSIPHY
+
+Some Qualcomm regulators are configured with initial mode as
+HPM (High Power Mode), which may lead to higher power consumption.
+To reduce power usage, it's preferable to set the initial mode
+to LPM (Low Power Mode).
+
+To ensure the regulator can switch from LPM to HPM when needed,
+this patch adds current load configuration for CAMSS CSIPHY.
+This allows the regulator framework to scale the mode dynamically
+based on the load requirement.
+
+The current default value for current is uninitialized or random.
+To address this, initial current values are added for the
+following platforms:
+MSM8916, MSM8939, MSM8953, MSM8996, QCM2290, SDM670, SM8250, SC7280,
+SM8550, SM8650, QCS8300, SA8775P and X1E80100.
+
+For SDM660, SDM845, SC8280XP the value is set to 0,
+indicating that no default current value is configured,
+the other values are derived from the power grid.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251114082649.4240-1-wenmeng.liu@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20251114082649.4240-1-wenmeng.liu@oss.qualcomm.com/
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ .../media/platform/qcom/camss/camss-csid.c    |  18 +-
+ .../media/platform/qcom/camss/camss-csiphy.c  |  19 +-
+ drivers/media/platform/qcom/camss/camss.c     | 328 ++++++++++++++----
+ drivers/media/platform/qcom/camss/camss.h     |   2 +-
+ 4 files changed, 265 insertions(+), 102 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss-csid.c b/drivers/media/platform/qcom/camss/camss-csid.c
+index 5284b5857368..ed1820488c98 100644
+--- a/drivers/media/platform/qcom/camss/camss-csid.c
++++ b/drivers/media/platform/qcom/camss/camss-csid.c
+@@ -1187,24 +1187,12 @@ int msm_csid_subdev_init(struct camss *camss, struct csid_device *csid,
+ 
+ 	/* Regulator */
+ 	for (i = 0; i < ARRAY_SIZE(res->regulators); i++) {
+-		if (res->regulators[i])
++		if (res->regulators[i].supply)
+ 			csid->num_supplies++;
+ 	}
+ 
+-	if (csid->num_supplies) {
+-		csid->supplies = devm_kmalloc_array(camss->dev,
+-						    csid->num_supplies,
+-						    sizeof(*csid->supplies),
+-						    GFP_KERNEL);
+-		if (!csid->supplies)
+-			return -ENOMEM;
+-	}
+-
+-	for (i = 0; i < csid->num_supplies; i++)
+-		csid->supplies[i].supply = res->regulators[i];
+-
+-	ret = devm_regulator_bulk_get(camss->dev, csid->num_supplies,
+-				      csid->supplies);
++	ret = devm_regulator_bulk_get_const(camss->dev, csid->num_supplies,
++					    res->regulators, &csid->supplies);
+ 	if (ret)
+ 		return ret;
+ 
+diff --git a/drivers/media/platform/qcom/camss/camss-csiphy.c b/drivers/media/platform/qcom/camss/camss-csiphy.c
+index a734fb7dde0a..62623393f414 100644
+--- a/drivers/media/platform/qcom/camss/camss-csiphy.c
++++ b/drivers/media/platform/qcom/camss/camss-csiphy.c
+@@ -695,24 +695,13 @@ int msm_csiphy_subdev_init(struct camss *camss,
+ 
+ 	/* CSIPHY supplies */
+ 	for (i = 0; i < ARRAY_SIZE(res->regulators); i++) {
+-		if (res->regulators[i])
++		if (res->regulators[i].supply)
+ 			csiphy->num_supplies++;
+ 	}
+ 
+-	if (csiphy->num_supplies) {
+-		csiphy->supplies = devm_kmalloc_array(camss->dev,
+-						      csiphy->num_supplies,
+-						      sizeof(*csiphy->supplies),
+-						      GFP_KERNEL);
+-		if (!csiphy->supplies)
+-			return -ENOMEM;
+-	}
+-
+-	for (i = 0; i < csiphy->num_supplies; i++)
+-		csiphy->supplies[i].supply = res->regulators[i];
+-
+-	ret = devm_regulator_bulk_get(camss->dev, csiphy->num_supplies,
+-				      csiphy->supplies);
++	if (csiphy->num_supplies > 0)
++		ret = devm_regulator_bulk_get_const(camss->dev, csiphy->num_supplies,
++						    res->regulators, &csiphy->supplies);
+ 	return ret;
+ }
+ 
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index fcc2b2c3cba0..6cfb71fcd861 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -73,7 +73,9 @@ static const struct camss_subdev_resources csiphy_res_8x16[] = {
+ static const struct camss_subdev_resources csid_res_8x16[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 40000 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi0_ahb", "ahb",
+ 			   "csi0", "csi0_phy", "csi0_pix", "csi0_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -95,7 +97,9 @@ static const struct camss_subdev_resources csid_res_8x16[] = {
+ 
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 40000 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi1_ahb", "ahb",
+ 			   "csi1", "csi1_phy", "csi1_pix", "csi1_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -157,7 +161,9 @@ static const struct camss_subdev_resources vfe_res_8x16[] = {
+ static const struct camss_subdev_resources csiphy_res_8x39[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 40000 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "ahb", "csiphy0_timer" },
+ 		.clock_rate = { { 0 },
+ 				{ 40000000, 80000000 },
+@@ -174,7 +180,9 @@ static const struct camss_subdev_resources csiphy_res_8x39[] = {
+ 
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 40000 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "ahb", "csiphy1_timer" },
+ 		.clock_rate = { { 0 },
+ 				{ 40000000, 80000000 },
+@@ -300,7 +308,9 @@ static const struct camss_subdev_resources vfe_res_8x39[] = {
+ static const struct camss_subdev_resources csid_res_8x53[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 9900 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi0_ahb", "ahb",
+ 			   "csi0", "csi0_phy", "csi0_pix", "csi0_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -323,7 +333,9 @@ static const struct camss_subdev_resources csid_res_8x53[] = {
+ 
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 9900 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi1_ahb", "ahb",
+ 			   "csi1", "csi1_phy", "csi1_pix", "csi1_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -346,7 +358,9 @@ static const struct camss_subdev_resources csid_res_8x53[] = {
+ 
+ 	/* CSID2 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 9900 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi2_ahb", "ahb",
+ 			   "csi2", "csi2_phy", "csi2_pix", "csi2_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -507,7 +521,9 @@ static const struct camss_subdev_resources csiphy_res_8x96[] = {
+ static const struct camss_subdev_resources csid_res_8x96[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 80160 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi0_ahb", "ahb",
+ 			   "csi0", "csi0_phy", "csi0_pix", "csi0_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -529,7 +545,9 @@ static const struct camss_subdev_resources csid_res_8x96[] = {
+ 
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 80160 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi1_ahb", "ahb",
+ 			   "csi1", "csi1_phy", "csi1_pix", "csi1_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -551,7 +569,9 @@ static const struct camss_subdev_resources csid_res_8x96[] = {
+ 
+ 	/* CSID2 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 80160 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi2_ahb", "ahb",
+ 			   "csi2", "csi2_phy", "csi2_pix", "csi2_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -573,7 +593,9 @@ static const struct camss_subdev_resources csid_res_8x96[] = {
+ 
+ 	/* CSID3 */
+ 	{
+-		.regulators = { "vdda" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 80160 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi3_ahb", "ahb",
+ 			   "csi3", "csi3_phy", "csi3_pix", "csi3_rdi" },
+ 		.clock_rate = { { 0 },
+@@ -661,7 +683,10 @@ static const struct camss_subdev_resources vfe_res_8x96[] = {
+ static const struct camss_subdev_resources csiphy_res_2290[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdd-csiphy-1p2", "vdd-csiphy-1p8" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 26700 },
++			{ .supply = "vdd-csiphy-1p8", .init_load_uA = 2600 }
++		},
+ 		.clock = { "top_ahb", "ahb", "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 0 },
+ 				{ 0 },
+@@ -678,7 +703,10 @@ static const struct camss_subdev_resources csiphy_res_2290[] = {
+ 
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdd-csiphy-1p2", "vdd-csiphy-1p8" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 26700 },
++			{ .supply = "vdd-csiphy-1p8", .init_load_uA = 2600 }
++		},
+ 		.clock = { "top_ahb", "ahb", "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 0 },
+ 				{ 0 },
+@@ -854,7 +882,10 @@ static const struct camss_subdev_resources csiphy_res_660[] = {
+ static const struct camss_subdev_resources csid_res_660[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda", "vdd_sec" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 0 },
++			{ .supply = "vdd_sec", .init_load_uA = 0 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi0_ahb", "ahb",
+ 			   "csi0", "csi0_phy", "csi0_pix", "csi0_rdi",
+ 			   "cphy_csid0" },
+@@ -879,7 +910,10 @@ static const struct camss_subdev_resources csid_res_660[] = {
+ 
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda", "vdd_sec" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 0 },
++			{ .supply = "vdd_sec", .init_load_uA = 0 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi1_ahb", "ahb",
+ 			   "csi1", "csi1_phy", "csi1_pix", "csi1_rdi",
+ 			   "cphy_csid1" },
+@@ -904,7 +938,10 @@ static const struct camss_subdev_resources csid_res_660[] = {
+ 
+ 	/* CSID2 */
+ 	{
+-		.regulators = { "vdda", "vdd_sec" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 0 },
++			{ .supply = "vdd_sec", .init_load_uA = 0 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi2_ahb", "ahb",
+ 			   "csi2", "csi2_phy", "csi2_pix", "csi2_rdi",
+ 			   "cphy_csid2" },
+@@ -929,7 +966,10 @@ static const struct camss_subdev_resources csid_res_660[] = {
+ 
+ 	/* CSID3 */
+ 	{
+-		.regulators = { "vdda", "vdd_sec" },
++		.regulators = {
++			{ .supply = "vdda", .init_load_uA = 0 },
++			{ .supply = "vdd_sec", .init_load_uA = 0 }
++		},
+ 		.clock = { "top_ahb", "ispif_ahb", "csi3_ahb", "ahb",
+ 			   "csi3", "csi3_phy", "csi3_pix", "csi3_rdi",
+ 			   "cphy_csid3" },
+@@ -1026,7 +1066,10 @@ static const struct camss_subdev_resources vfe_res_660[] = {
+ static const struct camss_subdev_resources csiphy_res_670[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 42800 },
++			{ .supply = "vdda-pll", .init_load_uA = 13900 }
++		},
+ 		.clock = { "soc_ahb", "cpas_ahb",
+ 			   "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 0 },
+@@ -1044,7 +1087,10 @@ static const struct camss_subdev_resources csiphy_res_670[] = {
+ 
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 42800 },
++			{ .supply = "vdda-pll", .init_load_uA = 13900 }
++		},
+ 		.clock = { "soc_ahb", "cpas_ahb",
+ 			   "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 0 },
+@@ -1062,7 +1108,10 @@ static const struct camss_subdev_resources csiphy_res_670[] = {
+ 
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 42800 },
++			{ .supply = "vdda-pll", .init_load_uA = 13900 }
++		},
+ 		.clock = { "soc_ahb", "cpas_ahb",
+ 			   "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 0 },
+@@ -1302,7 +1351,10 @@ static const struct camss_subdev_resources csiphy_res_845[] = {
+ static const struct camss_subdev_resources csid_res_845[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "cpas_ahb", "cphy_rx_src", "slow_ahb_src",
+ 				"soc_ahb", "vfe0", "vfe0_src",
+ 				"vfe0_cphy_rx", "csi0",
+@@ -1327,7 +1379,10 @@ static const struct camss_subdev_resources csid_res_845[] = {
+ 
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "cpas_ahb", "cphy_rx_src", "slow_ahb_src",
+ 				"soc_ahb", "vfe1", "vfe1_src",
+ 				"vfe1_cphy_rx", "csi1",
+@@ -1352,7 +1407,10 @@ static const struct camss_subdev_resources csid_res_845[] = {
+ 
+ 	/* CSID2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "cpas_ahb", "cphy_rx_src", "slow_ahb_src",
+ 				"soc_ahb", "vfe_lite", "vfe_lite_src",
+ 				"vfe_lite_cphy_rx", "csi2",
+@@ -1464,7 +1522,10 @@ static const struct camss_subdev_resources vfe_res_845[] = {
+ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1478,7 +1539,10 @@ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1492,7 +1556,10 @@ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1506,7 +1573,10 @@ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	},
+ 	/* CSIPHY3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy3", "csiphy3_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1520,7 +1590,10 @@ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	},
+ 	/* CSIPHY4 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy4", "csiphy4_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1534,7 +1607,10 @@ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	},
+ 	/* CSIPHY5 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 17500 },
++			{ .supply = "vdda-pll", .init_load_uA = 10000 }
++		},
+ 		.clock = { "csiphy5", "csiphy5_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 300000000 } },
+@@ -1748,7 +1824,10 @@ static const struct resources_icc icc_res_sm8250[] = {
+ static const struct camss_subdev_resources csiphy_res_7280[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 16100 },
++			{ .supply = "vdda-pll", .init_load_uA = 9000 }
++		},
+ 
+ 		.clock = { "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 300000000, 400000000 },
+@@ -1763,7 +1842,10 @@ static const struct camss_subdev_resources csiphy_res_7280[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 16100 },
++			{ .supply = "vdda-pll", .init_load_uA = 9000 }
++		},
+ 
+ 		.clock = { "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 300000000, 400000000 },
+@@ -1778,7 +1860,10 @@ static const struct camss_subdev_resources csiphy_res_7280[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 16100 },
++			{ .supply = "vdda-pll", .init_load_uA = 9000 }
++		},
+ 
+ 		.clock = { "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 300000000, 400000000 },
+@@ -1793,7 +1878,10 @@ static const struct camss_subdev_resources csiphy_res_7280[] = {
+ 	},
+ 	/* CSIPHY3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 16100 },
++			{ .supply = "vdda-pll", .init_load_uA = 9000 }
++		},
+ 
+ 		.clock = { "csiphy3", "csiphy3_timer" },
+ 		.clock_rate = { { 300000000, 400000000 },
+@@ -1808,7 +1896,10 @@ static const struct camss_subdev_resources csiphy_res_7280[] = {
+ 	},
+ 	/* CSIPHY4 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 16100 },
++			{ .supply = "vdda-pll", .init_load_uA = 9000 }
++		},
+ 
+ 		.clock = { "csiphy4", "csiphy4_timer" },
+ 		.clock_rate = { { 300000000, 400000000 },
+@@ -2121,7 +2212,10 @@ static const struct camss_subdev_resources csiphy_res_sc8280xp[] = {
+ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	/* CSID0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe0_csid", "vfe0_cphy_rx", "vfe0", "vfe0_axi" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2137,7 +2231,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe1_csid", "vfe1_cphy_rx", "vfe1", "vfe1_axi" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2153,7 +2250,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe2_csid", "vfe2_cphy_rx", "vfe2", "vfe2_axi" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2169,7 +2269,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe3_csid", "vfe3_cphy_rx", "vfe3", "vfe3_axi" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2185,7 +2288,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID_LITE0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe_lite0_csid", "vfe_lite0_cphy_rx", "vfe_lite0" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2201,7 +2307,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID_LITE1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe_lite1_csid", "vfe_lite1_cphy_rx", "vfe_lite1" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2217,7 +2326,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID_LITE2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe_lite2_csid", "vfe_lite2_cphy_rx", "vfe_lite2" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2233,7 +2345,10 @@ static const struct camss_subdev_resources csid_res_sc8280xp[] = {
+ 	},
+ 	/* CSID_LITE3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 0 },
++			{ .supply = "vdda-pll", .init_load_uA = 0 }
++		},
+ 		.clock = { "vfe_lite3_csid", "vfe_lite3_cphy_rx", "vfe_lite3" },
+ 		.clock_rate = { { 400000000, 480000000, 600000000 },
+ 				{ 0 },
+@@ -2434,7 +2549,10 @@ static const struct resources_icc icc_res_sc8280xp[] = {
+ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2448,7 +2566,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2462,7 +2583,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2476,7 +2600,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy3", "csiphy3_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2490,7 +2617,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY4 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 37900 },
++			{ .supply = "vdda-pll", .init_load_uA = 18600 }
++		},
+ 		.clock = { "csiphy4", "csiphy4_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2504,7 +2634,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY5 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy5", "csiphy5_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2518,7 +2651,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY6 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 37900 },
++			{ .supply = "vdda-pll", .init_load_uA = 18600 }
++		},
+ 		.clock = { "csiphy6", "csiphy6_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2532,7 +2668,10 @@ static const struct camss_subdev_resources csiphy_res_8550[] = {
+ 	},
+ 	/* CSIPHY7 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 32200 },
++			{ .supply = "vdda-pll", .init_load_uA = 18000 }
++		},
+ 		.clock = { "csiphy7", "csiphy7_timer" },
+ 		.clock_rate = { { 400000000, 480000000 },
+ 				{ 400000000 } },
+@@ -2763,7 +2902,10 @@ static const struct resources_icc icc_res_sm8550[] = {
+ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdd-csiphy01-0p9", "vdd-csiphy01-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy01-0p9", .init_load_uA = 88000 },
++			{ .supply = "vdd-csiphy01-1p2", .init_load_uA = 17800 },
++		},
+ 		.clock = { "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = {	{ 400000000 },
+ 				{ 400000000 } },
+@@ -2777,7 +2919,10 @@ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdd-csiphy01-0p9", "vdd-csiphy01-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy01-0p9", .init_load_uA = 88000 },
++			{ .supply = "vdd-csiphy01-1p2", .init_load_uA = 17800 },
++		},
+ 		.clock = { "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 400000000 } },
+@@ -2791,7 +2936,10 @@ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdd-csiphy24-0p9", "vdd-csiphy24-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy24-0p9", .init_load_uA = 147000 },
++			{ .supply = "vdd-csiphy24-1p2", .init_load_uA = 24400 },
++		},
+ 		.clock = { "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 400000000 } },
+@@ -2805,7 +2953,10 @@ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	},
+ 	/* CSIPHY3 */
+ 	{
+-		.regulators = { "vdd-csiphy35-0p9", "vdd-csiphy35-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy35-0p9", .init_load_uA = 88000 },
++			{ .supply = "vdd-csiphy35-1p2", .init_load_uA = 17800 },
++		},
+ 		.clock = { "csiphy3", "csiphy3_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 400000000 } },
+@@ -2819,7 +2970,10 @@ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	},
+ 	/* CSIPHY4 */
+ 	{
+-		.regulators = { "vdd-csiphy24-0p9", "vdd-csiphy24-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy24-0p9", .init_load_uA = 147000 },
++			{ .supply = "vdd-csiphy24-1p2", .init_load_uA = 24400 },
++		},
+ 		.clock = { "csiphy4", "csiphy4_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 400000000 } },
+@@ -2833,7 +2987,10 @@ static const struct camss_subdev_resources csiphy_res_sm8650[] = {
+ 	},
+ 	/* CSIPHY5 */
+ 	{
+-		.regulators = { "vdd-csiphy35-0p9", "vdd-csiphy35-1p2", },
++		.regulators = {
++			{ .supply = "vdd-csiphy35-0p9", .init_load_uA = 88000 },
++			{ .supply = "vdd-csiphy35-1p2", .init_load_uA = 17800 },
++		},
+ 		.clock = { "csiphy5", "csiphy5_timer" },
+ 		.clock_rate = { { 400000000 },
+ 				{ 400000000 } },
+@@ -3074,7 +3231,10 @@ static const struct resources_icc icc_res_sm8650[] = {
+ static const struct camss_subdev_resources csiphy_res_8300[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 
+ 		.clock = { "csiphy_rx", "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = {
+@@ -3092,7 +3252,10 @@ static const struct camss_subdev_resources csiphy_res_8300[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 
+ 		.clock = { "csiphy_rx", "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = {
+@@ -3110,7 +3273,10 @@ static const struct camss_subdev_resources csiphy_res_8300[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 
+ 		.clock = { "csiphy_rx", "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = {
+@@ -3131,7 +3297,10 @@ static const struct camss_subdev_resources csiphy_res_8300[] = {
+ static const struct camss_subdev_resources csiphy_res_8775p[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 		.clock = { "csiphy_rx", "csiphy0", "csiphy0_timer"},
+ 		.clock_rate = {
+ 			{ 400000000 },
+@@ -3148,7 +3317,10 @@ static const struct camss_subdev_resources csiphy_res_8775p[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 		.clock = { "csiphy_rx", "csiphy1", "csiphy1_timer"},
+ 		.clock_rate = {
+ 			{ 400000000 },
+@@ -3165,7 +3337,10 @@ static const struct camss_subdev_resources csiphy_res_8775p[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 		.clock = { "csiphy_rx", "csiphy2", "csiphy2_timer"},
+ 		.clock_rate = {
+ 			{ 400000000 },
+@@ -3182,7 +3357,10 @@ static const struct camss_subdev_resources csiphy_res_8775p[] = {
+ 	},
+ 	/* CSIPHY3 */
+ 	{
+-		.regulators = { "vdda-phy", "vdda-pll" },
++		.regulators = {
++			{ .supply = "vdda-phy", .init_load_uA = 15900 },
++			{ .supply = "vdda-pll", .init_load_uA = 8900 }
++		},
+ 		.clock = { "csiphy_rx", "csiphy3", "csiphy3_timer"},
+ 		.clock_rate = {
+ 			{ 400000000 },
+@@ -3535,8 +3713,10 @@ static const struct resources_icc icc_res_sa8775p[] = {
+ static const struct camss_subdev_resources csiphy_res_x1e80100[] = {
+ 	/* CSIPHY0 */
+ 	{
+-		.regulators = { "vdd-csiphy-0p8",
+-				"vdd-csiphy-1p2" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-0p8", .init_load_uA = 105000 },
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 58900 }
++		},
+ 		.clock = { "csiphy0", "csiphy0_timer" },
+ 		.clock_rate = { { 300000000, 400000000, 480000000 },
+ 				{ 266666667, 400000000 } },
+@@ -3550,8 +3730,10 @@ static const struct camss_subdev_resources csiphy_res_x1e80100[] = {
+ 	},
+ 	/* CSIPHY1 */
+ 	{
+-		.regulators = { "vdd-csiphy-0p8",
+-				"vdd-csiphy-1p2" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-0p8", .init_load_uA = 105000 },
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 58900 }
++		},
+ 		.clock = { "csiphy1", "csiphy1_timer" },
+ 		.clock_rate = { { 300000000, 400000000, 480000000 },
+ 				{ 266666667, 400000000 } },
+@@ -3565,8 +3747,10 @@ static const struct camss_subdev_resources csiphy_res_x1e80100[] = {
+ 	},
+ 	/* CSIPHY2 */
+ 	{
+-		.regulators = { "vdd-csiphy-0p8",
+-				"vdd-csiphy-1p2" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-0p8", .init_load_uA = 105000 },
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 58900 }
++		},
+ 		.clock = { "csiphy2", "csiphy2_timer" },
+ 		.clock_rate = { { 300000000, 400000000, 480000000 },
+ 				{ 266666667, 400000000 } },
+@@ -3580,8 +3764,10 @@ static const struct camss_subdev_resources csiphy_res_x1e80100[] = {
+ 	},
+ 	/* CSIPHY4 */
+ 	{
+-		.regulators = { "vdd-csiphy-0p8",
+-				"vdd-csiphy-1p2" },
++		.regulators = {
++			{ .supply = "vdd-csiphy-0p8", .init_load_uA = 105000 },
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 58900 }
++		},
+ 		.clock = { "csiphy4", "csiphy4_timer" },
+ 		.clock_rate = { { 300000000, 400000000, 480000000 },
+ 				{ 266666667, 400000000 } },
+diff --git a/drivers/media/platform/qcom/camss/camss.h b/drivers/media/platform/qcom/camss/camss.h
+index 9d9a62640e25..e34f06b4e153 100644
+--- a/drivers/media/platform/qcom/camss/camss.h
++++ b/drivers/media/platform/qcom/camss/camss.h
+@@ -44,7 +44,7 @@
+ #define CAMSS_INIT_BUF_COUNT 2
+ 
+ struct camss_subdev_resources {
+-	char *regulators[CAMSS_RES_MAX];
++	struct regulator_bulk_data regulators[CAMSS_RES_MAX];
+ 	char *clock[CAMSS_RES_MAX];
+ 	char *clock_for_reset[CAMSS_RES_MAX];
+ 	u32 clock_rate[CAMSS_RES_MAX][CAMSS_RES_MAX];

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0006-media-qcom-camss-Do-not-enable-cpas-fast-ahb-clock-f.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0006-media-qcom-camss-Do-not-enable-cpas-fast-ahb-clock-f.patch
@@ -1,0 +1,50 @@
+From d2b122b40dff6b8f1f01d3b7c8fda4c60686caee Mon Sep 17 00:00:00 2001
+From: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Date: Mon, 20 Oct 2025 17:02:27 +0300
+Subject: [PATCH] media: qcom: camss: Do not enable cpas fast ahb clock for
+ SM8550 VFE lite
+
+The clock is needed to stream images over a full VFE IP on SM8550 CAMSS,
+and it should not be enabled, when an image stream is routed over any of
+two lite VFE IPs on the SoC.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251020140227.2264634-1-vladimir.zapolskiy@linaro.org]
+Link: https://lore.kernel.org/all/20251020140227.2264634-1-vladimir.zapolskiy@linaro.org/
+Signed-off-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Acked-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+ drivers/media/platform/qcom/camss/camss.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index 6cfb71fcd861..9122568f9b0a 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -2843,12 +2843,11 @@ static const struct camss_subdev_resources vfe_res_8550[] = {
+ 	/* VFE3 lite */
+ 	{
+ 		.regulators = {},
+-		.clock = { "gcc_axi_hf", "cpas_ahb", "cpas_fast_ahb_clk", "vfe_lite_ahb",
++		.clock = { "gcc_axi_hf", "cpas_ahb", "vfe_lite_ahb",
+ 			   "vfe_lite", "cpas_ife_lite", "camnoc_axi" },
+ 		.clock_rate = {	{ 0 },
+ 				{ 80000000 },
+ 				{ 300000000, 400000000 },
+-				{ 300000000, 400000000 },
+ 				{ 400000000, 480000000 },
+ 				{ 300000000, 400000000 },
+ 				{ 300000000, 400000000 } },
+@@ -2865,12 +2864,11 @@ static const struct camss_subdev_resources vfe_res_8550[] = {
+ 	/* VFE4 lite */
+ 	{
+ 		.regulators = {},
+-		.clock = { "gcc_axi_hf", "cpas_ahb", "cpas_fast_ahb_clk", "vfe_lite_ahb",
++		.clock = { "gcc_axi_hf", "cpas_ahb", "vfe_lite_ahb",
+ 			   "vfe_lite", "cpas_ife_lite", "camnoc_axi" },
+ 		.clock_rate = {	{ 0 },
+ 				{ 80000000 },
+ 				{ 300000000, 400000000 },
+-				{ 300000000, 400000000 },
+ 				{ 400000000, 480000000 },
+ 				{ 300000000, 400000000 },
+ 				{ 300000000, 400000000 } },

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0007-media-qcom-camss-csid-340-Fix-unused-variables.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0007-media-qcom-camss-csid-340-Fix-unused-variables.patch
@@ -1,0 +1,63 @@
+From 4d2e71d3e5e5b89b12ce13d96259fbdc92a3a6e5 Mon Sep 17 00:00:00 2001
+From: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Date: Thu, 11 Dec 2025 14:59:39 +0100
+Subject: [PATCH] media: qcom: camss: csid-340: Fix unused variables
+
+The CSID driver has some unused variables and function parameters
+that are no longer needed (due to refactoring). Clean up those
+unused elements:
+
+- Remove the `vc` parameter from `__csid_configure_rx()`.
+- Drop the unused `lane_cnt` variable.
+- Adjust call to `__csid_configure_rx()` accordingly.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251211135939.1779544-1-loic.poulain@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20251211135939.1779544-1-loic.poulain@oss.qualcomm.com/
+Signed-off-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+---
+ drivers/media/platform/qcom/camss/camss-csid-340.c | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss-csid-340.c b/drivers/media/platform/qcom/camss/camss-csid-340.c
+index 22a30510fb79..2b50f9b96a34 100644
+--- a/drivers/media/platform/qcom/camss/camss-csid-340.c
++++ b/drivers/media/platform/qcom/camss/camss-csid-340.c
+@@ -55,8 +55,7 @@
+ #define CSID_RDI_CTRL_HALT_AT_FRAME_BOUNDARY		0
+ #define CSID_RDI_CTRL_RESUME_AT_FRAME_BOUNDARY		1
+ 
+-static void __csid_configure_rx(struct csid_device *csid,
+-				struct csid_phy_config *phy, int vc)
++static void __csid_configure_rx(struct csid_device *csid, struct csid_phy_config *phy)
+ {
+ 	u32 val;
+ 
+@@ -81,13 +80,9 @@ static void __csid_configure_rdi_stream(struct csid_device *csid, u8 enable, u8
+ 	const struct csid_format_info *format = csid_get_fmt_entry(csid->res->formats->formats,
+ 								   csid->res->formats->nformats,
+ 								   input_format->code);
+-	u8 lane_cnt = csid->phy.lane_cnt;
+ 	u8 dt_id;
+ 	u32 val;
+ 
+-	if (!lane_cnt)
+-		lane_cnt = 4;
+-
+ 	/*
+ 	 * DT_ID is a two bit bitfield that is concatenated with
+ 	 * the four least significant bits of the five bit VC
+@@ -120,10 +115,11 @@ static void csid_configure_stream(struct csid_device *csid, u8 enable)
+ {
+ 	int i;
+ 
++	__csid_configure_rx(csid, &csid->phy);
++
+ 	for (i = 0; i < MSM_CSID_MAX_SRC_STREAMS; i++) {
+ 		if (csid->phy.en_vc & BIT(i)) {
+ 			__csid_configure_rdi_stream(csid, enable, i);
+-			__csid_configure_rx(csid, &csid->phy, i);
+ 			__csid_ctrl_rdi(csid, enable, i);
+ 		}
+ 	}

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0008-media-qcom-camss-vfe-Fix-out-of-bounds-access-in-vfe.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0008-media-qcom-camss-vfe-Fix-out-of-bounds-access-in-vfe.patch
@@ -1,0 +1,46 @@
+From 2088bff49b47c41b342ddd94bac25ac93d9338fa Mon Sep 17 00:00:00 2001
+From: Alper Ak <alperyasinak1@gmail.com>
+Date: Mon, 29 Dec 2025 10:52:17 +0300
+Subject: [PATCH] media: qcom: camss: vfe: Fix out-of-bounds access in
+ vfe_isr_reg_update()
+
+vfe_isr() iterates using MSM_VFE_IMAGE_MASTERS_NUM(7) as the loop
+bound and passes the index to vfe_isr_reg_update(). However,
+vfe->line[] array is defined with VFE_LINE_NUM_MAX(4):
+
+    struct vfe_line line[VFE_LINE_NUM_MAX];
+
+When index is 4, 5, 6, the access to vfe->line[line_id] exceeds
+the array bounds and resulting in out-of-bounds memory access.
+
+Fix this by using separate loops for output lines and write masters.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251229075217.24679-1-alperyasinak1@gmail.com]
+Fixes: 4edc8eae715c ("media: camss: Add initial support for VFE hardware version Titan 480")
+Link: https://lore.kernel.org/all/20251229075217.24679-1-alperyasinak1@gmail.com/
+Signed-off-by: Alper Ak <alperyasinak1@gmail.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+ drivers/media/platform/qcom/camss/camss-vfe-480.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss-vfe-480.c b/drivers/media/platform/qcom/camss/camss-vfe-480.c
+index 4feea590a47b..d73f733fde04 100644
+--- a/drivers/media/platform/qcom/camss/camss-vfe-480.c
++++ b/drivers/media/platform/qcom/camss/camss-vfe-480.c
+@@ -202,11 +202,13 @@ static irqreturn_t vfe_isr(int irq, void *dev)
+ 		writel_relaxed(status, vfe->base + VFE_BUS_IRQ_CLEAR(0));
+ 		writel_relaxed(1, vfe->base + VFE_BUS_IRQ_CLEAR_GLOBAL);
+ 
+-		/* Loop through all WMs IRQs */
+-		for (i = 0; i < MSM_VFE_IMAGE_MASTERS_NUM; i++) {
++		for (i = 0; i < MAX_VFE_OUTPUT_LINES; i++) {
+ 			if (status & BUS_IRQ_MASK_0_RDI_RUP(vfe, i))
+ 				vfe_isr_reg_update(vfe, i);
++		}
+ 
++		/* Loop through all WMs IRQs */
++		for (i = 0; i < MSM_VFE_IMAGE_MASTERS_NUM; i++) {
+ 			if (status & BUS_IRQ_MASK_0_COMP_DONE(vfe, RDI_COMP_GROUP(i)))
+ 				vfe_buf_done(vfe, i);
+ 		}

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0009-media-qcom-camss-change-internals-of-endpoint-parsin.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0009-media-qcom-camss-change-internals-of-endpoint-parsin.patch
@@ -1,0 +1,132 @@
+From a998c54d3d45f16c8e454f469fdcc14a8c95b639 Mon Sep 17 00:00:00 2001
+From: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Date: Thu, 20 Nov 2025 02:46:03 +0200
+Subject: [PATCH] media: qcom: camss: change internals of endpoint parsing to
+ fwnode handling
+
+Since a few called V4L2 functions operate with fwnode arguments the change
+from OF device nodes to fwnodes brings a simplification to the code.
+
+The camss_parse_endpoint_node() function is called once by camss_probe(),
+and there is no use of knowing a number of asynchronously registered
+remote devices, so it makes sense to remove the related computation from
+the function.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251120004604.2573803-2-vladimir.zapolskiy@linaro.org]
+Link: https://lore.kernel.org/all/20251120004604.2573803-2-vladimir.zapolskiy@linaro.org/
+Tested-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Signed-off-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+---
+ drivers/media/platform/qcom/camss/camss.c | 49 +++++++++++------------
+ 1 file changed, 23 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index 9122568f9b0a..8e0809202362 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -4206,16 +4206,16 @@ static const struct parent_dev_ops vfe_parent_dev_ops = {
+ };
+ 
+ /*
+- * camss_of_parse_endpoint_node - Parse port endpoint node
+- * @dev: Device
+- * @node: Device node to be parsed
++ * camss_parse_endpoint_node - Parse port endpoint node
++ * @dev: CAMSS device
++ * @ep: Device endpoint to be parsed
+  * @csd: Parsed data from port endpoint node
+  *
+  * Return 0 on success or a negative error code on failure
+  */
+-static int camss_of_parse_endpoint_node(struct device *dev,
+-					struct device_node *node,
+-					struct camss_async_subdev *csd)
++static int camss_parse_endpoint_node(struct device *dev,
++				     struct fwnode_handle *ep,
++				     struct camss_async_subdev *csd)
+ {
+ 	struct csiphy_lanes_cfg *lncfg = &csd->interface.csi2.lane_cfg;
+ 	struct v4l2_mbus_config_mipi_csi2 *mipi_csi2;
+@@ -4223,7 +4223,7 @@ static int camss_of_parse_endpoint_node(struct device *dev,
+ 	unsigned int i;
+ 	int ret;
+ 
+-	ret = v4l2_fwnode_endpoint_parse(of_fwnode_handle(node), &vep);
++	ret = v4l2_fwnode_endpoint_parse(ep, &vep);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -4258,49 +4258,46 @@ static int camss_of_parse_endpoint_node(struct device *dev,
+ }
+ 
+ /*
+- * camss_of_parse_ports - Parse ports node
+- * @dev: Device
+- * @notifier: v4l2_device notifier data
++ * camss_parse_ports - Parse ports node
++ * @dev: CAMSS device
+  *
+- * Return number of "port" nodes found in "ports" node
++ * Return 0 on success or a negative error code on failure
+  */
+-static int camss_of_parse_ports(struct camss *camss)
++static int camss_parse_ports(struct camss *camss)
+ {
+ 	struct device *dev = camss->dev;
+-	struct device_node *node = NULL;
+-	struct device_node *remote = NULL;
+-	int ret, num_subdevs = 0;
++	struct fwnode_handle *fwnode = dev_fwnode(dev), *ep;
++	int ret;
+ 
+-	for_each_endpoint_of_node(dev->of_node, node) {
++	fwnode_graph_for_each_endpoint(fwnode, ep) {
+ 		struct camss_async_subdev *csd;
++		struct fwnode_handle *remote;
+ 
+-		remote = of_graph_get_remote_port_parent(node);
++		remote = fwnode_graph_get_remote_port_parent(ep);
+ 		if (!remote) {
+ 			dev_err(dev, "Cannot get remote parent\n");
+ 			ret = -EINVAL;
+ 			goto err_cleanup;
+ 		}
+ 
+-		csd = v4l2_async_nf_add_fwnode(&camss->notifier,
+-					       of_fwnode_handle(remote),
++		csd = v4l2_async_nf_add_fwnode(&camss->notifier, remote,
+ 					       struct camss_async_subdev);
+-		of_node_put(remote);
++		fwnode_handle_put(remote);
+ 		if (IS_ERR(csd)) {
+ 			ret = PTR_ERR(csd);
+ 			goto err_cleanup;
+ 		}
+ 
+-		ret = camss_of_parse_endpoint_node(dev, node, csd);
++		ret = camss_parse_endpoint_node(dev, ep, csd);
+ 		if (ret < 0)
+ 			goto err_cleanup;
+-
+-		num_subdevs++;
+ 	}
+ 
+-	return num_subdevs;
++	return 0;
+ 
+ err_cleanup:
+-	of_node_put(node);
++	fwnode_handle_put(ep);
++
+ 	return ret;
+ }
+ 
+@@ -4857,7 +4854,7 @@ static int camss_probe(struct platform_device *pdev)
+ 
+ 	pm_runtime_enable(dev);
+ 
+-	ret = camss_of_parse_ports(camss);
++	ret = camss_parse_ports(camss);
+ 	if (ret < 0)
+ 		goto err_v4l2_device_unregister;
+ 

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0010-media-qcom-camss-use-a-handy-v4l2_async_nf_add_fwnod.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0010-media-qcom-camss-use-a-handy-v4l2_async_nf_add_fwnod.patch
@@ -1,0 +1,41 @@
+From 8e0268dfa07b409a40a661a8c62f83832a2ba94b Mon Sep 17 00:00:00 2001
+From: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Date: Thu, 20 Nov 2025 02:46:04 +0200
+Subject: [PATCH] media: qcom: camss: use a handy
+ v4l2_async_nf_add_fwnode_remote() function
+
+Another code simplification makes parsing of remote endpoints easy.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20251120004604.2573803-3-vladimir.zapolskiy@linaro.org]
+Link: https://lore.kernel.org/all/20251120004604.2573803-3-vladimir.zapolskiy@linaro.org/
+Tested-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Signed-off-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+---
+ drivers/media/platform/qcom/camss/camss.c | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index 8e0809202362..7f44b60bcd72 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -4271,18 +4271,9 @@ static int camss_parse_ports(struct camss *camss)
+ 
+ 	fwnode_graph_for_each_endpoint(fwnode, ep) {
+ 		struct camss_async_subdev *csd;
+-		struct fwnode_handle *remote;
+ 
+-		remote = fwnode_graph_get_remote_port_parent(ep);
+-		if (!remote) {
+-			dev_err(dev, "Cannot get remote parent\n");
+-			ret = -EINVAL;
+-			goto err_cleanup;
+-		}
+-
+-		csd = v4l2_async_nf_add_fwnode(&camss->notifier, remote,
+-					       struct camss_async_subdev);
+-		fwnode_handle_put(remote);
++		csd = v4l2_async_nf_add_fwnode_remote(&camss->notifier, ep,
++						      typeof(*csd));
+ 		if (IS_ERR(csd)) {
+ 			ret = PTR_ERR(csd);
+ 			goto err_cleanup;

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0011-media-dt-bindings-Add-qcom-sm6150-camss.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0011-media-dt-bindings-Add-qcom-sm6150-camss.patch
@@ -1,0 +1,475 @@
+From 8747f105f4565f5ac51c4ff59ee45956dc16f45d Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Mon, 12 Jan 2026 16:04:52 +0800
+Subject: [PATCH] media: dt-bindings: Add qcom,sm6150-camss
+
+Add bindings for the Camera Subsystem on the SM6150 SoC
+
+The SM6150 platform provides:
+- 2 x VFE (version 170), each with 3 RDI
+- 1 x VFE Lite (version 170), each with 4 RDI
+- 2 x CSID (version 170)
+- 1 x CSID Lite (version 170)
+- 3 x CSIPHY (version 2.0.0)
+- 1 x BPS (Bayer Processing Segment)
+- 1 x ICP (Imaging Control Processor)
+- 1 x IPE (Image Postprocessing Engine)
+- 1 x JPEG Encoder/Decoder
+- 1 x LRME (Low Resolution Motion Estimation)
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260112-sm6150-camss-v4-1-0cd576d627f7@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260112-sm6150-camss-v4-1-0cd576d627f7@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+ .../bindings/media/qcom,sm6150-camss.yaml     | 439 ++++++++++++++++++
+ 1 file changed, 439 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/media/qcom,sm6150-camss.yaml
+
+diff --git a/Documentation/devicetree/bindings/media/qcom,sm6150-camss.yaml b/Documentation/devicetree/bindings/media/qcom,sm6150-camss.yaml
+new file mode 100644
+index 000000000000..ba7b0acb9128
+--- /dev/null
++++ b/Documentation/devicetree/bindings/media/qcom,sm6150-camss.yaml
+@@ -0,0 +1,439 @@
++# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/media/qcom,sm6150-camss.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Qualcomm SM6150 Camera Subsystem (CAMSS)
++
++maintainers:
++  - Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
++
++description:
++  This binding describes the camera subsystem hardware found on SM6150
++  Qualcomm SoCs. It includes submodules such as CSIPHY (CSI Physical layer)
++  and CSID (CSI Decoder), which comply with the MIPI CSI2 protocol.
++
++  The subsystem also integrates a set of real-time image processing engines
++  and their associated configuration modules, as well as non-real-time engines.
++
++properties:
++  compatible:
++    const: qcom,sm6150-camss
++
++  reg:
++    items:
++      - description: Registers for CSID 0
++      - description: Registers for CSID 1
++      - description: Registers for CSID Lite
++      - description: Registers for CSIPHY 0
++      - description: Registers for CSIPHY 1
++      - description: Registers for CSIPHY 2
++      - description: Registers for VFE 0
++      - description: Registers for VFE 1
++      - description: Registers for VFE Lite
++      - description: Registers for BPS (Bayer Processing Segment)
++      - description: Registers for CAMNOC
++      - description: Registers for CPAS CDM
++      - description: Registers for CPAS TOP
++      - description: Registers for ICP (Imaging Control Processor) CSR (Control and Status Registers)
++      - description: Registers for ICP QGIC (Qualcomm Generic Interrupt Controller)
++      - description: Registers for ICP SIERRA ((A5 subsystem communication))
++      - description: Registers for IPE (Image Postprocessing Engine) 0
++      - description: Registers for JPEG DMA
++      - description: Registers for JPEG ENC
++      - description: Registers for LRME (Low Resolution Motion Estimation)
++
++  reg-names:
++    items:
++      - const: csid0
++      - const: csid1
++      - const: csid_lite
++      - const: csiphy0
++      - const: csiphy1
++      - const: csiphy2
++      - const: vfe0
++      - const: vfe1
++      - const: vfe_lite
++      - const: bps
++      - const: camnoc
++      - const: cpas_cdm
++      - const: cpas_top
++      - const: icp_csr
++      - const: icp_qgic
++      - const: icp_sierra
++      - const: ipe0
++      - const: jpeg_dma
++      - const: jpeg_enc
++      - const: lrme
++
++  clocks:
++    maxItems: 33
++
++  clock-names:
++    items:
++      - const: gcc_ahb
++      - const: gcc_axi_hf
++      - const: camnoc_axi
++      - const: cpas_ahb
++      - const: csiphy0
++      - const: csiphy0_timer
++      - const: csiphy1
++      - const: csiphy1_timer
++      - const: csiphy2
++      - const: csiphy2_timer
++      - const: soc_ahb
++      - const: vfe0
++      - const: vfe0_axi
++      - const: vfe0_cphy_rx
++      - const: vfe0_csid
++      - const: vfe1
++      - const: vfe1_axi
++      - const: vfe1_cphy_rx
++      - const: vfe1_csid
++      - const: vfe_lite
++      - const: vfe_lite_cphy_rx
++      - const: vfe_lite_csid
++      - const: bps
++      - const: bps_ahb
++      - const: bps_axi
++      - const: bps_areg
++      - const: icp
++      - const: ipe0
++      - const: ipe0_ahb
++      - const: ipe0_areg
++      - const: ipe0_axi
++      - const: jpeg
++      - const: lrme
++
++  interrupts:
++    maxItems: 15
++
++  interrupt-names:
++    items:
++      - const: csid0
++      - const: csid1
++      - const: csid_lite
++      - const: csiphy0
++      - const: csiphy1
++      - const: csiphy2
++      - const: vfe0
++      - const: vfe1
++      - const: vfe_lite
++      - const: camnoc
++      - const: cdm
++      - const: icp
++      - const: jpeg_dma
++      - const: jpeg_enc
++      - const: lrme
++
++  interconnects:
++    maxItems: 4
++
++  interconnect-names:
++    items:
++      - const: ahb
++      - const: hf_0
++      - const: hf_1
++      - const: sf_mnoc
++
++  iommus:
++    items:
++      - description: Camera IFE 0 non-protected stream
++      - description: Camera IFE 1 non-protected stream
++      - description: Camera IFE 3 non-protected stream
++      - description: Camera CDM non-protected stream
++      - description: Camera LRME read non-protected stream
++      - description: Camera IPE 0 read non-protected stream
++      - description: Camera BPS read non-protected stream
++      - description: Camera IPE 0 write non-protected stream
++      - description: Camera BPS write non-protected stream
++      - description: Camera LRME write non-protected stream
++      - description: Camera JPEG read non-protected stream
++      - description: Camera JPEG write non-protected stream
++      - description: Camera ICP stream
++
++  power-domains:
++    items:
++      - description:
++          IFE0 GDSC - Image Front End, Global Distributed Switch Controller.
++      - description:
++          IFE1 GDSC - Image Front End, Global Distributed Switch Controller.
++      - description:
++          Titan GDSC - Titan ISP Block, Global Distributed Switch Controller.
++      - description:
++          Titan BPS - Bayer Processing Segment, Global Distributed Switch Controller.
++      - description:
++          IPE GDSC - Image Postprocessing Engine, Global Distributed Switch Controller.
++
++  power-domain-names:
++    items:
++      - const: ife0
++      - const: ife1
++      - const: top
++      - const: bps
++      - const: ipe
++
++  vdd-csiphy-1p2-supply:
++    description:
++      Phandle to a 1.2V regulator supply to CSI PHYs.
++
++  vdd-csiphy-1p8-supply:
++    description:
++      Phandle to 1.8V regulator supply to CSI PHYs pll block.
++
++  ports:
++    $ref: /schemas/graph.yaml#/properties/ports
++
++    description:
++      CSI input ports.
++
++    patternProperties:
++      "^port@[0-2]$":
++        $ref: /schemas/graph.yaml#/$defs/port-base
++        unevaluatedProperties: false
++
++        description:
++          Input port for receiving CSI data from a CSIPHY.
++
++        properties:
++          endpoint:
++            $ref: video-interfaces.yaml#
++            unevaluatedProperties: false
++
++            properties:
++              data-lanes:
++                minItems: 1
++                maxItems: 4
++
++            required:
++              - data-lanes
++
++required:
++  - compatible
++  - reg
++  - reg-names
++  - clocks
++  - clock-names
++  - interrupts
++  - interrupt-names
++  - interconnects
++  - interconnect-names
++  - iommus
++  - power-domains
++  - power-domain-names
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/clock/qcom,qcs615-camcc.h>
++    #include <dt-bindings/clock/qcom,qcs615-gcc.h>
++    #include <dt-bindings/clock/qcom,rpmh.h>
++    #include <dt-bindings/interconnect/qcom,icc.h>
++    #include <dt-bindings/interconnect/qcom,qcs615-rpmh.h>
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/power/qcom-rpmpd.h>
++
++    soc {
++        #address-cells = <2>;
++        #size-cells = <2>;
++
++        camss: isp@acb3000 {
++            compatible = "qcom,sm6150-camss";
++
++            reg = <0x0 0x0acb3000 0x0 0x1000>,
++                  <0x0 0x0acba000 0x0 0x1000>,
++                  <0x0 0x0acc8000 0x0 0x1000>,
++                  <0x0 0x0ac65000 0x0 0x1000>,
++                  <0x0 0x0ac66000 0x0 0x1000>,
++                  <0x0 0x0ac67000 0x0 0x1000>,
++                  <0x0 0x0acaf000 0x0 0x4000>,
++                  <0x0 0x0acb6000 0x0 0x4000>,
++                  <0x0 0x0acc4000 0x0 0x4000>,
++                  <0x0 0x0ac6f000 0x0 0x3000>,
++                  <0x0 0x0ac42000 0x0 0x5000>,
++                  <0x0 0x0ac48000 0x0 0x1000>,
++                  <0x0 0x0ac40000 0x0 0x1000>,
++                  <0x0 0x0ac18000 0x0 0x3000>,
++                  <0x0 0x0ac00000 0x0 0x6000>,
++                  <0x0 0x0ac10000 0x0 0x8000>,
++                  <0x0 0x0ac87000 0x0 0x3000>,
++                  <0x0 0x0ac52000 0x0 0x4000>,
++                  <0x0 0x0ac4e000 0x0 0x4000>,
++                  <0x0 0x0ac6b000 0x0 0x0a00>;
++            reg-names = "csid0",
++                        "csid1",
++                        "csid_lite",
++                        "csiphy0",
++                        "csiphy1",
++                        "csiphy2",
++                        "vfe0",
++                        "vfe1",
++                        "vfe_lite",
++                        "bps",
++                        "camnoc",
++                        "cpas_cdm",
++                        "cpas_top",
++                        "icp_csr",
++                        "icp_qgic",
++                        "icp_sierra",
++                        "ipe0",
++                        "jpeg_dma",
++                        "jpeg_enc",
++                        "lrme";
++
++            clocks = <&gcc GCC_CAMERA_AHB_CLK>,
++                     <&gcc GCC_CAMERA_HF_AXI_CLK>,
++                     <&camcc CAM_CC_CAMNOC_AXI_CLK>,
++                     <&camcc CAM_CC_CPAS_AHB_CLK>,
++                     <&camcc CAM_CC_CSIPHY0_CLK>,
++                     <&camcc CAM_CC_CSI0PHYTIMER_CLK>,
++                     <&camcc CAM_CC_CSIPHY1_CLK>,
++                     <&camcc CAM_CC_CSI1PHYTIMER_CLK>,
++                     <&camcc CAM_CC_CSIPHY2_CLK>,
++                     <&camcc CAM_CC_CSI2PHYTIMER_CLK>,
++                     <&camcc CAM_CC_SOC_AHB_CLK>,
++                     <&camcc CAM_CC_IFE_0_CLK>,
++                     <&camcc CAM_CC_IFE_0_AXI_CLK>,
++                     <&camcc CAM_CC_IFE_0_CPHY_RX_CLK>,
++                     <&camcc CAM_CC_IFE_0_CSID_CLK>,
++                     <&camcc CAM_CC_IFE_1_CLK>,
++                     <&camcc CAM_CC_IFE_1_AXI_CLK>,
++                     <&camcc CAM_CC_IFE_1_CPHY_RX_CLK>,
++                     <&camcc CAM_CC_IFE_1_CSID_CLK>,
++                     <&camcc CAM_CC_IFE_LITE_CLK>,
++                     <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
++                     <&camcc CAM_CC_IFE_LITE_CSID_CLK>,
++                     <&camcc CAM_CC_BPS_CLK>,
++                     <&camcc CAM_CC_BPS_AHB_CLK>,
++                     <&camcc CAM_CC_BPS_AXI_CLK>,
++                     <&camcc CAM_CC_BPS_AREG_CLK>,
++                     <&camcc CAM_CC_ICP_CLK>,
++                     <&camcc CAM_CC_IPE_0_CLK>,
++                     <&camcc CAM_CC_IPE_0_AHB_CLK>,
++                     <&camcc CAM_CC_IPE_0_AREG_CLK>,
++                     <&camcc CAM_CC_IPE_0_AXI_CLK>,
++                     <&camcc CAM_CC_JPEG_CLK>,
++                     <&camcc CAM_CC_LRME_CLK>;
++
++            clock-names = "gcc_ahb",
++                          "gcc_axi_hf",
++                          "camnoc_axi",
++                          "cpas_ahb",
++                          "csiphy0",
++                          "csiphy0_timer",
++                          "csiphy1",
++                          "csiphy1_timer",
++                          "csiphy2",
++                          "csiphy2_timer",
++                          "soc_ahb",
++                          "vfe0",
++                          "vfe0_axi",
++                          "vfe0_cphy_rx",
++                          "vfe0_csid",
++                          "vfe1",
++                          "vfe1_axi",
++                          "vfe1_cphy_rx",
++                          "vfe1_csid",
++                          "vfe_lite",
++                          "vfe_lite_cphy_rx",
++                          "vfe_lite_csid",
++                          "bps",
++                          "bps_ahb",
++                          "bps_axi",
++                          "bps_areg",
++                          "icp",
++                          "ipe0",
++                          "ipe0_ahb",
++                          "ipe0_areg",
++                          "ipe0_axi",
++                          "jpeg",
++                          "lrme";
++
++            interconnects = <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++                             &config_noc SLAVE_CAMERA_CFG QCOM_ICC_TAG_ACTIVE_ONLY>,
++                            <&mmss_noc MASTER_CAMNOC_HF0 QCOM_ICC_TAG_ALWAYS
++                             &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++                            <&mmss_noc MASTER_CAMNOC_HF1 QCOM_ICC_TAG_ALWAYS
++                             &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++                            <&mmss_noc MASTER_CAMNOC_SF QCOM_ICC_TAG_ALWAYS
++                             &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++            interconnect-names = "ahb",
++                                 "hf_0",
++                                 "hf_1",
++                                 "sf_mnoc";
++
++            interrupts = <GIC_SPI 464 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 466 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 468 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 477 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 478 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 479 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 465 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 467 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 469 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 459 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 461 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 463 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 475 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 474 IRQ_TYPE_EDGE_RISING>,
++                         <GIC_SPI 476 IRQ_TYPE_EDGE_RISING>;
++            interrupt-names = "csid0",
++                              "csid1",
++                              "csid_lite",
++                              "csiphy0",
++                              "csiphy1",
++                              "csiphy2",
++                              "vfe0",
++                              "vfe1",
++                              "vfe_lite",
++                              "camnoc",
++                              "cdm",
++                              "icp",
++                              "jpeg_dma",
++                              "jpeg_enc",
++                              "lrme";
++
++            iommus = <&apps_smmu 0x0820 0x40>,
++                     <&apps_smmu 0x0840 0x00>,
++                     <&apps_smmu 0x0860 0x40>,
++                     <&apps_smmu 0x0c00 0x00>,
++                     <&apps_smmu 0x0cc0 0x00>,
++                     <&apps_smmu 0x0c80 0x00>,
++                     <&apps_smmu 0x0ca0 0x00>,
++                     <&apps_smmu 0x0d00 0x00>,
++                     <&apps_smmu 0x0d20 0x00>,
++                     <&apps_smmu 0x0d40 0x00>,
++                     <&apps_smmu 0x0d80 0x20>,
++                     <&apps_smmu 0x0da0 0x20>,
++                     <&apps_smmu 0x0de2 0x00>;
++
++            power-domains = <&camcc IFE_0_GDSC>,
++                            <&camcc IFE_1_GDSC>,
++                            <&camcc TITAN_TOP_GDSC>,
++                            <&camcc BPS_GDSC>,
++                            <&camcc IPE_0_GDSC>;
++            power-domain-names = "ife0",
++                                 "ife1",
++                                 "top",
++                                 "bps",
++                                 "ipe";
++
++            vdd-csiphy-1p2-supply = <&vreg_l11a_1p2>;
++            vdd-csiphy-1p8-supply = <&vreg_l12a_1p8>;
++
++            ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    csiphy_ep0: endpoint {
++                        data-lanes = <0 1>;
++                        remote-endpoint = <&sensor_ep>;
++                    };
++                };
++            };
++        };
++    };

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0012-media-qcom-camss-add-support-for-SM6150-camss.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0012-media-qcom-camss-add-support-for-SM6150-camss.patch
@@ -1,0 +1,298 @@
+From 254accd4e7ca0d951501da2114cb71cdc289707d Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Mon, 12 Jan 2026 16:04:53 +0800
+Subject: [PATCH] media: qcom: camss: add support for SM6150 camss
+
+The camera subsystem for SM6150 which is based on Spectra 230.
+
+For SM6150:
+- VFE and CSID version: 170 (vfe170, csid170)
+- CSIPHY version: csiphy-v2.0.1 (14nm)
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260112-sm6150-camss-v4-2-0cd576d627f7@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260112-sm6150-camss-v4-2-0cd576d627f7@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+ .../qcom/camss/camss-csiphy-3ph-1-0.c         |   2 +
+ drivers/media/platform/qcom/camss/camss-vfe.c |   2 +
+ drivers/media/platform/qcom/camss/camss.c     | 198 ++++++++++++++++++
+ drivers/media/platform/qcom/camss/camss.h     |   1 +
+ 4 files changed, 203 insertions(+)
+
+diff --git a/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c b/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
+index d70d4f611798..415483274552 100644
+--- a/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
++++ b/drivers/media/platform/qcom/camss/camss-csiphy-3ph-1-0.c
+@@ -1010,6 +1010,7 @@ static bool csiphy_is_gen2(u32 version)
+ 
+ 	switch (version) {
+ 	case CAMSS_2290:
++	case CAMSS_6150:
+ 	case CAMSS_7280:
+ 	case CAMSS_8250:
+ 	case CAMSS_8280XP:
+@@ -1100,6 +1101,7 @@ static int csiphy_init(struct csiphy_device *csiphy)
+ 		regs->lane_array_size = ARRAY_SIZE(lane_regs_sdm845);
+ 		break;
+ 	case CAMSS_2290:
++	case CAMSS_6150:
+ 		regs->lane_regs = &lane_regs_qcm2290[0];
+ 		regs->lane_array_size = ARRAY_SIZE(lane_regs_qcm2290);
+ 		break;
+diff --git a/drivers/media/platform/qcom/camss/camss-vfe.c b/drivers/media/platform/qcom/camss/camss-vfe.c
+index 9c7ad8aa4058..5baf0e3d4bc4 100644
+--- a/drivers/media/platform/qcom/camss/camss-vfe.c
++++ b/drivers/media/platform/qcom/camss/camss-vfe.c
+@@ -342,6 +342,7 @@ static u32 vfe_src_pad_code(struct vfe_line *line, u32 sink_code,
+ 		break;
+ 	case CAMSS_660:
+ 	case CAMSS_2290:
++	case CAMSS_6150:
+ 	case CAMSS_7280:
+ 	case CAMSS_8x96:
+ 	case CAMSS_8250:
+@@ -2001,6 +2002,7 @@ static int vfe_bpl_align(struct vfe_device *vfe)
+ 	int ret = 8;
+ 
+ 	switch (vfe->camss->res->version) {
++	case CAMSS_6150:
+ 	case CAMSS_7280:
+ 	case CAMSS_8250:
+ 	case CAMSS_8280XP:
+diff --git a/drivers/media/platform/qcom/camss/camss.c b/drivers/media/platform/qcom/camss/camss.c
+index 7f44b60bcd72..00b87fd9afbd 100644
+--- a/drivers/media/platform/qcom/camss/camss.c
++++ b/drivers/media/platform/qcom/camss/camss.c
+@@ -1519,6 +1519,190 @@ static const struct camss_subdev_resources vfe_res_845[] = {
+ 	}
+ };
+ 
++static const struct camss_subdev_resources csiphy_res_sm6150[] = {
++	/* CSIPHY0 */
++	{
++		.regulators = {
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 35000 },
++			{ .supply = "vdd-csiphy-1p8", .init_load_uA = 5000 }
++		},
++		.clock = { "csiphy0", "csiphy0_timer" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 269333333 } },
++		.reg = { "csiphy0" },
++		.interrupt = { "csiphy0" },
++		.csiphy = {
++			.id = 0,
++			.hw_ops = &csiphy_ops_3ph_1_0,
++			.formats = &csiphy_formats_sdm845
++		}
++	},
++	/* CSIPHY1 */
++	{
++		.regulators = {
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 35000 },
++			{ .supply = "vdd-csiphy-1p8", .init_load_uA = 5000 }
++		},
++		.clock = { "csiphy1", "csiphy1_timer" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 269333333 } },
++		.reg = { "csiphy1" },
++		.interrupt = { "csiphy1" },
++		.csiphy = {
++			.id = 1,
++			.hw_ops = &csiphy_ops_3ph_1_0,
++			.formats = &csiphy_formats_sdm845
++		}
++	},
++	/* CSIPHY2 */
++	{
++		.regulators = {
++			{ .supply = "vdd-csiphy-1p2", .init_load_uA = 35000 },
++			{ .supply = "vdd-csiphy-1p8", .init_load_uA = 5000 }
++		},
++		.clock = { "csiphy2", "csiphy2_timer" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 269333333 } },
++		.reg = { "csiphy2" },
++		.interrupt = { "csiphy2" },
++		.csiphy = {
++			.id = 2,
++			.hw_ops = &csiphy_ops_3ph_1_0,
++			.formats = &csiphy_formats_sdm845
++		}
++	},
++};
++
++static const struct camss_subdev_resources csid_res_sm6150[] = {
++	/* CSID0 */
++	{
++		.regulators = {},
++		.clock = { "vfe0_cphy_rx", "vfe0_csid" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 320000000, 540000000 } },
++		.reg = { "csid0" },
++		.interrupt = { "csid0" },
++		.csid = {
++			.is_lite = false,
++			.hw_ops = &csid_ops_gen2,
++			.parent_dev_ops = &vfe_parent_dev_ops,
++			.formats = &csid_formats_gen2
++		}
++	},
++	/* CSID1 */
++	{
++		.regulators = {},
++		.clock = { "vfe1_cphy_rx", "vfe1_csid" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 320000000, 540000000 } },
++		.reg = { "csid1" },
++		.interrupt = { "csid1" },
++		.csid = {
++			.is_lite = false,
++			.hw_ops = &csid_ops_gen2,
++			.parent_dev_ops = &vfe_parent_dev_ops,
++			.formats = &csid_formats_gen2
++		}
++	},
++	/* CSID2 */
++	{
++		.regulators = {},
++		.clock = { "vfe_lite_cphy_rx", "vfe_lite_csid" },
++		.clock_rate = { { 269333333, 384000000 },
++				{ 320000000, 540000000 } },
++		.reg = { "csid_lite" },
++		.interrupt = { "csid_lite" },
++		.csid = {
++			.is_lite = true,
++			.hw_ops = &csid_ops_gen2,
++			.parent_dev_ops = &vfe_parent_dev_ops,
++			.formats = &csid_formats_gen2
++		}
++	},
++};
++
++static const struct camss_subdev_resources vfe_res_sm6150[] = {
++	/* VFE0 */
++	{
++		.regulators = {},
++		.clock = { "gcc_axi_hf", "camnoc_axi", "cpas_ahb", "soc_ahb",
++			   "vfe0", "vfe0_axi"},
++		.clock_rate = { { 0 },
++				{ 0 },
++				{ 80000000 },
++				{ 37500000, 40000000 },
++				{ 360000000, 432000000, 540000000, 600000000 },
++				{ 265000000, 426000000 } },
++		.reg = { "vfe0" },
++		.interrupt = { "vfe0" },
++		.vfe = {
++			.line_num = 3,
++			.is_lite = false,
++			.has_pd = true,
++			.pd_name = "ife0",
++			.hw_ops = &vfe_ops_170,
++			.formats_rdi = &vfe_formats_rdi_845,
++			.formats_pix = &vfe_formats_pix_845
++		}
++	},
++	/* VFE1 */
++	{
++		.regulators = {},
++		.clock = { "gcc_axi_hf", "camnoc_axi", "cpas_ahb", "soc_ahb",
++			   "vfe1", "vfe1_axi"},
++		.clock_rate = { { 0 },
++				{ 0 },
++				{ 80000000 },
++				{ 37500000, 40000000 },
++				{ 360000000, 432000000, 540000000, 600000000 },
++				{ 265000000, 426000000 } },
++		.reg = { "vfe1" },
++		.interrupt = { "vfe1" },
++		.vfe = {
++			.line_num = 3,
++			.is_lite = false,
++			.has_pd = true,
++			.pd_name = "ife1",
++			.hw_ops = &vfe_ops_170,
++			.formats_rdi = &vfe_formats_rdi_845,
++			.formats_pix = &vfe_formats_pix_845
++		}
++	},
++	/* VFE2 */
++	{
++		.regulators = {},
++		.clock = { "gcc_axi_hf", "camnoc_axi", "cpas_ahb", "soc_ahb",
++			   "vfe_lite" },
++		.clock_rate = { { 0 },
++				{ 0 },
++				{ 80000000 },
++				{ 37500000, 40000000 },
++				{ 360000000, 432000000, 540000000, 600000000 } },
++		.reg = { "vfe_lite" },
++		.interrupt = { "vfe_lite" },
++		.vfe = {
++			.line_num = 4,
++			.is_lite = true,
++			.hw_ops = &vfe_ops_170,
++			.formats_rdi = &vfe_formats_rdi_845,
++			.formats_pix = &vfe_formats_pix_845
++		}
++	},
++};
++
++static const struct resources_icc icc_res_sm6150[] = {
++	{
++		.name = "ahb",
++		.icc_bw_tbl.avg = 38400,
++		.icc_bw_tbl.peak = 76800,
++	},
++	{
++		.name = "hf_0",
++		.icc_bw_tbl.avg = 2097152,
++		.icc_bw_tbl.peak = 2097152,
++	},
++};
++
+ static const struct camss_subdev_resources csiphy_res_8250[] = {
+ 	/* CSIPHY0 */
+ 	{
+@@ -5036,6 +5220,19 @@ static const struct camss_resources sdm845_resources = {
+ 	.vfe_num = ARRAY_SIZE(vfe_res_845),
+ };
+ 
++static const struct camss_resources sm6150_resources = {
++	.version = CAMSS_6150,
++	.pd_name = "top",
++	.csiphy_res = csiphy_res_sm6150,
++	.csid_res = csid_res_sm6150,
++	.vfe_res = vfe_res_sm6150,
++	.icc_res = icc_res_sm6150,
++	.icc_path_num = ARRAY_SIZE(icc_res_sm6150),
++	.csiphy_num = ARRAY_SIZE(csiphy_res_sm6150),
++	.csid_num = ARRAY_SIZE(csid_res_sm6150),
++	.vfe_num = ARRAY_SIZE(vfe_res_sm6150),
++};
++
+ static const struct camss_resources sm8250_resources = {
+ 	.version = CAMSS_8250,
+ 	.pd_name = "top",
+@@ -5131,6 +5328,7 @@ static const struct of_device_id camss_dt_match[] = {
+ 	{ .compatible = "qcom,sdm660-camss", .data = &sdm660_resources },
+ 	{ .compatible = "qcom,sdm670-camss", .data = &sdm670_resources },
+ 	{ .compatible = "qcom,sdm845-camss", .data = &sdm845_resources },
++	{ .compatible = "qcom,sm6150-camss", .data = &sm6150_resources },
+ 	{ .compatible = "qcom,sm8250-camss", .data = &sm8250_resources },
+ 	{ .compatible = "qcom,sm8550-camss", .data = &sm8550_resources },
+ 	{ .compatible = "qcom,sm8650-camss", .data = &sm8650_resources },
+diff --git a/drivers/media/platform/qcom/camss/camss.h b/drivers/media/platform/qcom/camss/camss.h
+index e34f06b4e153..6d048414c919 100644
+--- a/drivers/media/platform/qcom/camss/camss.h
++++ b/drivers/media/platform/qcom/camss/camss.h
+@@ -80,6 +80,7 @@ enum pm_domain {
+ enum camss_version {
+ 	CAMSS_660,
+ 	CAMSS_2290,
++	CAMSS_6150,
+ 	CAMSS_7280,
+ 	CAMSS_8x16,
+ 	CAMSS_8x39,

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0013-dt-bindings-i2c-qcom-cci-Document-sm6150-compatible.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0013-dt-bindings-i2c-qcom-cci-Document-sm6150-compatible.patch
@@ -1,0 +1,37 @@
+From 9b18ad5bceccd82af76307ef4bae2b5526a562a9 Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Thu, 22 Jan 2026 18:48:53 +0800
+Subject: [PATCH] dt-bindings: i2c: qcom-cci: Document sm6150 compatible
+
+Add the sm6150 CCI device string compatible.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260122-sm6150_evk-v5-2-039b170450a3@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260122-sm6150_evk-v5-2-039b170450a3@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Reviewed-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+---
+ Documentation/devicetree/bindings/i2c/qcom,i2c-cci.yaml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/i2c/qcom,i2c-cci.yaml b/Documentation/devicetree/bindings/i2c/qcom,i2c-cci.yaml
+index 399a09409e07..35d3a0685ac4 100644
+--- a/Documentation/devicetree/bindings/i2c/qcom,i2c-cci.yaml
++++ b/Documentation/devicetree/bindings/i2c/qcom,i2c-cci.yaml
+@@ -34,6 +34,7 @@ properties:
+               - qcom,sc8280xp-cci
+               - qcom,sdm670-cci
+               - qcom,sdm845-cci
++              - qcom,sm6150-cci
+               - qcom,sm6350-cci
+               - qcom,sm8250-cci
+               - qcom,sm8450-cci
+@@ -251,6 +252,7 @@ allOf:
+           contains:
+             enum:
+               - qcom,sa8775p-cci
++              - qcom,sm6150-cci
+               - qcom,sm8550-cci
+               - qcom,sm8650-cci
+               - qcom,x1e80100-cci

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0014-media-i2c-imx412-Assert-reset-GPIO-during-probe.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0014-media-i2c-imx412-Assert-reset-GPIO-during-probe.patch
@@ -1,0 +1,29 @@
+From 45620f4c73544407abf86b3bac34b754f244e204 Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Fri, 23 Jan 2026 17:19:55 +0800
+Subject: [PATCH] media: i2c: imx412: Assert reset GPIO during probe
+
+Assert the reset GPIO before first power up. This avoids a mismatch where
+the first power up (when the reset GPIO defaults deasserted) differs from
+subsequent cycles.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260123-imx412-v7-1-e58303f2b76b@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260123-imx412-v7-1-e58303f2b76b@oss.qualcomm.com/
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ drivers/media/i2c/imx412.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/imx412.c b/drivers/media/i2c/imx412.c
+index b3826f803547..aa63dfc34918 100644
+--- a/drivers/media/i2c/imx412.c
++++ b/drivers/media/i2c/imx412.c
+@@ -925,7 +925,7 @@ static int imx412_parse_hw_config(struct imx412 *imx412)
+ 
+ 	/* Request optional reset pin */
+ 	imx412->reset_gpio = devm_gpiod_get_optional(imx412->dev, "reset",
+-						     GPIOD_OUT_LOW);
++						     GPIOD_OUT_HIGH);
+ 	if (IS_ERR(imx412->reset_gpio)) {
+ 		dev_err(imx412->dev, "failed to get reset gpio %pe\n",
+ 			imx412->reset_gpio);

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0015-media-i2c-imx412-Extend-the-power-on-waiting-time.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0015-media-i2c-imx412-Extend-the-power-on-waiting-time.patch
@@ -1,0 +1,36 @@
+From f748ec1cc1df471ebd212056f6e3fef25de0e92c Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Fri, 23 Jan 2026 17:19:56 +0800
+Subject: [PATCH] media: i2c: imx412: Extend the power-on waiting time
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Arducam IMX577 module requires a longer reset time than the 1000µs
+configured in the current driver. Increase the wait time after power-on
+to ensure proper initialization.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260123-imx412-v7-2-e58303f2b76b@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260123-imx412-v7-2-e58303f2b76b@oss.qualcomm.com/
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ drivers/media/i2c/imx412.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/imx412.c b/drivers/media/i2c/imx412.c
+index aa63dfc34918..e25e0a9ff65c 100644
+--- a/drivers/media/i2c/imx412.c
++++ b/drivers/media/i2c/imx412.c
+@@ -1037,7 +1037,11 @@ static int imx412_power_on(struct device *dev)
+ 		goto error_reset;
+ 	}
+ 
+-	usleep_range(1000, 1200);
++	/*
++	 * Certain Arducam IMX577 module variants require a longer reset settle
++	 * time. Increasing the delay from 1ms to 10ms ensures reliable startup.
++	 */
++	usleep_range(10000, 12000);
+ 
+ 	return 0;
+ 

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0016-arm64-dts-qcom-talos-Add-camss-node.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0016-arm64-dts-qcom-talos-Add-camss-node.patch
@@ -1,0 +1,227 @@
+From ee27472652c5e679caf4ddcf99a6605163f1d57e Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Thu, 22 Jan 2026 18:48:52 +0800
+Subject: [PATCH] arm64: dts: qcom: talos: Add camss node
+
+Add node for the SM6150 camera subsystem.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260122-sm6150_evk-v5-1-039b170450a3@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260122-sm6150_evk-v5-1-039b170450a3@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/talos.dtsi | 200 ++++++++++++++++++++++++++++
+ 1 file changed, 200 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/talos.dtsi b/arch/arm64/boot/dts/qcom/talos.dtsi
+index 008dcced46a9..7cc0c22c36cb 100644
+--- a/arch/arm64/boot/dts/qcom/talos.dtsi
++++ b/arch/arm64/boot/dts/qcom/talos.dtsi
+@@ -3945,6 +3945,206 @@ videocc: clock-controller@ab00000 {
+ 			#power-domain-cells = <1>;
+ 		};
+ 
++		camss: isp@acb3000 {
++			compatible = "qcom,sm6150-camss";
++
++			reg = <0x0 0x0acb3000 0x0 0x1000>,
++			      <0x0 0x0acba000 0x0 0x1000>,
++			      <0x0 0x0acc8000 0x0 0x1000>,
++			      <0x0 0x0ac65000 0x0 0x1000>,
++			      <0x0 0x0ac66000 0x0 0x1000>,
++			      <0x0 0x0ac67000 0x0 0x1000>,
++			      <0x0 0x0acaf000 0x0 0x4000>,
++			      <0x0 0x0acb6000 0x0 0x4000>,
++			      <0x0 0x0acc4000 0x0 0x4000>,
++			      <0x0 0x0ac6f000 0x0 0x3000>,
++			      <0x0 0x0ac42000 0x0 0x5000>,
++			      <0x0 0x0ac48000 0x0 0x1000>,
++			      <0x0 0x0ac40000 0x0 0x1000>,
++			      <0x0 0x0ac18000 0x0 0x3000>,
++			      <0x0 0x0ac00000 0x0 0x6000>,
++			      <0x0 0x0ac10000 0x0 0x8000>,
++			      <0x0 0x0ac87000 0x0 0x3000>,
++			      <0x0 0x0ac52000 0x0 0x4000>,
++			      <0x0 0x0ac4e000 0x0 0x4000>,
++			      <0x0 0x0ac6b000 0x0 0x0a00>;
++			reg-names = "csid0",
++				    "csid1",
++				    "csid_lite",
++				    "csiphy0",
++				    "csiphy1",
++				    "csiphy2",
++				    "vfe0",
++				    "vfe1",
++				    "vfe_lite",
++				    "bps",
++				    "camnoc",
++				    "cpas_cdm",
++				    "cpas_top",
++				    "icp_csr",
++				    "icp_qgic",
++				    "icp_sierra",
++				    "ipe0",
++				    "jpeg_dma",
++				    "jpeg_enc",
++				    "lrme";
++
++			clocks = <&gcc GCC_CAMERA_AHB_CLK>,
++				 <&gcc GCC_CAMERA_HF_AXI_CLK>,
++				 <&camcc CAM_CC_CAMNOC_AXI_CLK>,
++				 <&camcc CAM_CC_CPAS_AHB_CLK>,
++				 <&camcc CAM_CC_CSIPHY0_CLK>,
++				 <&camcc CAM_CC_CSI0PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY1_CLK>,
++				 <&camcc CAM_CC_CSI1PHYTIMER_CLK>,
++				 <&camcc CAM_CC_CSIPHY2_CLK>,
++				 <&camcc CAM_CC_CSI2PHYTIMER_CLK>,
++				 <&camcc CAM_CC_SOC_AHB_CLK>,
++				 <&camcc CAM_CC_IFE_0_CLK>,
++				 <&camcc CAM_CC_IFE_0_AXI_CLK>,
++				 <&camcc CAM_CC_IFE_0_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_0_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_1_CLK>,
++				 <&camcc CAM_CC_IFE_1_AXI_CLK>,
++				 <&camcc CAM_CC_IFE_1_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_1_CSID_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
++				 <&camcc CAM_CC_IFE_LITE_CSID_CLK>,
++				 <&camcc CAM_CC_BPS_CLK>,
++				 <&camcc CAM_CC_BPS_AHB_CLK>,
++				 <&camcc CAM_CC_BPS_AXI_CLK>,
++				 <&camcc CAM_CC_BPS_AREG_CLK>,
++				 <&camcc CAM_CC_ICP_CLK>,
++				 <&camcc CAM_CC_IPE_0_CLK>,
++				 <&camcc CAM_CC_IPE_0_AHB_CLK>,
++				 <&camcc CAM_CC_IPE_0_AREG_CLK>,
++				 <&camcc CAM_CC_IPE_0_AXI_CLK>,
++				 <&camcc CAM_CC_JPEG_CLK>,
++				 <&camcc CAM_CC_LRME_CLK>;
++			clock-names = "gcc_ahb",
++				      "gcc_axi_hf",
++				      "camnoc_axi",
++				      "cpas_ahb",
++				      "csiphy0",
++				      "csiphy0_timer",
++				      "csiphy1",
++				      "csiphy1_timer",
++				      "csiphy2",
++				      "csiphy2_timer",
++				      "soc_ahb",
++				      "vfe0",
++				      "vfe0_axi",
++				      "vfe0_cphy_rx",
++				      "vfe0_csid",
++				      "vfe1",
++				      "vfe1_axi",
++				      "vfe1_cphy_rx",
++				      "vfe1_csid",
++				      "vfe_lite",
++				      "vfe_lite_cphy_rx",
++				      "vfe_lite_csid",
++				      "bps",
++				      "bps_ahb",
++				      "bps_axi",
++				      "bps_areg",
++				      "icp",
++				      "ipe0",
++				      "ipe0_ahb",
++				      "ipe0_areg",
++				      "ipe0_axi",
++				      "jpeg",
++				      "lrme";
++
++			interconnects = <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_CAMERA_CFG QCOM_ICC_TAG_ACTIVE_ONLY>,
++					<&mmss_noc MASTER_CAMNOC_HF0 QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&mmss_noc MASTER_CAMNOC_HF1 QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&mmss_noc MASTER_CAMNOC_SF QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "ahb",
++					     "hf_0",
++					     "hf_1",
++					     "sf_mnoc";
++
++			interrupts = <GIC_SPI 464 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 466 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 468 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 477 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 478 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 479 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 465 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 467 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 469 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 459 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 461 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 463 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 475 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 474 IRQ_TYPE_EDGE_RISING 0>,
++				     <GIC_SPI 476 IRQ_TYPE_EDGE_RISING 0>;
++			interrupt-names = "csid0",
++					  "csid1",
++					  "csid_lite",
++					  "csiphy0",
++					  "csiphy1",
++					  "csiphy2",
++					  "vfe0",
++					  "vfe1",
++					  "vfe_lite",
++					  "camnoc",
++					  "cdm",
++					  "icp",
++					  "jpeg_dma",
++					  "jpeg_enc",
++					  "lrme";
++
++			iommus = <&apps_smmu 0x0820 0x40>,
++				 <&apps_smmu 0x0840 0x00>,
++				 <&apps_smmu 0x0860 0x40>,
++				 <&apps_smmu 0x0c00 0x00>,
++				 <&apps_smmu 0x0cc0 0x00>,
++				 <&apps_smmu 0x0c80 0x00>,
++				 <&apps_smmu 0x0ca0 0x00>,
++				 <&apps_smmu 0x0d00 0x00>,
++				 <&apps_smmu 0x0d20 0x00>,
++				 <&apps_smmu 0x0d40 0x00>,
++				 <&apps_smmu 0x0d80 0x20>,
++				 <&apps_smmu 0x0da0 0x20>,
++				 <&apps_smmu 0x0de2 0x00>;
++
++			power-domains = <&camcc IFE_0_GDSC>,
++					<&camcc IFE_1_GDSC>,
++					<&camcc TITAN_TOP_GDSC>,
++					<&camcc BPS_GDSC>,
++					<&camcc IPE_0_GDSC>;
++			power-domain-names = "ife0",
++					     "ife1",
++					     "top",
++					     "bps",
++					     "ipe";
++
++			status = "disabled";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++				};
++
++				port@1 {
++					reg = <1>;
++				};
++
++				port@2 {
++					reg = <2>;
++				};
++			};
++		};
++
+ 		camcc: clock-controller@ad00000 {
+ 			compatible = "qcom,qcs615-camcc";
+ 			reg = <0 0x0ad00000 0 0x10000>;

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0017-arm64-dts-qcom-talos-Add-CCI-definitions.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0017-arm64-dts-qcom-talos-Add-CCI-definitions.patch
@@ -1,0 +1,85 @@
+From 6b8b27216d424305ea5ac59969d8e180d2ff9376 Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Thu, 22 Jan 2026 18:48:54 +0800
+Subject: [PATCH] arm64: dts: qcom: talos: Add CCI definitions
+
+Qualcomm Talos SoC contains single controller,
+containing 2 I2C hosts.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260122-sm6150_evk-v5-3-039b170450a3@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260122-sm6150_evk-v5-3-039b170450a3@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/talos.dtsi | 51 +++++++++++++++++++++++++++++
+ 1 file changed, 51 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/talos.dtsi b/arch/arm64/boot/dts/qcom/talos.dtsi
+index 7cc0c22c36cb..3ba8bf03c655 100644
+--- a/arch/arm64/boot/dts/qcom/talos.dtsi
++++ b/arch/arm64/boot/dts/qcom/talos.dtsi
+@@ -1571,6 +1571,22 @@ tlmm: pinctrl@3100000 {
+ 			#interrupt-cells = <2>;
+ 			wakeup-parent = <&pdc>;
+ 
++			cci_i2c0_default: cci-i2c0-default-state {
++				/* SDA, SCL */
++				pins = "gpio32", "gpio33";
++				function = "cci_i2c";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			cci_i2c1_default: cci-i2c1-default-state {
++				/* SDA, SCL */
++				pins = "gpio34", "gpio35";
++				function = "cci_i2c";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
+ 			qup_i2c1_data_clk: qup-i2c1-data-clk-state {
+ 				pins = "gpio4", "gpio5";
+ 				function = "qup0";
+@@ -3945,6 +3961,41 @@ videocc: clock-controller@ab00000 {
+ 			#power-domain-cells = <1>;
+ 		};
+ 
++		cci: cci@ac4a000 {
++			compatible = "qcom,sm6150-cci", "qcom,msm8996-cci";
++
++			reg = <0x0 0x0ac4a000 0x0 0x4000>;
++			interrupts = <GIC_SPI 460 IRQ_TYPE_EDGE_RISING 0>;
++			power-domains = <&camcc TITAN_TOP_GDSC>;
++			clocks = <&camcc CAM_CC_SOC_AHB_CLK>,
++				 <&camcc CAM_CC_CPAS_AHB_CLK>,
++				 <&camcc CAM_CC_CCI_CLK>;
++			clock-names = "camnoc_axi",
++				      "cpas_ahb",
++				      "cci";
++			pinctrl-0 = <&cci_i2c0_default &cci_i2c1_default>;
++			pinctrl-names = "default";
++
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			status = "disabled";
++
++			cci_i2c0: i2c-bus@0 {
++				reg = <0>;
++				clock-frequency = <1000000>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++
++			cci_i2c1: i2c-bus@1 {
++				reg = <1>;
++				clock-frequency = <1000000>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++		};
++
+ 		camss: isp@acb3000 {
+ 			compatible = "qcom,sm6150-camss";
+ 

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0018-arm64-dts-qcom-talos-Add-camera-MCLK-pinctrl.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0018-arm64-dts-qcom-talos-Add-camera-MCLK-pinctrl.patch
@@ -1,0 +1,56 @@
+From 763131d892395cadc967e658fe61a2cb48414e38 Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Thu, 22 Jan 2026 18:48:55 +0800
+Subject: [PATCH] arm64: dts: qcom: talos: Add camera MCLK pinctrl
+
+Define pinctrl definitions to enable camera master clocks on Talos.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260122-sm6150_evk-v5-4-039b170450a3@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260122-sm6150_evk-v5-4-039b170450a3@oss.qualcomm.com/
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/talos.dtsi | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/talos.dtsi b/arch/arm64/boot/dts/qcom/talos.dtsi
+index 3ba8bf03c655..af7f8643a10a 100644
+--- a/arch/arm64/boot/dts/qcom/talos.dtsi
++++ b/arch/arm64/boot/dts/qcom/talos.dtsi
+@@ -1571,6 +1571,34 @@ tlmm: pinctrl@3100000 {
+ 			#interrupt-cells = <2>;
+ 			wakeup-parent = <&pdc>;
+ 
++			cam0_default: cam0-default-state {
++				pins = "gpio28";
++				function = "cam_mclk";
++				drive-strength = <2>;
++				bias-disable;
++			};
++
++			cam1_default: cam1-default-state {
++				pins = "gpio29";
++				function = "cam_mclk";
++				drive-strength = <2>;
++				bias-disable;
++			};
++
++			cam2_default: cam2-default-state {
++				pins = "gpio30";
++				function = "cam_mclk";
++				drive-strength = <2>;
++				bias-disable;
++			};
++
++			cam3_default: cam3-default-state {
++				pins = "gpio31";
++				function = "cam_mclk";
++				drive-strength = <2>;
++				bias-disable;
++			};
++
+ 			cci_i2c0_default: cci-i2c0-default-state {
+ 				/* SDA, SCL */
+ 				pins = "gpio32", "gpio33";

--- a/recipes-kernel/linux/linux-qcom-next/qcs615/0019-arm64-dts-qcom-talos-evk-camera-Add-DT-overlay.patch
+++ b/recipes-kernel/linux/linux-qcom-next/qcs615/0019-arm64-dts-qcom-talos-evk-camera-Add-DT-overlay.patch
@@ -1,0 +1,106 @@
+From 894a35f76253799e1c51832047d477170970bb2e Mon Sep 17 00:00:00 2001
+From: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+Date: Thu, 22 Jan 2026 18:48:56 +0800
+Subject: [PATCH] arm64: dts: qcom: talos-evk-camera: Add DT overlay
+
+Enable IMX577 via CCI on Taloss EVK Core Kit.
+
+The Talos EVK board does not include a camera sensor
+by default, this DTSO has enabled the Arducam 12.3MP
+IMX577 Mini Camera Module on the CSI-1 interface.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260122-sm6150_evk-v5-5-039b170450a3@oss.qualcomm.com]
+Link: https://lore.kernel.org/all/20260122-sm6150_evk-v5-5-039b170450a3@oss.qualcomm.com/
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Signed-off-by: Wenmeng Liu <wenmeng.liu@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/Makefile             |  3 +
+ .../dts/qcom/talos-evk-camera-imx577.dtso     | 63 +++++++++++++++++++
+ 2 files changed, 66 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/qcom/talos-evk-camera-imx577.dtso
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index 76ab65939023..8627d9fe7ff0 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -379,8 +379,11 @@ dtb-$(CONFIG_ARCH_QCOM)	+= sm8650-qrd.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8750-mtp.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8750-qrd.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-camera-imx577.dtbo
++talos-evk-camera-imx577-dtbs	:= talos-evk.dtb talos-evk-camera-imx577.dtbo
+ talos-evk-lvds-auo,g133han01-dtbs	:= \
+ 	talos-evk.dtb talos-evk-lvds-auo,g133han01.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-camera-imx577.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-lvds-auo,g133han01.dtb
+ x1e001de-devkit-el2-dtbs	:= x1e001de-devkit.dtb x1-el2.dtbo
+ dtb-$(CONFIG_ARCH_QCOM)	+= x1e001de-devkit.dtb x1e001de-devkit-el2.dtb
+diff --git a/arch/arm64/boot/dts/qcom/talos-evk-camera-imx577.dtso b/arch/arm64/boot/dts/qcom/talos-evk-camera-imx577.dtso
+new file mode 100644
+index 000000000000..53006a861878
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/talos-evk-camera-imx577.dtso
+@@ -0,0 +1,63 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/clock/qcom,qcs615-camcc.h>
++#include <dt-bindings/gpio/gpio.h>
++
++&camss {
++	vdd-csiphy-1p2-supply = <&vreg_l11a>;
++	vdd-csiphy-1p8-supply = <&vreg_l12a>;
++
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@1 {
++			reg = <1>;
++
++			csiphy1_ep: endpoint {
++				data-lanes = <0 1 2 3>;
++				remote-endpoint = <&imx577_ep1>;
++			};
++		};
++	};
++};
++
++&cci {
++	status = "okay";
++};
++
++&cci_i2c1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	camera@1a {
++		compatible = "sony,imx577";
++		reg = <0x1a>;
++
++		reset-gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&cam2_default>;
++		pinctrl-names = "default";
++
++		clocks = <&camcc CAM_CC_MCLK2_CLK>;
++		assigned-clocks = <&camcc CAM_CC_MCLK2_CLK>;
++		assigned-clock-rates = <24000000>;
++
++		avdd-supply = <&vreg_s4a>;
++
++		port {
++			imx577_ep1: endpoint {
++				link-frequencies = /bits/ 64 <600000000>;
++				data-lanes = <1 2 3 4>;
++				remote-endpoint = <&csiphy1_ep>;
++			};
++		};
++	};
++};

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -20,6 +20,9 @@ SRCBRANCH:class-devupstream ?= "branch=qcom-next"
 
 SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
 
+# Apply additional qcom patches
+require ${PN}/qcs615.inc
+
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \


### PR DESCRIPTION
Since kernel issues on other platforms block tips update in linux‑qcom‑next,
we temporarily backported the required Talos‑EVK DT/Driver changes(include
talos-evk base DT, camera DT and drivers) into the linux‑qcom‑next
recipe to unblock enablement workflow.
    PR Links: 
    https://github.com/qualcomm-linux/kernel-topics/pull/549
    https://github.com/qualcomm-linux/kernel-topics/pull/565
    https://github.com/qualcomm-linux/kernel-topics/pull/567