### PR TITLE
Ci rt config

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -28,3 +28,8 @@ QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-8275-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+   'linux-qcom-rt',\
+   ' rcupdate.rcu_expedited=1 rcu_nocbs=3 isolcpus=3 irqaffinity=0-2,3-7 cpuidle.off=1',\
+   '', d)}"

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -28,3 +28,9 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-9075-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+   ' linux-qcom-rt',\
+   ' rcupdate.rcu_expedited=1 rcu_nocbs=7 isolcpus=7 irqaffinity=0-6 cpuidle.off=1',\
+   '', d)}"
+

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -21,3 +21,8 @@ QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcm6490-idp/ufs"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+    'linux-qcom-rt',\
+    ' rcupdate.rcu_expedited=1 rcu_nocbs=7 isolcpus=7 irqaffinity=0-6 cpuidle.off=1',\
+    '', d)}"

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -29,3 +29,8 @@ QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs8300-ride-sx/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+     'linux-qcom-rt',\
+     ' rcupdate.rcu_expedited=1 rcu_nocbs=3 isolcpus=3 irqaffinity=0-2,4-7 cpuidle.off=1',\
+     '', d)}"

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -32,3 +32,8 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs9100-ride-sx/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+    'linux-qcom-rt', \
+    ' rcupdate.rcu_expedited=1 rcu_nocbs=7 isolcpus=7 irqaffinity=0-6 cpuidle.off=1',\
+    '', d)}"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -31,3 +31,8 @@ QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs6490-rb3gen2/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
+
+KERNEL_CMDLINE_EXTRA .= "${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/kernel',\
+     'linux-qcom-rt',\
+     ' rcupdate.rcu_expedited=1 rcu_nocbs=7 isolcpus=7 irqaffinity=0-6 cpuidle.off=1',\
+     '', d)}"


### PR DESCRIPTION
Updated following in meta-qcom/ci/linux-qcom-rt-6.18.yml:
1. kernel cmdline parameters in for Kodiak, Lemans, Monaco & Talos
2. cyclictest
3. stress-ng

orbit CR: https://orbit/CR/4434203 