### PR TITLE
WIP: workflows: limit the testjobs count list-files action

### DIFF
--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -34,7 +34,7 @@ runs:
       id: listjobs
       shell: bash
       run: |
-        JOBFILES=$(find . -name "${{ input.prefix }}*.yaml")
+        JOBFILES=$(find . -name "*.yaml" | grep ${{ inputs.prefix }})
         RESULT_JSON=$(jq -n '{target: []}')
         for J in $JOBFILES
           do


### PR DESCRIPTION
There was a typo in list-files action: ${{ input.prefix }}. Should be ${{ inputs.prefix }}. This causes unrelated files to be counted towards the list of test jobs to be executed. This patch fixes the typo and uses the prefix to filter the files that will be send to LAVA for execution.