### PR TITLE
ci: lava-test-plans: correct image file name for db410c / db820c

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -85,7 +85,7 @@ runs:
           echo "ROOTFS_URL=${BUILD_URL}/${{ inputs.distro_name }}${{ inputs.kernel }}/${{ inputs.machine }}/${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
           if [ "${{ inputs.machine }}" = "qcom-armv8a" ]; then
-              echo "ROOTFS_IMG_FILE=core-image-base-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
+              echo "ROOTFS_IMG_FILE=${IMAGE_TYPE}-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
               cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-410c.ini
               echo "DEVICE_TYPE=dragonboard-410c" >> dragonboard-410c.ini
               echo "BOOT_IMG_FILE=boot-apq8016-sbc-qcom-armv8a.img" >> dragonboard-410c.ini


### PR DESCRIPTION
Unlike all other boards, db410c / db820c don't use ROOTFS_URL for passing the rootfs. Instead they use ROOTFS_IMG_FILE variable. Currently it is set to core-image-base, which makes tests fail for qcom-distro images (which should be using qcom-mulimedia-image). Use IMAGE_TYPE instead of hardcoding image names to make tests pass.