### PR TITLE
ci: remove qcm6490 qmc2290 soc yaml file

### DIFF
--- a/ci/qcm2290.yml
+++ b/ci/qcm2290.yml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
-
-header:
-  version: 14
-  includes:
-  - ci/base.yml

--- a/ci/qcm6490-idp.yml
+++ b/ci/qcm6490-idp.yml
@@ -3,6 +3,6 @@
 header:
   version: 14
   includes:
-  - ci/qcm6490.yml
+  - ci/base.yml
 
 machine: qcm6490-idp

--- a/ci/qcm6490.yml
+++ b/ci/qcm6490.yml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
-
-header:
-  version: 14
-  includes:
-  - ci/base.yml

--- a/ci/rb1-core-kit.yml
+++ b/ci/rb1-core-kit.yml
@@ -3,6 +3,6 @@
 header:
   version: 14
   includes:
-  - ci/qcm2290.yml
+  - ci/base.yml
 
 machine: rb1-core-kit

--- a/ci/rb3gen2-core-kit.yml
+++ b/ci/rb3gen2-core-kit.yml
@@ -3,6 +3,6 @@
 header:
   version: 14
   includes:
-  - ci/qcm6490.yml
+  - ci/base.yml
 
 machine: rb3gen2-core-kit


### PR DESCRIPTION
qcm6490.yml and qcm2290.yml are effectively empty, only includes base.yml file. It was initially anticipated that we might need soc specific kas configuration, but it turns out we don't. For all recent machines (iq-*.yml and others) we simply include base.yml without using any soc yaml file.

Let's remove these 2 files.