### PR TITLE
firmware-qcom-boot-qcs615: update to 00116.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00114.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00114.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a5cd09352d760699ca79d76b28a20f6519db8d2c3b121074c15235d01f7e3a76"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00116.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "e9552e73ebde1a814fd4452540826d3cf4f25d70a98ab508a7afe860b1fb24a9"


### PR DESCRIPTION
=== Build Information ===
Meta_Build_ID: QCS615.LE.1.0-00095-STD.PROD-1
Timestamp: 2026-02-04 04:39:36

=== Selected Image Build IDs ===
TZ: TZ.XF.5.29.1-00132-KODIAKAAAAANAAZT-1
BOOT: BOOT.MXF.1.0.c1-00449-KODIAKLA-1
AOP: AOP.HO.3.6.2-00007-SM6150AUAAANAZO-1
TZ_APPS: TZ.APPS.1.29-00318-KODIAKAAAAANAZT-1

Known changes:
    - Support FIT dtb
    - Minor fixes for the CDT of Talos EVK

External link:
https://qartifactory-edge.qualcomm.com/ui/native/qsc_releases/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcs615-le-1-0