### PR TITLE
workflows: exclude AudioRecord test on RB8

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -27,7 +27,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: 1ab5e2f1d6cc3559ca4685941cc9fd17ab132c2d
+          ref: 6f79a2492a982d990238545efe3c66ccb87dbe22
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
AudioRecord test when executed on RB8 causes device to freeze. This causes the test job to timeout. Since the timeout is rather long, and the test never completes it should be disabled until it's fixed.

This patch corresponds to:
qualcomm-linux/lava-test-plans#16

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>