### PR TITLE
Update boot firmware to 00116.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00114.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00114.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "3bfc7748493e4ac8d8ad77db5c132b5301195ce02d377c62171332a81901f552"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00116.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "ad5434f1afd2f801e63266d75c97425d1fea22b2edc67b6f5a0f472ca55844ed"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00114.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00114.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "2067015d9a96d7e009ffec3a42bb7f88a659eb96c6b9e6f9df849af222a8f0e3"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00116.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "e7a22f9a7ddae92e6e307afdd9f06608ddd3b0ac7f2e4994bacfb51729e8337f"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00114.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00114.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "963d54a9e9a3ef29c6933b3d71faa035b72df07cc36f42c14c39ed5f47878026"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00116.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "f19724eab9571b97087933b60a0b75246537fda5ef75a97e6d5dee4020ef59a2"


### PR DESCRIPTION
Below are the known changes across targets:

QCS8300 (Monaco)
- Fixes boot and recovery issues including EDL entry failures, SEC watchdog enablement, and HLOS recovery paths.
- Enables deep sleep and DSP‑specific power optimizations to meet power and thermal targets.
- Hardens TZ and security with PIL authentication/reset handling and security-review fixes.
- Improves DSP and storage stability by addressing quantum, DSQB, and RAMdump-related failures.

QCS9100 (Lemans)
- Resolves critical DDR PASS1/SDI PASS1 regressions to stabilize early memory initialization.
- Optimizes power and performance through sleep target tuning, deep sleep enablement, and DSP PM updates.
- Improves DSP and audio stability with crash fixes, SRM updates, and AP-ADSP shared memory changes.
- Fixes storage and RAMdump failures, improving crash recovery reliability.

QCM6490 (Kodiak)
- Improves UEFI boot stability via TLMM/XPU fixes, PCIe RP tuning, log overload fixes, and problematic DXE disables.
- Enhances NVMe usability by enabling Fastboot flashing, improving enumeration, and fixing boot-order handling.
- Strengthens security with TZ image signing, OEM-only QTEE signing, and PKCS11 hardening.
- Fixes RAMdump, watchdog, and crash/debug issues to improve recoverability and post‑mortem analysis.