### PR TITLE
Add iq-x7181-evk to test workflows in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         machine:
           - iq-8275-evk
           - iq-9075-evk
+          - iq-x7181-evk
           - qcm6490-idp
           - qcs615-ride
           - rb3gen2-core-kit


### PR DESCRIPTION
Add iq-x7181-evk machine to the build matrix in test.yml workflows to enable boot testing for this platform.