### PR TITLE
Use qcom-distro-kvm by default for RT 6.18 builds

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -111,9 +111,9 @@ jobs:
           - type: 6.18
             dirname: "_linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
-          - type: rt-6.18
-            dirname: "_linux-qcom-rt-6.18"
-            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
+          - type: rt-6.18-distro-kvm
+            dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
       - uses: actions/checkout@v4
@@ -166,9 +166,9 @@ jobs:
           - type: 6.18
             dirname: "_linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
-          - type: rt-6.18
-            dirname: "_linux-qcom-rt-6.18"
-            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
+          - type: rt-6.18-distro-kvm
+            dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a


### PR DESCRIPTION
The primary use case for RT kernel builds is latency testing under the KVM hypervisor. Update the CI build matrix to use the qcom-distro-kvm variant by default for RT 6.18 builds.