### PR TITLE
Disable PAuth to allow all CPUs to boot with KVM on QCS8300

### DIFF
--- a/conf/machine/include/qcom-qcs8300.inc
+++ b/conf/machine/include/qcom-qcs8300.inc
@@ -7,6 +7,10 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
+# Disable PAuth via cmdline to allow all cores to boot with KVM.
+# More details at https://lore.kernel.org/all/3fcf6614-ee83-4a06-9024-83573b2e642e@quicinc.com/
+KERNEL_CMDLINE_EXTRA:append = " arm64.nopauth"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs8300-soc \


### PR DESCRIPTION
On QCS8300 platforms, ARM64 Pointer Authentication (PAuth) is supported only on the boot CPUs (0–3) and not on the secondary CPUs (4–7). The ARM64 CPU feature discovery logic expects secondary CPUs to support all features enabled on the boot CPU. When this mismatch is detected, the secondary CPUs are prevented from booting, which is undesirable for production systems.

To ensure that all CPUs can boot correctly, disable PAuth by appending `arm64.nopauth` to the kernel cmdline.

This issue is observed only when Linux is booted in EL2 (i.e. KVM in use). When Linux runs under Gunyah (Type‑1 hypervisor), the PAuth feature is hidden from EL1 via HCR_EL2.TID3.