### PR TITLE
ci: actions/compile: update upload-private-artifact-action tag

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -117,7 +117,7 @@ runs:
         path: ./uploads
 
     - name: Upload artifacts to S3 bucket
-      uses: qualcomm-linux/upload-private-artifact-action@aws-v1
+      uses: qualcomm-linux/upload-private-artifact-action@aws-v3
       with:
         path: ./uploads
         destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/


### PR DESCRIPTION
update image tag from aws-v1 to aws-v3 to prevent API limit exceed errors during installation.