### PR TITLE
Add kas configuration to generate mirror tarballs

### DIFF
--- a/ci/mirror-tarballs.yml
+++ b/ci/mirror-tarballs.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+local_conf_header:
+  generate_mirror_tarballs: |
+    BB_GENERATE_MIRROR_TARBALLS = "1"


### PR DESCRIPTION
Add a `mirror-tarballs.yml` kas configuration to enable generation of mirror tarballs by
setting `BB_GENERATE_MIRROR_TARBALLS = "1"`. This configuration can be appended
to other kas files to preserve source tarballs locally, for improving build reproducibility.