### PR TITLE
Enable linux-qcom-6.18 RT kernel builds for all machines

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -118,6 +118,9 @@ jobs:
           - type: 6.18
             dirname: "+linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
+          - type: rt-6.18
+            dirname: "+linux-qcom-rt-6.18"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
       - uses: actions/checkout@v4
@@ -170,6 +173,9 @@ jobs:
           - type: 6.18
             dirname: "+linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
+          - type: rt-6.18
+            dirname: "+linux-qcom-rt-6.18"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a
@@ -180,14 +186,6 @@ jobs:
                 type: additional
                 dirname: "+linux-yocto-dev"
                 yamlfile: ":ci/linux-yocto-dev.yml"
-          - machine: iq-9075-evk
-            distro:
-                name: qcom-distro
-                yamlfile: ':ci/qcom-distro-prop-image.yml'
-            kernel:
-                type: rt-6.18
-                dirname: "+linux-qcom-rt-6.18"
-                yamlfile: ":ci/linux-qcom-rt-6.18.yml"
           - machine: iq-9075-evk
             distro:
                 name: qcom-distro


### PR DESCRIPTION
Remove machine-specific build entries and enable linux-qcom-rt-6.18 builds
across the entire CI matrix. This provides comprehensive build and test coverage
of the RT kernel on all supported machines and distros.