### PR TITLE
firmware-qcom-sdm845-hdk: fix path for the SLPI firmware

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-sdm845-hdk.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sdm845-hdk.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "QCOM Firmware for SDM845 HDK (aka HDK845) board"
 LICENSE = "CLOSED"
 
 FW_QCOM_NAME = "sdm845-hdk"
-FW_QCOM_DIR = "sdm845/Qualcomm/SDM845-HDK"
+FW_QCOM_SUBDIR = "sdm845/Qualcomm/SDM845-HDK"
 
 # ADSP, CDSP, modem and WLAN are a part of linux-firmware
 FW_QCOM_LIST = "\


### PR DESCRIPTION
The recipe specifies FW_QCOM_DIR as a location of the device-specific firmware, however firmware-qcom.inc uses FW_QCOM_SUBDIR. Correct the variable name to move HDK-specific firmware (SLPI) to the correct location.

Fixes: 1cff03767926 ("firmware-qcom-sdm845-hdk: package SLPI firmware for SDM845-HDK")