### PR TITLE
Purwa(IQ-X5121) IOT EVK enablement

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -144,6 +144,7 @@ jobs:
           - iq-615-evk
           - iq-8275-evk
           - iq-9075-evk
+          - iq-x5121-evk
           - iq-x7181-evk
           - kaanapali-mtp
           - qcm6490-idp

--- a/ci/iq-x5121-evk.yml
+++ b/ci/iq-x5121-evk.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: iq-x5121-evk

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -35,6 +35,7 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine] = " \
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subtype3"
+FIT_DTB_COMPATIBLE[purwa-iot-evk] = "qcom,purwa-evk"
 FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"
 FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo] = "qcom,apq8064"
 FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410] = "qcom,apq8064-ifc6410"

--- a/conf/machine/include/qcom-purwa.inc
+++ b/conf/machine/include/qcom-purwa.inc
@@ -1,0 +1,19 @@
+# Configurations and variables for Purwa SoC family.
+
+SOC_FAMILY = "purwa"
+require conf/machine/include/qcom-base.inc
+require conf/machine/include/qcom-common.inc
+
+QCOM_VFAT_SECTOR_SIZE = "512"
+
+DEFAULTTUNE = "armv8-6a-crypto"
+require conf/machine/include/arm/arch-armv8-6a.inc
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+    packagegroup-machine-essential-qcom-purwa-soc \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -1,0 +1,27 @@
+#@TYPE: Machine
+#@NAME: Qualcomm Purwa IoT Evaluation Kit (EVK) based on IQ-X5121
+#@DESCRIPTION: Machine configuration for Qualcomm IQ-X5121 Evaluation Kit (EVK)
+
+require conf/machine/include/qcom-purwa.inc
+
+MACHINE_FEATURES += "efi pci"
+
+QCOM_DTB_DEFAULT ?= "purwa-iot-evk"
+
+KERNEL_DEVICETREE ?= " \
+    qcom/purwa-iot-evk.dtb \
+    "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-purwa-iot-evk-firmware \
+    packagegroup-purwa-iot-evk-hexagon-dsp-binaries \
+"
+
+# IQ-X5121 and IQ-x7181 share the same partition configuration.
+QCOM_CDT_FILE = "IQ_X_EVK_CDT"
+QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/nvme"
+QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
+
+# IQ-X5121 and IQ-x7181 share the same boot firmware.
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"

--- a/recipes-bsp/images/initramfs-firmware-mega-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bb
@@ -12,6 +12,7 @@ PACKAGE_INSTALL += " \
     packagegroup-dragonboard820c-firmware \
     packagegroup-dragonboard845c-firmware \
     packagegroup-hamoa-iot-evk-firmware \
+    packagegroup-purwa-iot-evk-firmware \
     packagegroup-iq-8275-evk-firmware \
     packagegroup-iq-9075-evk-firmware \
     packagegroup-qcs615-ride-firmware \
@@ -24,6 +25,7 @@ PACKAGE_INSTALL += " \
     packagegroup-dragonboard820c-hexagon-dsp-binaries \
     packagegroup-dragonboard845c-hexagon-dsp-binaries \
     packagegroup-hamoa-iot-evk-hexagon-dsp-binaries \
+    packagegroup-purwa-iot-evk-hexagon-dsp-binaries \
     packagegroup-iq-8275-evk-hexagon-dsp-binaries \
     packagegroup-iq-9075-evk-hexagon-dsp-binaries \
     packagegroup-qcs615-ride-hexagon-dsp-binaries \

--- a/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
+++ b/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
@@ -6,6 +6,7 @@ PACKAGES = " \
     ${PN}-board-generic \
     ${PN}-qcom-generic \
     ${PN}-qcom-hamoa-soc \
+    ${PN}-qcom-purwa-soc \
     ${PN}-qcom-qcm2290-soc \
     ${PN}-qcom-qcs615-soc \
     ${PN}-qcom-qcs6490-soc \
@@ -113,6 +114,26 @@ RRECOMMENDS:${PN}-qcom-hamoa-soc += " \
     kernel-module-snd-soc-x1e80100 \
     kernel-module-tscrcc-x1e80100 \
     kernel-module-videocc-sm8550 \
