### PR TITLE
hexagon-dsp-binaries: backport DSP_LIBRARY_PATH for Lemans Ride

### DIFF
--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries/0001-conf-add-DSP_LIBRARY_PATH-for-Lemans-Ride-variants.patch
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries/0001-conf-add-DSP_LIBRARY_PATH-for-Lemans-Ride-variants.patch
@@ -1,0 +1,36 @@
+From 84afe907a9a9a78019822da850d5e38776c0117e Mon Sep 17 00:00:00 2001
+From: Ekansh Gupta <ekansh.gupta@oss.qualcomm.com>
+Date: Tue, 27 Jan 2026 10:43:44 +0530
+Subject: [PATCH] conf: add DSP_LIBRARY_PATH for Lemans Ride variants
+
+Add machine mappings for:
+- "Qualcomm Technologies, Inc. Lemans Ride"
+- "Qualcomm Technologies, Inc. Lemans Ride Rev3"
+
+This fixes the fastrpc library config parser warning where
+DSP_LIBRARY_PATH is not found for "Qualcomm Technologies, Inc.
+Lemans Ride" in /usr/share/qcom/conf.d/00-hexagon-dsp-binaries.yaml,
+and ensures Lemans Ride boards resolve the expected DSP library
+directory.
+
+Signed-off-by: Ekansh Gupta <ekansh.gupta@oss.qualcomm.com>
+Upstream-Status: Backport [https://github.com/linux-msm/hexagon-dsp-binaries/commit/84afe907a9a9a78019822da850d5e38776c0117e]
+---
+ 00-hexagon-dsp-binaries.yaml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/00-hexagon-dsp-binaries.yaml b/00-hexagon-dsp-binaries.yaml
+index d6c94e7..e8b9570 100644
+--- a/00-hexagon-dsp-binaries.yaml
++++ b/00-hexagon-dsp-binaries.yaml
+@@ -16,6 +16,10 @@ machines:
+     DSP_LIBRARY_PATH: "kaanapali/Qualcomm/Kaanapali-MTP/dsp"
+   "Qualcomm Technologies, Inc. Lemans EVK":
+     DSP_LIBRARY_PATH: "sa8775p/Qualcomm/IQ9075-EVK/dsp"
++  "Qualcomm Technologies, Inc. Lemans Ride":
++    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
++  "Qualcomm Technologies, Inc. Lemans Ride Rev3":
++    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
+   "Qualcomm Technologies, Inc. Monaco EVK":
+     DSP_LIBRARY_PATH: "qcs8300/Qualcomm/IQ8275-EVK/dsp"
+   "Qualcomm Technologies, Inc. QCS615 Ride (IQ-615 Beta EVK)":

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260110.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260110.bb
@@ -23,6 +23,7 @@ NO_GENERIC_LICENSE[dspso-WHENCE] = "WHENCE"
 SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk;tag=${PV} \
     file://0001-conf-link-DB845c-to-SDM845-HDK.patch \
+    file://0001-conf-add-DSP_LIBRARY_PATH-for-Lemans-Ride-variants.patch \
 "
 
 SRCREV = "9efc74739b457bed846e53bb8cf46d524ce58791"


### PR DESCRIPTION
Backport DSP_LIBRARY_PATH entries for:
- "Qualcomm Technologies, Inc. Lemans Ride"
- "Qualcomm Technologies, Inc. Lemans Ride Rev3"

This eliminates the fastrpc config warning caused by missing DSP_LIBRARY_PATH mappings and ensures Lemans Ride boards resolve the correct DSP library directory.