### PR TITLE
sm8750-mtp.conf: add boot firmware for SM8750-MTP

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -96,6 +96,7 @@ create_qcomflash_pkg() {
         for bfw in `find ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR} -maxdepth 1 -type f \
                 \( -name '*.elf' ! -name 'abl2esp*.elf' ! -name 'xbl_config*.elf' ! -name 'uefi.elf' \) -o \
                 -name '*.mbn*' -o \
+                -name '*.melf*' -o \
                 -name '*.fv' -o \
                 -name 'cdt_*.bin' -o \
                 -name 'logfs_*.bin' -o \

--- a/conf/machine/sm8750-mtp.conf
+++ b/conf/machine/sm8750-mtp.conf
@@ -8,8 +8,6 @@ MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
 
 QCOM_DTB_DEFAULT ?= "sm8750-mtp"
 
-ABL_SIGNATURE_VERSION ?= "v7"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/sm8750-mtp.dtb \
                       "
@@ -19,3 +17,9 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-sm8750-mtp-hexagon-dsp-binaries \
     qcom-fastcv-binaries-sm8750-mtp-dsp \
 "
+
+QCOM_CDT_FILE = "cdt_pakala_mtp_0.4.0"
+QCOM_BOOT_FILES_SUBDIR = "sm8750"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/sm8750-mtp/ufs"
+
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-sm8750"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
@@ -1,0 +1,20 @@
+DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm SM8750-MTP platform"
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/software/chip/qualcomm_linux-spf-0-0/qualcomm-linux-spf-0-0_test_device_public"
+FW_BUILD_ID = "r0.0_${PV}/pakala-le-0-0"
+FW_BIN_PATH = "common/build/ufs/bin"
+BOOTBINARIES = "pakala_bootbinaries"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SM8750/cdt/sm8750-mtp_wcn7881.zip;downloadfilename=sm8750-mtp_wcn7881_${PV}.zip;name=sm8750-mtp_wcn7881 \
+    "
+SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
+SRC_URI[sm8750-mtp_wcn7881.sha256sum] = "474c35a6f06948808be118a8b0dac61ca53fd71182c1f03b92ca30d34dbb8a58"
+
+QCOM_BOOT_IMG_SUBDIR = "sm8750"
+
+include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00008.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00008.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-sm8750.inc
+
+SRC_URI[bootbinaries.sha256sum] = "3e09eef0dbdecf2c5680f9278ed4fd6f32b0b5f89cb16e7ad3459a56986c4469"


### PR DESCRIPTION
Add boot firmware recipe and include in machine conf 

systemd-boot is enabled, so drop ABL_SIGNATURE_VERSION definition from machine conf as we no longer need to use abl2esp.elf file during boot.

SM8750-MTP uses xbl_s_devprg_ns.melf as device programmer while flashing, and xbl_s.melf file is flashed in xbl partiiton, so include *.melf files in image_types_qcom.bbclass