### PR TITLE
dtb-fit-image: fix do_generate_qcom_fitimage[vardeps]

### DIFF
--- a/classes-recipe/dtb-fit-image.bbclass
+++ b/classes-recipe/dtb-fit-image.bbclass
@@ -114,15 +114,4 @@ python do_generate_qcom_fitimage_setscene () {
 addtask do_generate_qcom_fitimage_setscene
 
 do_generate_qcom_fitimage[stamp-extra-info] = "${MACHINE_ARCH}"
-
-# Serialize FIT_DTB_COMPATIBLE for cache invalidation on changes
-python __anonymous() {
-    compat_flags = d.getVarFlags('FIT_DTB_COMPATIBLE') or {}
-    compat_lines = []
-    for k in sorted(compat_flags.keys()):
-        v = " ".join((compat_flags[k] or "").split())
-        compat_lines.append(f"{k}={v}")
-    d.setVar('FIT_DTB_COMPATIBLE_SIG', "\n".join(compat_lines))
-}
-
-do_generate_qcom_fitimage[vardeps] += "FIT_DTB_COMPATIBLE_SIG"
+do_generate_qcom_fitimage[vardeps] += "FIT_DTB_COMPATIBLE"


### PR DESCRIPTION
2b272aa22 add the FIT_DTB_COMPATIBLE in task signature parsing all the keys
and values of the variable. But we can use the FIT_DTB_COMPATIBLE directly
on the vardeps of the qcom_generate_qcom_fitimage task.

This was tested building linux-qcom-next and afer that
removing one element from FIT_DTB_COMPATIBLE[...] = ...'
then looking at the signatures and the change is caught by bitbake.

| Task linux-qcom-next:do_generate_qcom_fitimage couldn't be used from the cache because:
|   ...
|   changed items: frozenset({'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01]'})
|   Dependency on Variable FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01] was removed

