### PR TITLE
CI: test: download build URLs from the correct GitHub run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/actions/list-jobs
         with:
           prefix: "boottest"
-          build_id: ${{ inputs.build_id }}
+          build_id: ${{ github.run_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   submit-boot-job:
@@ -194,7 +194,7 @@ jobs:
         uses: ./.github/actions/list-jobs
         with:
           prefix: "premerge"
-          build_id: ${{ inputs.build_id }}
+          build_id: ${{ github.run_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   submit-premerge-job:


### PR DESCRIPTION
Before the commit 06b45e2959cf ("CI: test: stop downloading artifacts one more time") all build URLs were attempted to be downloaded twice, once in test.yml and once in the list-jobs/action.yml.

The commit dropped artifact downloading from test.yml, deferring all downloads to the list-jobs action, however the workflow passes the calling build id to the action rather than the current one, ending up with the list-jobs not finding any build URLs (because it tries to download them from the build run rather than the test run).

The issue didn't manifest in the 'Build on Push' workflows because the the build run and the test run are the same.

Fixes: 06b45e2959cf ("CI: test: stop downloading artifacts one more time")