### PR TITLE
Update userspace-resource-manager version from 0.1 to 0.2

### DIFF
--- a/recipes-support/userspace-resource-manager/userspace-resource-manager_0.2.bb
+++ b/recipes-support/userspace-resource-manager/userspace-resource-manager_0.2.bb
@@ -8,13 +8,14 @@ LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
 
 SRC_URI = "git://github.com/qualcomm/userspace-resource-manager.git;protocol=https;branch=main;tag=v${PV}"
-SRCREV = "2e4383baad53acbeb93ab63b409b8cb47f996e6d"
+SRCREV = "659e283c60ccd10e7d5320e8673a650cf2d3336f"
 
 inherit cmake pkgconfig systemd
 
 DEPENDS += "libyaml"
 
 PACKAGECONFIG ??= "\
+    classifier \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'state-detector systemd', '', d)} \
     tests \
 "
@@ -25,13 +26,14 @@ PACKAGECONFIG[systemd] = ",,systemd"
 PACKAGECONFIG[tests] = "-DBUILD_TESTS=ON,-DBUILD_TESTS=OFF"
 
 SYSTEMD_SERVICE:${PN} = "urm.service"
+FILES:${PN}-dev += "${libdir}/urm/libUrmTestPlugin.so"
 FILES:${PN} += "${sysconfdir}/urm/*"
 
 PACKAGE_BEFORE_PN += "${PN}-tests"
 FILES:${PN}-tests += " \
     ${sysconfdir}/urm/tests/* \
-    ${bindir}/RestuneComponentTests \
-    ${bindir}/RestuneIntegrationTests \
+    ${bindir}/UrmComponentTests \
+    ${bindir}/UrmIntegrationTests \
     ${libdir}/libRestuneTestUtils.so* \
-    ${libdir}/libRestunePlugin.so* \
+    ${libdir}/urm/libUrmTestPlugin.so* \
 "


### PR DESCRIPTION
CHANGES for 0.2:
* Added Classifier support to listen to and respond to incoming process events, in the 0.1 release classifier was disabled by default as the module was in active development, this release enables it.
* Added support for custom AppConfigs to support use case specific per-app configurations.
* Extended support for multiple Plugins, to influence config selection, and addition of custom resource Appliers and Teardown Callbacks.
* Enhanced config parsing code to support common, target specific as well as custom configs.
* Bug fixes for memory leaks and memory increase patterns seen in 0.1
* Renaming and Addition of new Interfaces, like URM_REGISTER_POST_PROCESS_CB, GET_TARGET_INFO which can be used by plugin code to register with URM, and fetch target information respectively.
* Additional test cases for classifier, improved framework for running tests and generating results (test report)