### PR TITLE
fit-dtb-compatible: update compatible string for kodiak lite core kit

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -41,8 +41,8 @@ FIT_DTB_COMPATIBLE[qcs615-ride] = " \
     qcom,qcs615v1.1-adp \
 "
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
-    qcom,qcs5430-iot \
-    qcom,qcs6490-iot \
+    qcom,qcs5430-iot-subtype5 \
+    qcom,qcs6490-iot-subtype5 \
 "
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
     qcom,qcs5430-iot-subtype9 \


### PR DESCRIPTION
Update QCS5430 Core Kit compatible string to use subtype5.

| Platform / Board       | CDT Subtype |
|------------------------|--------------- |
| Vision Mezzanine      | 2                    |
| Core Kit                     | 5                    |
| Industrial Mezzanine | 9                    |