### PR TITLE
rb3gen2-core-kit: add Industrial Mezzanine firmware packagegroup

### DIFF
--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -22,6 +22,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb3gen2-hexagon-dsp-binaries \
+    packagegroup-rb3gen2-industrial-mezzanine-firmware \
     qairt-sdk-hexagon-v68 \
     qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
 "


### PR DESCRIPTION
Including this packagegroup ensures that the required firmware for the Industrial Mezzanine.