### PR TITLE
camxlib-talos: Update to the 1.0.3 revision

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.2.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260211"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "772f3f7970db9d639a87d55fd9bac07cb9726866d5eef7b983dcfdd86ec14415"
-SRC_URI[camx.sha256sum]        = "b860fde72e6a965cc1811afedb164fdb593338325fc80476026d11f9800ebfe9"
-SRC_URI[chicdk.sha256sum]      = "dd38a3d1599cfe5ef2fa40b5eb00016b03fd9800c919edd7689857193a5d1d7e"
-SRC_URI[camxcommon.sha256sum]  = "3cdc8717e8778d4f19231067a82e44dddc563f8e05bf058901f0b74784312fa7"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.3.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260224.1"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "263a9f4f1ac609bd51ad8af92a47da9ea7b9be844a45a5f4b4d741e0bfebf5a9"
+SRC_URI[camx.sha256sum]        = "47b3996ec1ba386877aa1de6519ba68084d4da7f47958fe64569c0a3011f4bcd"
+SRC_URI[chicdk.sha256sum]      = "730341ba1d1d505d8493eff1cc5cdbfa07f266ecb57fe39017bba16cf66f7cd3"
+SRC_URI[camxcommon.sha256sum]  = "2c019c4d07d1e9927ce1dc641cd90940a3e3a90464cd1d5b79ae7e63b0e37b79"


### PR DESCRIPTION
Fix snapshot corruption issue with 12MP sensor resolution and enable Offline Image Quality modules.