### PR TITLE
Bump qcom-dtb-metadata to v0.3 and update FIT compatible strings

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -9,24 +9,24 @@ FIT_DTB_COMPATIBLE[apq8096-db820c] = "qcom,apq8096-sbc"
 FIT_DTB_COMPATIBLE[glymur-crd] = "qcom,glymur-crd"
 FIT_DTB_COMPATIBLE[hamoa-iot-evk+hamoa-iot-evk-camera-imx577] = " \
     qcom,hamoa-evk \
-    qcom,hamoav2.1-evk \
+    qcom,hamoa-socv2.1-evk \
 "
 FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577] = " \
     qcom,qcs9075-iot \
-    qcom,qcs9075v2-iot \
+    qcom,qcs9075-socv2.0-iot \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx] = " \
     qcom,qcs9075-iot-camx \
-    qcom,qcs9075v2-iot-camx \
+    qcom,qcs9075-socv2.0-iot-camx \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2] = " \
     qcom,qcs9075-iot-el2kvm \
-    qcom,qcs9075v2-iot-el2kvm \
+    qcom,qcs9075-socv2.0-iot-el2kvm \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2] = " \
     qcom,qcs9075-iot-camx-el2kvm \
-    qcom,qcs9075v2-iot-camx-el2kvm \
+    qcom,qcs9075-socv2.0-iot-camx-el2kvm \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine] = " \
     qcom,qcs9075-iot-subtype1 \
@@ -44,7 +44,7 @@ FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead] = "qcom,msm8974"
 FIT_DTB_COMPATIBLE[qcs404-evb-4000] = "qcom,qcs404-evb-4000"
 FIT_DTB_COMPATIBLE[qcs615-ride] = " \
     qcom,qcs615-adp \
-    qcom,qcs615v1.1-adp \
+    qcom,qcs615-socv1.1-adp \
 "
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
     qcom,qcs5430-iot \
@@ -68,51 +68,51 @@ FIT_DTB_COMPATIBLE[qcs8300-ride] = "qcom,qcs8300-adp"
 FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx] = "qcom,qcs8300-adp-camx"
 FIT_DTB_COMPATIBLE[qcs9100-ride] = " \
     qcom,qcs9100-qam \
-    qcom,qcs9100v2-qam \
+    qcom,qcs9100-socv2.0-qam \
 "
 FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx] = " \
     qcom,qcs9100-qam-camx \
-    qcom,qcs9100v2-qam-camx \
+    qcom,qcs9100-socv2.0-qam-camx \
 "
 FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2] = " \
     qcom,qcs9100-qam-el2kvm \
-    qcom,qcs9100v2-qam-el2kvm \
+    qcom,qcs9100-socv2.0-qam-el2kvm \
 "
 FIT_DTB_COMPATIBLE[qcs9100-ride-r3] = " \
-    qcom,qcs9100-qamr2 \
-    qcom,qcs9100v2-qamr2 \
+    qcom,qcs9100-qam-r2.0 \
+    qcom,qcs9100-socv2.0-qam-r2.0 \
 "
 FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx] = " \
-    qcom,qcs9100-qamr2-camx \
-    qcom,qcs9100v2-qamr2-camx \
+    qcom,qcs9100-qam-r2.0 \
+    qcom,qcs9100-socv2.0-qam-r2.0-camx \
 "
 FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2] = " \
-    qcom,qcs9100-qamr2-el2kvm \
-    qcom,qcs9100v2-qamr2-el2kvm \
+    qcom,qcs9100-qam-r2.0-el2kvm \
+    qcom,qcs9100-socv2.0-qam-r2.0-el2kvm \
 "
 FIT_DTB_COMPATIBLE[qrb2210-rb1] = "qcom,qrb2210-rb1"
 FIT_DTB_COMPATIBLE[qrb4210-rb2] = "qcom,qrb4210-rb2"
 FIT_DTB_COMPATIBLE[qrb5165-rb5] = "qcom,qrb5165-rb5"
 FIT_DTB_COMPATIBLE[sa8775p-ride] = " \
     qcom,sa8775p-qam \
-    qcom,sa8775pv2-qam \
+    qcom,sa8775p-socv2.0-qam \
 "
 FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx] = " \
     qcom,sa8775p-qam-camx \
-    qcom,sa8775pv2-qam-camx \
+    qcom,sa8775p-socv2.0-qam-camx \
 "
 FIT_DTB_COMPATIBLE[sa8775p-ride-camx] = "qcom,sa8775p-qam-camx"
 FIT_DTB_COMPATIBLE[sa8775p-ride-r3] = " \
-    qcom,sa8775p-qamr2 \
-    qcom,sa8775pv2-qamr2 \
+    qcom,sa8775p-qam-r2.0 \
+    qcom,sa8775p-socv2.0-qam-r2.0 \
 "
 FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx] = " \
-    qcom,sa8775p-qamr2-camx \
-    qcom,sa8775pv2-qamr2-camx \
+    qcom,sa8775p-qam-r2.0-camx \
+    qcom,sa8775p-socv2.0-qam-r2.0-camx \
 "
 FIT_DTB_COMPATIBLE[sdm845-db845c] = "qcom,sdm845"
 FIT_DTB_COMPATIBLE[sm8450-hdk] = "qcom,sm8450-hdk"
 FIT_DTB_COMPATIBLE[sm8750-mtp] = "qcom,sm8750-mtp"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577] = "qcom,qcs615v1.1-iot"
+FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577] = "qcom,qcs615-socv1.1-iot"
 FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx] = "qcom,qcs615v1.1-iot-camx"
 FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01] = "qcom,talos-evk-lvds-auo,g133han01"

--- a/recipes-kernel/linux/qcom-dtb-metadata_0.3.bb
+++ b/recipes-kernel/linux/qcom-dtb-metadata_0.3.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-dtb-metadata.git;branch=main;protocol=https;tag=v${PV}"
 
-SRCREV = "7edf88de5af4d595fc1c91ed67b457501cffb609"
+SRCREV = "0c3dbe81151caa7f797c5cf34d6f7581ad416aa6"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Bump the qcom-dtb-metadata recipe to v0.3 to pick up support for the
new compatible string format. In this version, explicit `soc version` and 
`board revision` suffixes are introduced for DTB compatible string matching.
With this change, compatible strings that previously encoded SoC version or
board revision implicitly must be updated to the new format. 