### PR TITLE
Add kas config for debug build

### DIFF
--- a/ci/debug.yml
+++ b/ci/debug.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+local_conf_header:
+  debug-build: |
+    DEBUG_BUILD = "1"


### PR DESCRIPTION
Add `debug.yml` kas configuration to enable builds with DEBUG_BUILD set to "1". 