### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260217

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260207
-SRCREV ?= "93be04f5fe1314eafb3293abc558e8ade4e8d2bb"
+# tag: qcom-6.18.y-20260217
+SRCREV ?= "faac849b351a06e9328b9af65035331a325de108"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Changelog:
WORKAROUND: scsi: ufs: core: Set uic_cmd_timeout to max
UPSTREAM: arm64: dts: qcom: talos: Correct UFS clocks ordering
FROMLIST: soc: qcom: ice: Add explicit power-domain and clock voting calls for ICE
FROMLIST: arm64: dts: qcom: sm8750: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8650: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8550: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8450: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: kodiak: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sc7180: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: monaco: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: lemans: Add power-domain and iface clk for ice node
FROMLIST: dt-bindings: crypto: qcom,ice: Require power-domain and iface clk
FROMLIST: arm64: dts: qcom: qcm6490-idp: add and enable BT node
FROMLIST: net: phy: qcom: qca808x: Add .get_rate_matching support
WORKAROUND: pci: quirks: Disable L1.1 and L1.2 for USB hub attach
WORKAROUND: phy: qcom: qmp-pcie: Add qref regulator vote for QCS8300
WORKAROUND: arm64: dts: qcom: Add qref supply for QCS8300
PENDING: arm64: dts: qcom: talos-evk-som: Enable Adreno 612 GPU
FROMLIST: arm64: dts: qcom: qcs615-ride: Enable Adreno 612 GPU
FROMLIST: arm64: dts: qcom: talos: Add gpu and rgmu nodes
FROMLIST: arm64: dts: qcom: talos: add the GPU SMMU node
Revert "FROMLIST: arm64: dts: qcom: talos: Add gpu and rgmu nodes"
Revert "FROMLIST: arm64: dts: qcom: qcs615-ride: Enable Adreno 612 GPU"
Revert "FROMLIST: arm64: dts: qcom: talos: add the GPU SMMU node"
FROMLIST: arm64: dts: qcom: rename qcs8300 to monaco
FROMLIST: arm64: dts: qcom: rename x1e80100 to hamoa
FROMLIST: remoteproc: qcom: pas: Enable Secure PAS support with IOMMU managed by Linux
FROMLIST: remoteproc: pas: Extend parse_fw callback to fetch resources via SMC call
FROMLIST: firmware: qcom_scm: Add qcom_scm_pas_get_rsc_table() to get resource table
FROMLIST: firmware: qcom_scm: Add SHM bridge handling for PAS when running without QHEE
FROMLIST: firmware: qcom_scm: Refactor qcom_scm_pas_init_image()
FROMLIST: firmware: qcom_scm: Add a prep version of auth_and_reset function
FROMLIST: soc: qcom: mdtloader: Remove qcom_mdt_pas_init() from exported symbols
FROMLIST: soc: qcom: mdtloader: Add PAS context aware qcom_mdt_pas_load() function
FROMLIST: remoteproc: pas: Replace metadata context with PAS context structure
FROMLIST: firmware: qcom_scm: Introduce PAS context allocator helper function
FROMLIST: firmware: qcom_scm: Rename peripheral as pas_id
FROMLIST: firmware: qcom_scm: Remove redundant piece of code
FROMLIST: dt-bindings: remoteproc: qcom,pas: Add iommus property
Revert "FROMLIST: dt-bindings: remoteproc: qcom,pas: Add iommus property"
Revert "FROMLIST: firmware: qcom_scm: Remove redundant piece of code"
Revert "FROMLIST: firmware: qcom_scm: Rename peripheral as pas_id"
Revert "FROMLIST: firmware: qcom_scm: Introduce PAS context initialization helper function"
Revert "FROMLIST: remoteproc: pas: Replace metadata context with PAS context structure"
Revert "FROMLIST: soc: qcom: mdtloader: Add PAS context aware qcom_mdt_pas_load() function"
Revert "FROMLIST: soc: qcom: mdtloader: Remove qcom_mdt_pas_init() from exported symbols"
Revert "FROMLIST: firmware: qcom_scm: Add a prep version of auth_and_reset function"
Revert "FROMLIST: firmware: qcom_scm: Refactor qcom_scm_pas_init_image()"
Revert "FROMLIST: firmware: qcom_scm: Add SHM bridge handling for PAS when running without QHEE"
Revert "FROMLIST: firmware: qcom_scm: Add qcom_scm_pas_get_rsc_table() to get resource table"
Revert "FROMLIST: remoteproc: pas: Extend parse_fw callback to fetch resources via SMC call"
Revert "FROMLIST: remoteproc: qcom: pas: Enable Secure PAS support with IOMMU managed by Linux"
BACKPORT: arm64: dts: qcom: talos: Add PMU support