### PR TITLE
ci/base: fix incorrect regex for CodeLinaro yocto-mirrors 

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -46,7 +46,7 @@ local_conf_header:
   clo-mirrors: |
     MIRRORS:append = " \
     git://github.com git://git.codelinaro.org/clo/yocto-mirrors/github/ \
-    git://.*/.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
+    git://.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |


### PR DESCRIPTION
Fix an incorrect regex used for matching CodeLinaro yocto-mirrors URLs.
The previous pattern assumed a single path component, which caused
incorrect mirror resolution for repositories hosted under nested paths.