### PR TITLE
Add debug build support in CI

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -106,6 +106,8 @@ jobs:
             yamlfile: ':ci/qcom-distro-prop-image.yml'
           - name: qcom-distro-catchall
             yamlfile: ':ci/qcom-distro-catchall.yml'
+          - name: debug
+            yamlfile: ':ci/qcom-distro-prop-image.yml:ci/debug.yml'
           - name: performance
             yamlfile: ':ci/qcom-distro-prop-image.yml:ci/performance.yml'
         kernel:
@@ -164,6 +166,8 @@ jobs:
             yamlfile: ':ci/qcom-distro-prop-image.yml'
           - name: qcom-distro-catchall
             yamlfile: ':ci/qcom-distro-catchall.yml'
+          - name: debug
+            yamlfile: ':ci/qcom-distro-prop-image.yml:ci/debug.yml'
           - name: performance
             yamlfile: ':ci/qcom-distro-prop-image.yml:ci/performance.yml'
         kernel:


### PR DESCRIPTION
Extend the GitHub workflows to build debug variants in CI. These builds are produced
with `DEBUG_BUILD=1` and are intended for long‑running stability testing, providing
additional logging and diagnostics to help analyze system behavior and failures.