### PR TITLE
ci: actions: align on the latest upload-artifact and download-artifact releases

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -23,13 +23,13 @@ runs:
   using: "composite"
   steps:
     - name: Download kas lockfile
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: kas-lockfile
         path: ci/
 
     - name: Download kas-container
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
          name: kas-container
          path: ${{runner.temp}}

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -34,7 +34,7 @@ runs:
           python-version: 3.11
 
       - name: 'Download build URLs'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ inputs.gh_token }}
           run-id: ${{ inputs.build_id }}

--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: 'Download build URLs'
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         github-token: ${{ inputs.gh_token }}
         run-id: ${{ inputs.build_id }}

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -21,7 +21,7 @@ runs:
 
   steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ inputs.gh_token }}
           run-id: ${{ inputs.build_id }}

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -60,13 +60,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download kas lockfile
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: kas-lockfile
           path: ci
 
       - name: Download kas-container
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: kas-container
           path: ${{ runner.temp }}
@@ -240,7 +240,7 @@ jobs:
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - name: 'Download build URLs'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: build-url*

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download result files
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
             run-id: ${{ inputs.workflow_id }}
             path: artifacts
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download result files PR
         if: ${{ github.run_id != inputs.workflow_id }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
             path: artifacts
             github-token: ${{ github.token }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,13 +30,13 @@ jobs:
 
       - name: Download Result Summary
         id: download-result-summary
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           artifact-ids: ${{ needs.test.outputs.summary_id }}
           path: results_summary
 
       - name: Download event file
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
             run-id: ${{ github.event.workflow_run.id }}
             path: artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Download job templates'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: boottest-*
 
@@ -85,7 +85,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-boot-job-list.outputs.jobmatrix) }}
     steps:
       - name: 'Download job templates'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: boottest-*
 
@@ -194,7 +194,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 'Download job templates'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: premerge-*
 
@@ -215,7 +215,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-premerge-job-list.outputs.jobmatrix) }}
     steps:
       - name: 'Download job templates'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: premerge-*
 
@@ -261,7 +261,7 @@ jobs:
           summary_file_name: test_job_summary
 
       - name: Download Summary
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           artifact-ids: ${{ steps.generate-summary.outputs.artifact_id }}
 


### PR DESCRIPTION
Align on the same upload-artifact tag (v6) and update download-artifact to the latest release (v7.0.0, base v7 tag) to align on the same node.js requirements as used by upload-artifact.