### PR TITLE
ci: workflows/build-yocto: add KAS_CLONE_DEPTH and drop KAS_REPO_REF_DIR

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   CACHE_DIR: /efs/qli/meta-qcom
-  KAS_REPO_REF_DIR: /efs/qli/meta-qcom/kas-mirrors
+  KAS_CLONE_DEPTH: 1
 
 jobs:
   kas-setup:
@@ -33,13 +33,6 @@ jobs:
           LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
           wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
           chmod +x ${KAS_CONTAINER}
-
-      - name: Update kas mirrors
-        run: |
-          for r in $(find ${KAS_REPO_REF_DIR}/* -maxdepth 0 -type d); do
-            echo "pre-fetch: $r"
-            git -C $r fetch --prune origin '+refs/*:refs/*'
-          done
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Perform shallow git clone/fetch using –depth=1 specified by this variable. This is useful in case CI always starts with empty work directory and this directory is always discarded after the CI run.
With the KAS_CLONE_DEPTH we can drop the KAS_REPO_REF_DIR and we no longer need to have our local storage since there is no benefit in having it.

This change considerably reduced the time from approximately 4 minutes to 40 seconds to run the entire job.