### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260220

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260217
-SRCREV ?= "faac849b351a06e9328b9af65035331a325de108"
+# tag: qcom-6.18.y-20260220
+SRCREV ?= "0e842c87bef399ca8ceee751c8c0073fd463bac6"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260220

Changelog :

BACKPORT: arm64: dts: qcom: qcs6490-rb3gen2: Add TC9563 PCIe switch nodei
Revert "FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add TC9563 PCIe switch node"
PENDING: arm64: dts: qcom: Add EL2 support for Iris for lemans
FROMLIST: media: iris: Enable Secure PAS support with IOMMU managed by Linux
FROMLIST: driver: bluetooth: hci_qca: Cleanup on all setup failures
FROMLIST: arm64: dts: qcom: qcm6490-idp: Enable PCIe1
FROMLIST: arm64: dts: qcom: monaco-evk: Add Mezzanine
QCLINUX: qcom.config: add crypto corresponding config
FROMLIST: arm64: dts: qcom: lemans-evk: Add Mezzanine
FROMLIST: PCI: qcom: Rename PERST# assert/deassert helpers for uniformity
FROMLIST: PCI: Drop the assert_perst() callback
FROMLIST: PCI: qcom: Drop the assert_perst() callbacks
FROMLIST: PCI/pwrctrl: Switch to pwrctrl create, power on/off, destroy APIs
FROMLIST: PCI/pwrctrl: Add APIs to power on/off pwrctrl devices
FROMLIST: PCI/pwrctrl: Add APIs to create, destroy pwrctrl devices
FROMLIST: PCI/pwrctrl: Add 'struct pci_pwrctrl::power_{on/off}' callbacks
FROMLIST: PCI/pwrctrl: pwrseq: Factor out power on/off code to helpers
FROMLIST: PCI/pwrctrl: slot: Factor out power on/off code to helpers
FROMLIST: PCI/pwrctrl: tc9563: Rename private struct and pointers for consistency
FROMLIST: PCI/pwrctrl: tc9563: Add local variables to reduce repetition
FROMLIST: PCI/pwrctrl: tc9563: Clean up whitespace
FROMLIST: PCI/pwrctrl: tc9563: Use put_device() instead of i2c_put_adapter()
FROMLIST: PCI/pwrctrl: slot: Rename private struct and pointers for consistency
FROMLIST: PCI/pwrctrl: pwrseq: Rename private struct and pointers for consistency
BACKPORT: PCI/pwrctrl: tc9563: Remove unnecessary semicolons
BACKPORT: PCI/pwrctrl: tc9563: Enforce I2C dependency
BACKPORT: PCI: pwrctrl: Add power control driver for TC9563
BACKPORT: PCI: qcom: Add support for assert_perst()
BACKPORT: PCI: dwc: Implement .assert_perst() hook
BACKPORT: PCI: dwc: Add assert_perst() hook for dwc glue drivers
BACKPORT: PCI: Add assert_perst() operation to control PCIe PERST#
BACKPORT: dt-bindings: PCI: Add binding for Toshiba TC9563 PCIe switch
Revert "FROMLIST: PCI: pwrctrl: Add power control driver for tc9563"
Revert "FROMLIST: PCI: Add pcie_link_is_active() to determine if the link is active"
Revert "FROMLIST: PCI: qcom: Add support for host_stop_link() & host_start_link()"
Revert "FROMLIST: PCI: dwc: Implement .start_link(), .stop_link() hooks"
Revert "FROMLIST: PCI: dwc: Add host_start_link() & host_start_link() hooks for dwc glue drivers"
Revert "FROMLIST: PCI: Add new start_link() & stop_link function ops"
Revert "FROMLIST: dt-bindings: PCI: Add binding for Toshiba TC9563 PCIe switch"
QCLINUX: memory-dump: add memory dump table for Hamoa
QCLINUX: qcom-dcc: add device configuration for Hamoa
QCLINUX: memory-dump: add memory dump table for Kaanapali
QCLINUX: qcom-dcc: add device configuration for Kaanapali
QCLINUX: memory-dump: add memory dump table for Pakala
QCLINUX: qcom-dcc: add device configuration for Pakala
QCLINUX: memory-dump: add logic for reserving CMA memory
QCLINUX: mem-dump: add memory dump device driver
QCLINUX: memory-dump: add QCOM memory dump driver
QCLINUX: qcom-dcc: add qcom-dcc dev driver
QCLINUX: add qcom_debug.config for debug features
QCLINUX: qcom-dcc: Add driver support for Data Capture and Compare unit(DCC)
FROMLIST: PCI: qcom: Prevent GDSC power down on suspend
FROMLIST: PCI: qcom: Add D3cold support
FROMLIST: PCI: dwc: Use common D3cold eligibility helper in suspend path
FROMLIST: PCI: host-common: Add shared D3cold eligibility helper for host bridges
FROMLIST: arm64: dts: qcom: kodiak: Fix PCIe1 PHY ref clock voting