### PR TITLE
fit-dtb-compatible: add compatible strings for Kodiak lite boards

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -34,9 +34,18 @@ FIT_DTB_COMPATIBLE[qcs615-ride] = " \
                                     qcom,qcs615-adp \
                                     qcom,qcs615v1.1-adp \
 "
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = "qcom,qcs6490-iot"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = "qcom,qcs6490-iot-subtype9"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = "qcom,qcs6490-iot-subtype2"
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
+    qcom,qcs5430-iot \
+    qcom,qcs6490-iot \
+"
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
+    qcom,qcs5430-iot-subtype9 \
+    qcom,qcs6490-iot-subtype9 \
+"
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
+    qcom,qcs5430-iot-subtype2 \
+    qcom,qcs6490-iot-subtype2 \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = "qcom,qcs6490-iot-camx"
 FIT_DTB_COMPATIBLE[qcs8300-ride] = "qcom,qcs8300-adp"
 FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx] = "qcom,qcs8300-adp-camx"


### PR DESCRIPTION
Add qcs5430-iot, qcs5430-iot-subtype9 and qcs5430-iot-subtype2 compatible strings for kodiak lite industrial and vision mezzanine board to ensure the correct DTB is selected.