### PR TITLE
Add `quiet` option to kernel cmdline

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -51,7 +51,7 @@ local_conf_header:
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
+    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1 quiet"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
Add the `quiet` option to the kernel command line to reduce verbose kernel output during boot. This suppresses driver/module initialization messages, filesystem checks, and other non-critical logs, helping improve overall boot time.