### PR TITLE
linux-qcom: specify dummy revision for devupstream

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -29,7 +29,9 @@ SRC_URI += " \
 # virtual/kernel provider to 'linux-qcom-next-upstream'
 BBCLASSEXTEND = "devupstream:target"
 PN:class-devupstream = "linux-qcom-next-upstream"
-SRCREV:class-devupstream ?= "${AUTOREV}"
+
+# Pin this to the qcom-next-6.19-rc6-20260207, override this in local.conf
+SRCREV:class-devupstream ?= "ccc1345fb4742e377d7d89658efe085c62c25164"
 
 S = "${UNPACKDIR}/${BP}"
 

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -32,7 +32,9 @@ SRC_URI += " \
 # virtual/kernel provider to 'linux-qcom-6.18.y-upstream'
 BBCLASSEXTEND = "devupstream:target"
 PN:class-devupstream = "linux-qcom-6.18.y-upstream"
-SRCREV:class-devupstream ?= "${AUTOREV}"
+
+# Pin this to the qcom-6.18.y-20260207, override this in local.conf
+SRCREV:class-devupstream ?= "93be04f5fe1314eafb3293abc558e8ade4e8d2bb"
 
 S = "${UNPACKDIR}/${BP}"
 


### PR DESCRIPTION
While correct, specifying AUTOREV in a recipe makes bitbake query the repository while parsing. That in turn leads to build failures in case of offline builds.

Specify the same revision as current fixed revision for devupstream as well to avoid this. It should be overridden by the user in local.conf.