### PR TITLE
Enable Talos CAMX DTB compilation for linux-qcom kernel 

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -14,7 +14,7 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
-KERNEL_DEVICETREE:append:pn-linux-qcom ?= " \
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk-camx.dtb \
                       "
 


### PR DESCRIPTION
Include the downstream camera DTB for linux-qcom kernels so it appears in
the final image when using linux-qcom-next, linux-qcom-rt, and linux-qcom-next-rt
kernels on the IQ-615-EVK platform.