### PR TITLE
Switch to bitbake nodistro

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -51,7 +51,7 @@ local_conf_header:
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
-    DISTRO_FEATURES:append = " efi pni-names"
+    DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
     WATCHDOG_RUNTIME_SEC:pn-systemd = "30"


### PR DESCRIPTION
Since [1-6] nodistro have mostly the same as in poky-alt distro.

[1] https://git.openembedded.org/openembedded-core/commit/?id=2e1e7c86064ce36580953650b27cca9ae7c269c4
[2] https://git.openembedded.org/openembedded-core/commit/?id=175fcf9fad699dd122680d3f6961af9bf8487046
[3] https://git.openembedded.org/openembedded-core/commit/?id=4c2d64c10a5b0437ab1ea04df22386f0f95124d1
[4] https://git.openembedded.org/openembedded-core/commit/?id=03fc931bfe9ea3fa9f33553e6020cbc067b24291
[5] https://git.openembedded.org/openembedded-core/commit/?id=722897f96d30e978b20e140419fb044d850f5c74
[6] https://git.openembedded.org/openembedded-core/commit/?id=0b4061c5d50261f826d0edb4b478d2d305274b7c

Consequently discard the meta-yocto layer.