### PR TITLE
Add blacklist package for iris-video-dlkm

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm/blacklist-video.conf.venus
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm/blacklist-video.conf.venus
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+blacklist qcom_iris
+blacklist venus_dec
+blacklist venus_enc
+blacklist venus_core

--- a/recipes-kernel/iris-video-module/iris-video-dlkm/blacklist-video.conf.vidc
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm/blacklist-video.conf.vidc
@@ -1,0 +1,4 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+blacklist iris_vpu

--- a/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_git.bb
@@ -5,10 +5,14 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 PV = "0.0+git"
 
-SRC_URI = "git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.main"
+SRC_URI = " \
+    git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.main \
+    file://blacklist-video.conf.venus \
+    file://blacklist-video.conf.vidc \
+"
 SRCREV  = "0e0fe75fb1910e011358485b078ea207a5c5f3e7"
 
-inherit module
+inherit module update-alternatives
 
 MAKE_TARGETS = "modules"
 
@@ -16,3 +20,30 @@ MAKE_TARGETS = "modules"
 # Therefore, builds for other architectures are not necessary and are explicitly excluded.
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -Dm 0644 ${UNPACKDIR}/blacklist-video.conf.venus \
+            ${D}${sysconfdir}/modprobe.d/blacklist-video.conf.venus
+    install -Dm 0644 ${UNPACKDIR}/blacklist-video.conf.vidc \
+            ${D}${sysconfdir}/modprobe.d/blacklist-video.conf.vidc
+}
+
+PACKAGES += "${PN}-bl-venus ${PN}-bl-vidc"
+RDEPENDS:${PN} += "${PN}-bl-venus ${PN}-bl-vidc"
+
+FILES:${PN}-bl-venus += "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
+FILES:${PN}-bl-vidc += "${sysconfdir}/modprobe.d/blacklist-video.conf.vidc"
+
+ALTERNATIVE:${PN}-bl-vidc  = "blacklist-video"
+ALTERNATIVE_TARGET_${PN}-bl-vidc = "${sysconfdir}/modprobe.d/blacklist-video.conf.vidc"
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc = "50"
+
+# On QCS615, prioritize blacklisting unsupported Vidc.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:qcs615 = "150"
+
+ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
+ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
+ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"
+
+ALTERNATIVE_LINK_NAME[blacklist-video] = "${sysconfdir}/modprobe.d/blacklist-video.conf"


### PR DESCRIPTION
The iris-vpu downstream video driver conflicts with upstream qcom_iris and Venus drivers. Install modprobe configuration files to blacklist these upstream kernel modules when using the iris-vpu driver.

Also, provide update-alternatives for the blacklist configuration to allow users to switch between upstream and downstream video drivers at runtime.
