### PR TITLE
CI: lava-test-plans: correct URL locations for db410c / db820c

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -89,11 +89,13 @@ runs:
               cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-410c.ini
               echo "DEVICE_TYPE=dragonboard-410c" >> dragonboard-410c.ini
               echo "BOOT_IMG_FILE=boot-apq8016-sbc-qcom-armv8a.img" >> dragonboard-410c.ini
+              echo "BUILD_OS=${{ inputs.distro_name }}${{ inputs.kernel }}/" >> dragonboard-410c.ini
               cat dragonboard-410c.ini
               lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "projects/${GITHUB_REPOSITORY#*/}/devices/dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
               cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-820c.ini
               echo "BOOT_IMG_FILE=boot-apq8096-db820c-qcom-armv8a.img" >> dragonboard-820c.ini
               echo "DEVICE_TYPE=dragonboard-820c" >> dragonboard-820c.ini
+              echo "BUILD_OS=${{ inputs.distro_name }}${{ inputs.kernel }}/" >> dragonboard-820c.ini
               cat dragonboard-820c.ini
               lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${GITHUB_REPOSITORY#*/}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "projects/${GITHUB_REPOSITORY#*/}/devices/dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
               echo "MACHINE=dragonboard" >> $GITHUB_ENV


### PR DESCRIPTION
For fastboot machines we need to pass the "os" part of the URL, otherwise the script will default to "poky-altcfg" distro location. The issue can be seen e.g. at the linked job, where the qcom-distro job tries to download poky-altcfg artifacts.

Link: https://github.com/qualcomm-linux/meta-qcom/actions/runs/22125170350/job/63977535234