### PR TITLE
Upgrade boot firmware to r2.0_00001.1 release

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -2,13 +2,15 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS615 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
-FW_BUILD_ID = "r1.0_${PV}/qcs615-le-1-0"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.2.0/qualcomm_linux.spf.2.0-test-device-public"
+BUILD_ID = "${@(d.getVar('PV')).rsplit('-', 1)[0].replace('-', '_')}"
+SPIN_ID = "${@d.getVar('PV').rsplit('-', 1)[-1]}"
+FW_BUILD_ID = "${BUILD_ID}/QCS615.LE.2.0"
 FW_BIN_PATH = "common/build/common/bin"
 BOOTBINARIES = "QCS615_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}_${SPIN_ID}.zip;downloadfilename=${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
     "

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00116.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "e9552e73ebde1a814fd4452540826d3cf4f25d70a98ab508a7afe860b1fb24a9"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_r2.0-00001.1-00003.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_r2.0-00001.1-00003.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "55281beda462f61cb4ea1d075510e275dc2a51258d3e4e903267a1c711c107ee"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
@@ -2,13 +2,15 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Robotics RB3Gen2 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
-FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.2.0/qualcomm_linux.spf.2.0-test-device-public"
+BUILD_ID = "${@(d.getVar('PV')).rsplit('-', 1)[0].replace('-', '_')}"
+SPIN_ID = "${@d.getVar('PV').rsplit('-', 1)[-1]}"
+FW_BUILD_ID = "${BUILD_ID}/QCM6490.LE.2.0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCM6490_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}_${SPIN_ID}.zip;downloadfilename=${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/qcm6490-idp.zip;downloadfilename=cdt-qcm6490-idp_${PV}.zip;name=qcm6490-idp \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00116.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "ad5434f1afd2f801e63266d75c97425d1fea22b2edc67b6f5a0f472ca55844ed"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_r2.0-00001.1-00004.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_r2.0-00001.1-00004.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "48d50c22d1b1e09ea2af1ada2adddee82bcf16a494fce656e8e3f5a694cef830"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -2,13 +2,15 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS8300 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
-FW_BUILD_ID = "r1.0_${PV}/qcs8300-le-1-0"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.2.0/qualcomm_linux.spf.2.0-test-device-public"
+BUILD_ID = "${@(d.getVar('PV')).rsplit('-', 1)[0].replace('-', '_')}"
+SPIN_ID = "${@d.getVar('PV').rsplit('-', 1)[-1]}"
+FW_BUILD_ID = "${BUILD_ID}/QCS8300.LE.2.0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCS8300_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}_${SPIN_ID}.zip;downloadfilename=${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00116.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "e7a22f9a7ddae92e6e307afdd9f06608ddd3b0ac7f2e4994bacfb51729e8337f"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_r2.0-00001.1-00003.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_r2.0-00001.1-00003.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "9cc8be5edede2f534e84c2340d3b7fe07af2369124f61610b3eda1ed90ddb737"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -2,13 +2,15 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS9100 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public"
-FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.2.0/qualcomm_linux.spf.2.0-test-device-public"
+BUILD_ID = "${@(d.getVar('PV')).rsplit('-', 1)[0].replace('-', '_')}"
+SPIN_ID = "${@d.getVar('PV').rsplit('-', 1)[-1]}"
+FW_BUILD_ID = "${BUILD_ID}/QCS9100.LE.2.0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCS9100_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}_${SPIN_ID}.zip;downloadfilename=${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx_v3.zip;downloadfilename=cdt-qcs9100-ride-sx-v3_${PV}.zip;name=qcs9100-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/rb8_core_kit.zip;downloadfilename=cdt-qcs9100-rb8-core-kit_${PV}.zip;name=qcs9100-rb8-ck \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00116.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00116.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "f19724eab9571b97087933b60a0b75246537fda5ef75a97e6d5dee4020ef59a2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_r2.0-00001.1-00003.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_r2.0-00001.1-00003.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "c8d09ea92523378b2ad16f05eadd28bdb37eb25d210abff24bdf58332316752e"


### PR DESCRIPTION
Update QCS615, QCS6490, QCS8300, QCS9100 boot firmware recipes to consume 
boot binaries from the r2.0_00001.1 release. Starting with this release, the firmware
artifacts are hosted using the new SPF 2.0 layout. Update the paths accordingly.