+"
+
+RRECOMMENDS:${PN}-qcom-purwa-soc += " \
+    ${PN}-board-generic \
+    ${PN}-qcom-generic \
+    kernel-module-ath11k-pci \
+    kernel-module-ath12k \
+    kernel-module-camcc-x1p42100 \
+    kernel-module-dispcc-x1e80100 \
+    kernel-module-gpucc-x1p42100 \
+    kernel-module-lpasscc-sc8280xp \
+    kernel-module-pinctrl-sm8550-lpass-lpi \
+    kernel-module-pmic-glink \
+    kernel-module-pmic-glink-altmode \
+    kernel-module-pwrseq-qcom-wcn \
+    kernel-module-snd-soc-wcd938x \
+    kernel-module-snd-soc-wsa884x \
+    kernel-module-snd-soc-x1e80100 \
+    kernel-module-tscrcc-x1e80100 \
+    kernel-module-videocc-x1p42100 \
 "
 
 RRECOMMENDS:${PN}-qcom-qcm2290-soc += " \

--- a/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Packages for the Purwa IoT EVK platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+# WLAN/BT/Audio/Video/Compute share the same firmware as Hamoa
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g715 linux-firmware-qcom-x1p42100-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
+    linux-firmware-qcom-x1e80100-audio \
+    linux-firmware-qcom-x1e80100-compute \
+    linux-firmware-qcom-vpu \
+"
+
+# Purwa IoT EVK and Hamoa IoT EVK share the same Hexagon DSP binaries.
+RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-hamoa-iot-evk-adsp \
+    hexagon-dsp-binaries-qcom-hamoa-iot-evk-cdsp \
+"


### PR DESCRIPTION
To enable Purwa IoT EVK board on meta-qcom, includes:

1. Add machine conf.
2. Add firmware package group.
3. Add kas configuration and GitHub CI support.
~~4. Consume boot firmware from external release.~~ shared with Hamoa
~~5. Upgrade qcom-ptool to consume partition conf.~~ shared with Hamoa
6. Support to create flat build with non-hlos images for spinor.

Depends on:
~~1. https://github.com/qualcomm-linux/qcom-ptool/pull/68~~ Use the IQ-X7181 partition configuration directly
2. Need HNHLOS META external pushed #1781 
3. Base DT merged to qcom-next 6.18.y https://github.com/qualcomm-linux/kernel/pull/383 #1883 

Flat build directory structure as followed(Since Purwa EVK boot firmware is not pushed, this flat build cannot bootup now):
```
tmp/deploy/images/iq-x5121-evk/qcom-multimedia-image-iq-x5121-evk.rootfs.qcomflash/
├── dtb.bin
├── dtb-purwa-iot-evk-image.vfat
├── efi.bin
├── gpt_backup0.bin
├── gpt_both0.bin
├── gpt_main0.bin
├── patch0.xml
├── rawprogram0.xml
├── rootfs.img
├── spinor
│   ├── adsp_dtbs.elf
│   ├── adsp_lite.lzma
│   ├── aop_devcfg.mbn
│   ├── aop.mbn
│   ├── cdt.bin
│   ├── contents.xml
│   ├── cpucp_dtbs.elf
│   ├── cpucp.elf
│   ├── devcfg_iot.mbn
│   ├── dtb.bin
│   ├── gpt_backup0.bin
│   ├── gpt_both0.bin
│   ├── gpt_main0.bin
│   ├── hypvm.mbn
│   ├── imagefv.elf
│   ├── IQ_X_EVK_CDT.bin
│   ├── multi_image.mbn
│   ├── patch0.xml
│   ├── qupv3fw.elf
│   ├── rawprogram0.xml
│   ├── shrm.elf
│   ├── tz.mbn
│   ├── uefi_dtbs.xz
│   ├── uefi.elf
│   ├── uefi_sec.mbn
│   ├── xbl_config.elf
│   ├── XblRamdump.xz
│   ├── xbl_s_devprg_ns.melf
│   ├── xbl_s.melf
│   ├── zeros_1sector.bin
│   ├── zeros_33sectors.bin
│   └── zeros_5sectors.bin
├── vmlinux
├── xbl_s_devprg_ns.melf
├── zeros_1sector.bin
└── zeros_33sectors.bin
```
