### PR TITLE
packagegroup-iq-8275-evk: add HMT WLAN and BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-8275-evk.bb
@@ -9,8 +9,8 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a623 linux-firmware-qcom-adreno-a650 linux-firmware-qcom-qcs8300-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x linux-firmware-qca-wcn7850', '', d)} \
     camxfirmware-monaco \
     linux-firmware-qcom-qcs8300-audio \
     linux-firmware-qcom-qcs8300-compute \


### PR DESCRIPTION
The IQ-8275-EVK platform needs support WCN7850 connectivity module over M.2 interface and therefore needs the corresponding firmware.

Add the required firmware packages for WCN7850 connectivity modules:
  - linux-firmware-ath12k-wcn7850 (WiFi firmware)
  - linux-firmware-qca-wcn7850 (BT UART firmware)