### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+lib/qcom/__pycache__/


### PR DESCRIPTION
Add initial .gitignore file to cover lib/qcom/__pycache__/, which is populated by python via dtb_only_fitimage.py.