### PR TITLE
sigma-dut: update SRC_URI to use qualcomm/sigma-dut

### DIFF
--- a/recipes-connectivity/sigma-dut/sigma-dut_git.bb
+++ b/recipes-connectivity/sigma-dut/sigma-dut_git.bb
@@ -1,9 +1,9 @@
 SUMMARY = "WFA certification testing tool for QCA devices."
-HOMEPAGE = "https://github.com/qca/sigma-dut"
+HOMEPAGE = "https://github.com/qualcomm/sigma-dut"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://README;md5=edb3527809487b74b4d4a7e02b05acf0"
 
-SRC_URI = "git://github.com/qca/sigma-dut.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/qualcomm/sigma-dut.git;branch=master;protocol=https"
 
 PV = "1.11+git"
 SRCREV = "21f3bb1c426367d9f480acb4f5f011dd0aa17875"


### PR DESCRIPTION
The qca/sigma-dut repo was recently transferred to the qualcomm organization. GitHub will automatically redirect, but we should still update the recipe to avoid confusion.