### PR TITLE
weston-init: add automatic multi-DPU detection and configuration

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,1 +1,26 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
 DEFAULTBACKEND:qcom ?= "drm"
+
+SRC_URI:append:qcom = " \
+    file://additional-devices.conf \
+    file://weston-start.sh \
+"
+
+do_compile:append:qcom() {
+    sed -i -e 's:@bindir@:${bindir}:g' ${WORKDIR}/sources/additional-devices.conf
+    sed -i -e 's:@bindir@:${bindir}:g' ${WORKDIR}/sources/weston-start.sh
+}
+
+do_install:append:qcom() {
+    install -d ${D}${systemd_system_unitdir}/weston.service.d
+    install -m 0644 ${WORKDIR}/sources/additional-devices.conf \
+        ${D}${systemd_system_unitdir}/weston.service.d/additional-devices.conf
+
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/sources/weston-start.sh \
+        ${D}${bindir}/weston-start.sh
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/weston.service.d/additional-devices.conf"
+FILES:${PN} += "${bindir}/weston-start.sh"

--- a/recipes-graphics/wayland/weston-init/additional-devices.conf
+++ b/recipes-graphics/wayland/weston-init/additional-devices.conf
@@ -1,0 +1,5 @@
+[Service]
+# Clear the original ExecStart from weston.service
+ExecStart=
+# Use weston script to dynamically detect and configure additional DRM devices
+ExecStart=@bindir@/weston-start.sh

--- a/recipes-graphics/wayland/weston-init/weston-start.sh
+++ b/recipes-graphics/wayland/weston-init/weston-start.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Weston startup script
+# Dynamically detects DRM cards and configures additional-devices parameter
+
+# Initialize options
+opts="--modules=systemd-notify.so"
+additional_cards=""
+first_kms_card=""
+kms_cards=""
+
+# Build a sorted list of KMS-capable cards by their platform path
+# This ensures consistent ordering regardless of probe order
+for path_link in /dev/dri/by-path/platform-*-card; do
+    # Skip if not a symlink
+    [ -L "$path_link" ] || continue
+
+    # Resolve symlink to actual device
+    card=$(readlink -f "$path_link")
+    [ -n "$card" ] || continue
+
+    card_name=$(basename "$card")
+    [ -n "$card_name" ] || continue
+
+    # Check if this card has KMS capability by looking for connectors
+    has_kms=0
+    for connector in /sys/class/drm/${card_name}-*; do
+        if [ -d "$connector" ]; then
+            has_kms=1
+            break
+        fi
+    done
+
+    # Only process KMS-capable cards
+    if [ "$has_kms" -eq 1 ]; then
+        # Extract platform address for sorting
+        platform_addr=$(echo "$path_link" | sed 's/.*platform-\([0-9a-f]*\).*/\1/')
+
+        # Verify we extracted a valid address
+        if [ -n "$platform_addr" ]; then
+            kms_cards="$kms_cards $platform_addr:$card_name"
+        fi
+    fi
+done
+
+# Sort by platform address to get consistent ordering
+sorted_cards=$(echo "$kms_cards" | tr ' ' '\n' | grep -v '^$' | sort | cut -d: -f2)
+
+# First card in sorted list is primary (Weston will auto-select it)
+# Remaining cards are added to additional-devices
+for card_name in $sorted_cards; do
+    if [ -z "$first_kms_card" ]; then
+        # Mark first card as primary (we skip adding it)
+        first_kms_card="$card_name"
+    else
+        # Add subsequent cards to additional-devices list
+        if [ -z "$additional_cards" ]; then
+            additional_cards="$card_name"
+        else
+            additional_cards="$additional_cards,$card_name"
+        fi
+    fi
+done
+
+# Add additional-devices parameter if we found any
+if [ -n "$additional_cards" ]; then
+    opts="$opts --additional-devices=$additional_cards"
+fi
+
+# Execute weston with the constructed options
+exec @bindir@/weston $opts


### PR DESCRIPTION
weston-init: add automatic multi-DPU detection and configuration

To provide multi-DPU support in Weston across hardware with varying configurations, add automatic detection and configuration of display devices: separate GPU + DPUs, GPU+DPU combos, DPU-only systems, and non-deterministic probe order.

On some platforms DRM card numbering is not stable: either DPU can become card1 or card2 depending on probe order. Weston does not pick the primary KMS device by cardN; it enumerates devices via sysfs/device-tree order and selects the first valid KMS device it finds. If a wrapper relies on /sys/class/drm/card* numeric ordering, it can accidentally pass the same card Weston already selected as primary in --additional-devices, which can lead to startup failures (duplicate open of the primary).

Example observed on LEMANS dual-DPU:

Scenario A: 22000000.display-subsystem (DPU) probed as card2
- Boot mapping:
  - 22000000.display-subsystem/.../drm/card2
  - ae00000.display-subsystem/.../drm/card1
- Weston log:
   - Checking device: .../22000000.../drm/card2
   - Selected .../drm/card2 (first valid KMS device found)
- Without platform/by-path ordering the wrapper can end up passing card2 as an additional device as well, resulting in:
      - ERROR: DRM device 'card2' is not a KMS device.

Scenario B: 22000000.display-subsystem (DPU) probed as card1
- Boot mapping:
  - 22000000.display-subsystem/.../drm/card1
  - ae00000.display-subsystem/.../drm/card2
- Weston log:
  - Checking device: .../22000000.../drm/card1
  - Selected .../drm/card1 (first valid KMS device found)
- This is the same failure mode if a wrapper assumes fixed card numbering: the primary (card1 in this case) may be incorrectly passed again via --additional-devices, causing a duplicate-open startup failure.

Add a wrapper script that detects DRM cards with KMS capability by checking for connector directories in sysfs and uses /dev/dri/by-path symlinks sorted by platform address (stable) to ensure deterministic ordering regardless of probe sequence. The first KMS-capable card is treated as primary; remaining KMS cards are passed via --additional-devices.
    
A systemd drop-in overrides ExecStart to call the wrapper, maintaining backward compatibility while enabling automatic multi-DPU support.