### PR TITLE
ci/qcs9100-ride-sx: Enable separate GPU KMS for dual DPU

### DIFF
--- a/ci/qcs9100-ride-sx.yml
+++ b/ci/qcs9100-ride-sx.yml
@@ -5,4 +5,8 @@ header:
   includes:
   - ci/base.yml
 
+local_conf_header:
+  extra_cmdline_dual_dpu: |
+    KERNEL_CMDLINE_EXTRA:append = " msm.separate_gpu_kms=1"
+
 machine: qcs9100-ride-sx


### PR DESCRIPTION
On QCS9100 Ride SX, enabling dual DPU configurations causes the GPU to bind to the first probed DPU by default. This binding prevents the second DPU from being successfully probed, effectively blocking dual-display support.

Add "msm.separate_gpu_kms=1" to the kernel command line. This allows the GPU and DPUs to be probed independently, ensuring that both DPU instances are initialized correctly.

Attaching PR link for the verified dual dpu changes for qcom-next
https://github.com/qualcomm-linux/kernel-topics/pull/693