### PR TITLE
gstreamer1.0-plugins-bad: enable WebRTC support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,2 @@
+# dependency recipes, srt, libsrtp, and libnice are provided by meta-oe layer
+PACKAGECONFIG:append:qcom = " sctp srt srtp webrtc"


### PR DESCRIPTION
Enable WebRTC functionality by adding the required components (sctp, srt, srtp, webrtc) to PACKAGECONFIG. 
This brings real‑time audio/video and data‑channel capabilities to GStreamer pipelines, allowing seamless peer‑to‑peer media transport and modern browser interoperability.