### PR TITLE
fit-dtb-compatible: add camx compatible overlay for qcs5430

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -53,6 +53,8 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
     qcom,qcs6490-iot-subtype2 \
 "
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
+    qcom,qcs5430-iot-camx \
+    qcom,qcs5430-iot-subtype2-camx \
     qcom,qcs6490-iot-camx \
     qcom,qcs6490-iot-subtype2-camx \
 "


### PR DESCRIPTION
Extend camx compatible overlay used by qcs6490 to also support qcs5430, which is the rb3gen2 lite variant.