### PR TITLE
workflows: update lava-test-plans to 5e2441f

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -27,7 +27,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: 1ab5e2f1d6cc3559ca4685941cc9fd17ab132c2d
+          ref: 5e2441fa312c380ba10f4eb028f2d08f5fcfa7e3
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Changes:
- pre-merge: add list of expected tests
- Allow target_deploy_timeout to be overridden and increase it for db410c
- Reduce timeout values for faster test feedback
- Add fastrpc_test to pre-merge-basic suite
- Add display-gfx test plan
- Refactor BT suite to use loop-based test definitions

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>