### PR TITLE
ci/base: Update kernel cmdline to enable ice wrapped keys

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -51,7 +51,7 @@ local_conf_header:
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
+    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1 qcom_ice.use_wrapped_keys=1"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
ice driver support both wrapped and standard keys and choice is on user to select key mechanism.

Wrapped key selection is given as userspace option and enabled on need basis. Enable use_wrapped_keys flag will still suffice both wrapped and standard keys hence, enable the flag via cmdline for meta-qcom users.