### PR TITLE
layer.conf: exclude qcom-adreno -> kgsl-dlkm from signature deps

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,3 +30,9 @@ PREFERRED_RPROVIDER_virtual-diag-router ?= "diag"
 
 # Location for layer-specific Python helpers
 addpylib ${LAYERDIR}/lib qcom
+
+# Runtime-only dependencies of recipes depending on kernel modules, safe to
+# exclude from task signatures.
+SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
+    qcom-adreno->kgsl-dlkm \
+"


### PR DESCRIPTION
qcom-adreno is a TUNE_PKGARCH package, but it has a runtime dependency on kgsl-dlkm, which is MACHINE_ARCH. This causes task signatures for qcom-adreno to vary across machines, which triggers yocto-check-layer failures due to conflicting signatures.

Since kgsl-dlkm does not affect the build or packaged output of qcom-adreno, it is safe to exclude this dependency from signature generation.