### PR TITLE
ci: actions/compile: disable SDK input control

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -12,9 +12,6 @@ inputs:
     required: true
   cache_dir:
     required: true
-  sdk:
-    required: false
-    default: "0"
 outputs:
   url:
     description: Location of the published binaries
@@ -87,7 +84,7 @@ runs:
 
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
           # SDK only with the default kernel
-          if [ "${INPUTS_SDK}" = "1" ] && [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
+          if [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
             $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk
             $KAS_CONTAINER shell ${KAS_YAMLS} \
               -c "buildstats-summary --sort duration --highlight 0 --shortest 300"

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -3,10 +3,6 @@ name: Build Yocto
 on:
   workflow_call:
     inputs:
-      sdk:
-        required: false
-        type: string
-        default: "0"
       profile:
         required: false
         type: string
@@ -129,7 +125,6 @@ jobs:
           kernel_yaml: ${{matrix.kernel.yamlfile}}
           kernel_dirname: ${{matrix.kernel.dirname}}
           cache_dir: ${{env.CACHE_DIR}}
-          sdk: ${{inputs.sdk}}
 
   compile:
     needs: compile_warm_up
@@ -302,7 +297,6 @@ jobs:
           kernel_yaml: ${{matrix.kernel.yamlfile}}
           kernel_dirname: ${{matrix.kernel.dirname}}
           cache_dir: ${{env.CACHE_DIR}}
-          sdk: ${{inputs.sdk}}
 
   publish_summary:
     needs: compile

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,8 +16,6 @@ permissions:
 jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml
-    with:
-      sdk: "1"
   test-nightly:
     uses: ./.github/workflows/test.yml
     needs: build-nightly

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,7 +17,7 @@ jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml
     with:
-      sdk: "0" # temporarily until we can split IMSDK correctly
+      sdk: "1"
   test-nightly:
     uses: ./.github/workflows/test.yml
     needs: build-nightly


### PR DESCRIPTION
Making the validation of the SDK build dependent on external conditions
is prone to fail and allows for the easy introduction of regressions.
Thus, this will be validated in all builds as all the others.