### PR TITLE
ci: update nightly build runs time

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,8 +4,8 @@ on:
   schedule:
   # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
   # so that build notification emails will be sent out properly.
-  # At 8:23 & 20:23 UTC everyday - picked a random "minute" as top of hour can be busy in github
-  - cron: "23 8,20 * * *"
+  # At 8:22 & 20:22 UTC everyday - picked a random "minute" as top of hour can be busy in github
+  - cron: "22 8,20 * * *"
 
 permissions:
   checks: write


### PR DESCRIPTION
Minor update (minute) so we can merge with quic-yocto-ci, required to share the build notification via list.