```
Task linux-qcom-next:do_generate_qcom_fitimage couldn't be used from the cache because:
  We need hash f61b6eda41af87052238107f7e37be851de2ea251f7cc043b3c118bdd4ee84a7, most recent matching task was 7b68002967b46797bbb20c792d3366595120747130c120ffe00c4c3f08ccc1b5
  Task dependencies changed from:
['ABIEXTENSION', 'ABIEXTENSION_32', 'ABIEXTENSION_64', 'ARCH', 'ARMPKGSFX_ENDIAN_64', 'B', 'DEPLOY_DIR_IMAGE', 'DISTRO_NAME', 'FIT_ADDRESS_CELLS', 'FIT_CONF_PREFIX', 'FIT_DESC', 'FIT_DTB_COMPATIBLE', 'FIT_DTB_COMPATIBLE[apq8016-sbc]', 'FIT_DTB_COMPATIBLE[apq8096-db820c]', 'FIT_DTB_COMPATIBLE[hamoa-iot-evk]', 'FIT_DTB_COMPATIBLE[kaanapali-mtp]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx]', 'FIT_DTB_COMPATIBLE[qcm6490-idp]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410]', 'FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard]', 'FIT_DTB_COMPATIBLE[qcom-apq8084-ifc6540]', 'FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead]', 'FIT_DTB_COMPATIBLE[qcs404-evb-4000]', 'FIT_DTB_COMPATIBLE[qcs615-ride]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2]', 'FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs8300-ride]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3]', 'FIT_DTB_COMPATIBLE[qcs9100-ride]', 'FIT_DTB_COMPATIBLE[qrb2210-rb1]', 'FIT_DTB_COMPATIBLE[qrb4210-rb2]', 'FIT_DTB_COMPATIBLE[qrb5165-rb5]', 'FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3]', 'FIT_DTB_COMPATIBLE[sa8775p-ride]', 'FIT_DTB_COMPATIBLE[sdm845-db845c]', 'FIT_DTB_COMPATIBLE[sm8450-hdk]', 'FIT_DTB_COMPATIBLE[sm8750-mtp]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01]', 'FIT_DTB_MKIMAGE_EXTRA_OPTS', 'KERNEL_DEVICETREE', 'LIBCEXTENSION', 'LINUX_QCOM_KERNEL_DEVICETREE', 'MACHINE', 'MKIMAGE', 'OE_SHARED_UMASK', 'PN', 'PV', 'QCOMFIT_DEPLOYDIR', 'RECIPE_SYSROOT_NATIVE', 'SSTATECREATEFUNCS', 'SSTATEPOSTCREATEFUNCS', 'SSTATEPOSTUNPACKFUNCS', 'SSTATE_BUILDDIR', 'SSTATE_INSTDIR', 'SSTATE_MANIFESTS', 'SSTATE_SCAN_FILES', 'SSTATE_SKIP_CREATION', 'STAGING_BINDIR_NATIVE', 'STAGING_DIR_NATIVE', 'TARGET_ARCH', 'TARGET_OS', 'TUNE_ARCH', 'TUNE_ARCH_32', 'TUNE_ARCH_64', 'bindir_native', 'do_generate_qcom_fitimage[cleandirs]', 'do_generate_qcom_fitimage[network]', 'do_generate_qcom_fitimage[sstate-inputdirs]', 'map_kernel_arch', 'oe.path.copyhardlinktree', 'oe.path.copytree', 'oe.path.remove', 'oe.sstatesig.sstate_get_manifest_filename', 'prefix_native', 'sstate_add', 'sstate_clean', 'sstate_clean_manifest', 'sstate_init', 'sstate_install', 'sstate_installpkgdir', 'sstate_package', 'sstate_state_fromvars', 'sstate_task_postfunc', 'sstate_task_prefunc', 'valid_archs']
to:
['ABIEXTENSION', 'ABIEXTENSION_32', 'ABIEXTENSION_64', 'ARCH', 'ARMPKGSFX_ENDIAN_64', 'B', 'DEPLOY_DIR_IMAGE', 'DISTRO_NAME', 'FIT_ADDRESS_CELLS', 'FIT_CONF_PREFIX', 'FIT_DESC', 'FIT_DTB_COMPATIBLE', 'FIT_DTB_COMPATIBLE[apq8016-sbc]', 'FIT_DTB_COMPATIBLE[apq8096-db820c]', 'FIT_DTB_COMPATIBLE[hamoa-iot-evk]', 'FIT_DTB_COMPATIBLE[kaanapali-mtp]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx]', 'FIT_DTB_COMPATIBLE[qcm6490-idp]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410]', 'FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard]', 'FIT_DTB_COMPATIBLE[qcom-apq8084-ifc6540]', 'FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead]', 'FIT_DTB_COMPATIBLE[qcs404-evb-4000]', 'FIT_DTB_COMPATIBLE[qcs615-ride]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2]', 'FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs8300-ride]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3]', 'FIT_DTB_COMPATIBLE[qcs9100-ride]', 'FIT_DTB_COMPATIBLE[qrb2210-rb1]', 'FIT_DTB_COMPATIBLE[qrb4210-rb2]', 'FIT_DTB_COMPATIBLE[qrb5165-rb5]', 'FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3]', 'FIT_DTB_COMPATIBLE[sa8775p-ride]', 'FIT_DTB_COMPATIBLE[sdm845-db845c]', 'FIT_DTB_COMPATIBLE[sm8450-hdk]', 'FIT_DTB_COMPATIBLE[sm8750-mtp]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx]', 'FIT_DTB_MKIMAGE_EXTRA_OPTS', 'KERNEL_DEVICETREE', 'LIBCEXTENSION', 'LINUX_QCOM_KERNEL_DEVICETREE', 'MACHINE', 'MKIMAGE', 'OE_SHARED_UMASK', 'PN', 'PV', 'QCOMFIT_DEPLOYDIR', 'RECIPE_SYSROOT_NATIVE', 'SSTATECREATEFUNCS', 'SSTATEPOSTCREATEFUNCS', 'SSTATEPOSTUNPACKFUNCS', 'SSTATE_BUILDDIR', 'SSTATE_INSTDIR', 'SSTATE_MANIFESTS', 'SSTATE_SCAN_FILES', 'SSTATE_SKIP_CREATION', 'STAGING_BINDIR_NATIVE', 'STAGING_DIR_NATIVE', 'TARGET_ARCH', 'TARGET_OS', 'TUNE_ARCH', 'TUNE_ARCH_32', 'TUNE_ARCH_64', 'bindir_native', 'do_generate_qcom_fitimage[cleandirs]', 'do_generate_qcom_fitimage[network]', 'do_generate_qcom_fitimage[sstate-inputdirs]', 'map_kernel_arch', 'oe.path.copyhardlinktree', 'oe.path.copytree', 'oe.path.remove', 'oe.sstatesig.sstate_get_manifest_filename', 'prefix_native', 'sstate_add', 'sstate_clean', 'sstate_clean_manifest', 'sstate_init', 'sstate_install', 'sstate_installpkgdir', 'sstate_package', 'sstate_state_fromvars', 'sstate_task_postfunc', 'sstate_task_prefunc', 'valid_archs']
  basehash changed from 399c9c3aea71c9a17e750329ee1d51753543640777f0442571ff44055c19d6c6 to 6dd90a4f9ea6a1d317ea5d89ef4054cf96c55b8f80f5409a231417054a04a010
  List of dependencies for variable FIT_DTB_COMPATIBLE changed from 'frozenset({'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine]', 'FIT_DTB_COMPATIBLE[hamoa-iot-evk]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx]', 'FIT_DTB_COMPATIBLE[sm8750-mtp]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo]', 'FIT_DTB_COMPATIBLE[qcom-apq8084-ifc6540]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine]', 'FIT_DTB_COMPATIBLE[sdm845-db845c]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[qrb5165-rb5]', 'FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2]', 'FIT_DTB_COMPATIBLE[sa8775p-ride]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01]', 'FIT_DTB_COMPATIBLE[qcm6490-idp]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[apq8096-db820c]', 'FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard]', 'FIT_DTB_COMPATIBLE[qrb4210-rb2]', 'FIT_DTB_COMPATIBLE[qcs615-ride]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2]', 'FIT_DTB_COMPATIBLE[apq8016-sbc]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3]', 'FIT_DTB_COMPATIBLE[sm8450-hdk]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx]', 'FIT_DTB_COMPATIBLE[qcs8300-ride]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577]', 'FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead]', 'FIT_DTB_COMPATIBLE[qcs404-evb-4000]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx]', 'FIT_DTB_COMPATIBLE[kaanapali-mtp]', 'FIT_DTB_COMPATIBLE[qrb2210-rb1]'})' to 'frozenset({'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine]', 'FIT_DTB_COMPATIBLE[hamoa-iot-evk]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx]', 'FIT_DTB_COMPATIBLE[sm8750-mtp]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo]', 'FIT_DTB_COMPATIBLE[qcom-apq8084-ifc6540]', 'FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine]', 'FIT_DTB_COMPATIBLE[sdm845-db845c]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577]', 'FIT_DTB_COMPATIBLE[qrb5165-rb5]', 'FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2]', 'FIT_DTB_COMPATIBLE[sa8775p-ride]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[qcm6490-idp]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[apq8096-db820c]', 'FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard]', 'FIT_DTB_COMPATIBLE[qrb4210-rb2]', 'FIT_DTB_COMPATIBLE[qcs615-ride]', 'FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx]', 'FIT_DTB_COMPATIBLE[qcs9100-ride]', 'FIT_DTB_COMPATIBLE[qcs6490-rb3gen2]', 'FIT_DTB_COMPATIBLE[apq8016-sbc]', 'FIT_DTB_COMPATIBLE[qcs9100-ride-r3]', 'FIT_DTB_COMPATIBLE[sm8450-hdk]', 'FIT_DTB_COMPATIBLE[sa8775p-ride-r3]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2]', 'FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx]', 'FIT_DTB_COMPATIBLE[qcs8300-ride]', 'FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577]', 'FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead]', 'FIT_DTB_COMPATIBLE[qcs404-evb-4000]', 'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx]', 'FIT_DTB_COMPATIBLE[kaanapali-mtp]', 'FIT_DTB_COMPATIBLE[qrb2210-rb1]'})'
  changed items: frozenset({'FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01]'})
  Dependency on Variable FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01] was removed
  ```