### PR TITLE
qairt-sdk: Upgrade 2.41 -> 2.43

### DIFF
--- a/recipes-ml/qairt/qairt-sdk_2.43.0.260128.bb
+++ b/recipes-ml/qairt/qairt-sdk_2.43.0.260128.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.pdf;md5=878b885995f453e328edbcd5a1302306"
 NO_GENERIC_LICENSE[qcom-ai-stack] = "LICENSE.pdf"
 
 SRC_URI = "https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/${PV}/v${PV}.zip"
-SRC_URI[sha256sum] = "c6306f7d70457e4d8736416bb406d8670f5186fb648dd6808db24e9b2176c28d"
+SRC_URI[sha256sum] = "e3fce35419310bf80aa2947442a4b39366d80237c4bd72946b77832f71b75223"
 
 S = "${UNPACKDIR}/qairt/${PV}"
 


### PR DESCRIPTION
Upgrade version from 2.41.0.251128 to 2.43.0.260128

- Added HTP compiler tuning APIs and backend performance improvements
- Expanded CPU, HTP, and LPAI op and datatype support
- Enhanced Genie GenAI features (LoRA, RoPE variants, dialog APIs)
- Fixed multiple backend accuracy, crash, and execution issues

For more details, please refer to the release notes at qairt/${PV}/QAIRT_ReleaseNotes.txt in the QAIRT SDK source archive.