### PR TITLE
qcom-armv8a: add camera IMX577 DTBO to KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -51,6 +51,11 @@ KERNEL_DEVICETREE ?= " \
     qcom/sm8750-mtp.dtb \
 "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/monaco-evk-camera-imx577.dtbo \
+"
+
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] ?= "2048"
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 QCOM_BOOTIMG_ROOTFS[apq8016-sbc] ?= "/dev/mmcblk0p14"


### PR DESCRIPTION
Add the camera overlay DTBO (IMX577) to KERNEL_DEVICETREE in the qcom-armv8a machine.
