### PR TITLE
packagegroup-iq-615-evk: Include camxfirmware in firmware packagegroup

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
@@ -12,6 +12,7 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a612 linux-firmware-qcom-qcs615-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
+    camxfirmware-talos \
     linux-firmware-qcom-qcs615-audio \
     linux-firmware-qcom-qcs615-compute \
     linux-firmware-qcom-venus-5.4 \


### PR DESCRIPTION
Add CAMERA_ICP, firmware required to support Qualcomm Camera X (CamX) on the board.