### PR TITLE
workflows: update lava-test-plans to 1ab5e2f

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -27,7 +27,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: 9127456666ae1c095fe3fdd2918b95299c2ea1eb
+          ref: 1ab5e2f1d6cc3559ca4685941cc9fd17ab132c2d
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Update lava-test-plans ref to fix test job submissions to QCS615-ride.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>