### PR TITLE
ci: actions/sync: added support for merging multiple prs during repo checkout

### DIFF
--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -1,0 +1,66 @@
+name: 'Sync Repo [optionally with PRs]'
+description: 'Fetches and merges a list of open PRs into the current workspace.'
+
+inputs:
+  prs:
+    description: 'A space-separated list of open PR numbers to sync.'
+    required: false
+    default: ''
+  path:
+    description: 'The path on the runner where the repository is checked out.'
+    required: true
+  repo:
+    description: 'The full name of the repository (e.g., owner/repo).'
+    required: true
+  ref:
+    description: 'Repository branch reference'
+    required: true
+
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repo }}
+        fetch-depth: 0
+        path: ${{ inputs.path }}
+        ref: ${{ inputs.ref }}
+
+
+    - name: Configure Git Identity
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+
+
+    - name: Fetch and Merge PRs
+      if: ${{ inputs.prs != '' }}
+      id: merge_prs
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: |
+        for pr_number in ${{ inputs.prs }}; do
+          echo "Syncing PR #${pr_number} into workspace..."
+         
+          git fetch https://github.com/${{ inputs.repo }}.git "pull/${pr_number}/head"
+         
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to fetch PR #${pr_number}."
+            exit 1
+          fi
+         
+          git merge --no-ff FETCH_HEAD --no-edit
+         
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to merge PR #${pr_number}. There might be merge conflicts."
+            exit 1
+          fi
+         
+          echo "Successfully merged PR #${pr_number}."
+        done
+        echo "All pending PRs have been successfully synced."

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,6 +7,21 @@ on:
         required: false
         type: string
         default: "0"
+      meta-qcom-repo:
+        description: meta-qcom repo name
+        type: string
+        required: false
+        default: "qualcomm-linux/meta-qcom"
+      meta-qcom-ref:
+        description: meta-qcom branch ref
+        type: string
+        required: false
+        default: "master"
+      meta-qcom-prs:
+        description: meta-qcom PRs
+        type: string
+        required: false
+        default: ""
     outputs:
       artifacts_url:
         description: "URL to retrieve build artifacts"
@@ -33,8 +48,14 @@ jobs:
           LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
           wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
           chmod +x ${KAS_CONTAINER}
-
-      - uses: actions/checkout@v4
+      
+      - name: Sync meta-qcom
+        uses: qualcomm-linux/meta-qcom/.github/actions/sync@master
+        with:
+          repo: ${{ inputs.meta-qcom-repo }}
+          path: .
+          ref: ${{ inputs.meta-qcom-ref }}
+          prs: ${{ inputs.meta-qcom-prs }}
 
       - name: Run kas lock
         run: |
@@ -57,8 +78,15 @@ jobs:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
-      - uses: actions/checkout@v4
 
+      - name: Sync meta-qcom
+        uses: qualcomm-linux/meta-qcom/.github/actions/sync@master
+        with:
+          repo: ${{ inputs.meta-qcom-repo }}
+          path: .
+          ref: ${{ inputs.meta-qcom-ref }}
+          prs: ${{ inputs.meta-qcom-prs }}
+      
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
         with:
@@ -116,7 +144,14 @@ jobs:
             yamlfile: ":ci/linux-qcom-rt-6.18.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+
+      - name: Sync meta-qcom
+        uses: qualcomm-linux/meta-qcom/.github/actions/sync@master
+        with:
+          repo: ${{ inputs.meta-qcom-repo }}
+          path: .
+          ref: ${{ inputs.meta-qcom-ref }}
+          prs: ${{ inputs.meta-qcom-prs }}
 
       - name: Run kas build
         uses: ./.github/actions/compile
@@ -221,7 +256,14 @@ jobs:
                 yamlfile: ""
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+
+      - name: Sync meta-qcom
+        uses: qualcomm-linux/meta-qcom/.github/actions/sync@master
+        with:
+          repo: ${{ inputs.meta-qcom-repo }}
+          path: .
+          ref: ${{ inputs.meta-qcom-ref }}
+          prs: ${{ inputs.meta-qcom-prs }}
 
       - name: Run kas build
         uses: ./.github/actions/compile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,4 +25,6 @@ jobs:
         path: ${{ github.event_path }}
   build-pr:
     uses: ./.github/workflows/build-yocto.yml
+    with:
+      meta-qcom-prs: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
This github action will be used to sync multiple prs while repo checkout. This can be extensively used to build a set of PRs together saving resources and time.