### PR TITLE
ci/base: add image-buildinfo to the inherit list

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -33,6 +33,7 @@ local_conf_header:
     INHERIT += "buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+    INHERIT += "image-buildinfo"
   diskmon: |
     BB_DISKMON_DIRS ??= "\
       STOPTASKS,${TMPDIR},1G,100K \


### PR DESCRIPTION
Currently, meta_qcom builds do not display any information on the device that identifies the latest PR (or source revision) used to generate the build. After flashing a build, there is no straightforward way to confirm which PR or exact code state the device is running.
This makes it difficult to validate that the intended build was flashed, especially when testing multiple builds/devices and comparing results.

This will add the following in /etc/buildinfo
```
-----------------------
Build Configuration:  |
-----------------------
DISTRO = poky-altcfg
DISTRO_VERSION = 5.3.99+snapshot-2c20c05b324e5d6564c8554381019170839509bb
-----------------------
Layer Revisions:      |
-----------------------
repo              = buildinfo:f1fd263dd1b6adcb66a6df02a7cb1bb76e126fcb
meta-poky         = master:2486ce2889062500e39446bc07c7d21120a0345e
meta              = master:2c20c05b324e5d6564c8554381019170839509bb
```
Ref https://docs.yoctoproject.org/dev/ref-manual/classes.html#ref-classes-image-buildinfo

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1579