### PR TITLE
Enable Talos upstream camera DTB compilation for linux-qcom kernel

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -10,6 +10,7 @@ QCOM_DTB_DEFAULT ?= "talos-evk"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \
+                      qcom/talos-evk-camera-imx577.dtbo \
                       qcom/talos-evk-lvds-auo,g133han01.dtbo \
                       "
 


### PR DESCRIPTION
Update recipe to pack upstream Camera dtbo into final dtb image of IQ-615-EVK (Talos-evk) platform.

