### PR TITLE
iq-615-evk: enable upstream LVDS DTB compilation

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -10,6 +10,7 @@ QCOM_DTB_DEFAULT ?= "talos-evk"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \
+                      qcom/talos-evk-lvds-auo,g133han01.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Enable talos-evk-lvds-auo,g133han01.dtb compilation in linux-qcom-next

upstream link: https://lore.kernel.org/all/20260114100043.1310164-4-tessolveupstream@gmail.com/

Build result:
$ ls tmp/deploy/images/iq-615-evk/ -lh | grep lvds
-rw-r--r--  2 xinlon users 4.0M Feb 11 10:48 dtb-talos-evk-lvds-auo,g133han01-image.vfat
lrwxrwxrwx  2 xinlon users   32 Feb 11 10:49 talos-evk-lvds-auo,g133han01--6.18+6.19-rc6+git0+ccc1345fb4-r0-iq-615-evk-20260211024538.dtb -> talos-evk-lvds-auo,g133han01.dtb
-rw-r--r--  2 xinlon users 109K Feb 11 10:49 talos-evk-lvds-auo,g133han01.dtb
lrwxrwxrwx  2 xinlon users   32 Feb 11 10:49 talos-evk-lvds-auo,g133han01-iq-615-evk.dtb -> talos-evk-lvds-auo,g133han01.dtb
