### PR TITLE
Switch to multiDTB FIT on RB3Gen2-Core-Kit

### DIFF
--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-qcs6490.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "qcs6490-rb3gen2"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine.dtbo \


### PR DESCRIPTION
Remove explicit setting of `QCOM_DTB_DEFAULT` to enable multi-DTB support on RB3Gen2-Core-Kit.