### PR TITLE
iq-9075-evk: build mezzanine DTs as an overlays

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -27,6 +27,10 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2] = " \
     qcom,qcs9075-iot-camx-el2kvm \
     qcom,qcs9075v2-iot-camx-el2kvm \
 "
+FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-mezzanine] = " \
+    qcom,qcs9075-iot-subtype1 \
+    qcom,qcs9075v2-iot-subtype1 \
+"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
 FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -9,6 +9,7 @@ MACHINE_FEATURES += "efi pci tpm2"
 KERNEL_DEVICETREE ?= " \
                       qcom/lemans-evk.dtb \
                       qcom/lemans-evk-camera-csi1-imx577.dtbo \
+                      qcom/lemans-evk-mezzanine.dtbo \
                       "
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels


### PR DESCRIPTION
Switch the mezzanine DT from a full DTB to a DTBO so it is built and packed as an overlay in multiDTB instead of a standalone base DTB. This aligns the lemans evk mezzanine hardware configuration with the intended hardware layering and avoids generating full DTB for mezzanine board.