### PR TITLE
Run nightly builds twice daily in CI.

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,7 +4,8 @@ on:
   schedule:
   # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
   # so that build notification emails will be sent out properly.
-  - cron: "23 23 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
+  # At 8:23 & 20:23 UTC everyday - picked a random "minute" as top of hour can be busy in github
+  - cron: "23 8,20 * * *"
 
 permissions:
   checks: write


### PR DESCRIPTION
Due to time zone differences, testers in some geographies have to wait
longer to access the latest nightly builds. Running the nightly workflow
twice a day reduces this wait time and allows teams to pick the build
that best aligns with their working hours.