### PR TITLE
msm-gbm-backend: rename GBM backend library from msm_gbm to msm-kms_gbm

### DIFF
--- a/recipes-graphics/msm-gbm-backend/files/0004-QCOM-libgbm-rename-GBM-backend-library-from-msm_gbm-.patch
+++ b/recipes-graphics/msm-gbm-backend/files/0004-QCOM-libgbm-rename-GBM-backend-library-from-msm_gbm-.patch
@@ -1,0 +1,46 @@
+From 6dc20b5b7c4e37443935107d2b14a0444964a4ac Mon Sep 17 00:00:00 2001
+From: Yash Gupta <quic_ygupt@quicinc.com>
+Date: Wed, 4 Mar 2026 22:39:55 +0530
+Subject: [PATCH] QCOM:libgbm: add support for both 'msm' and 'msm-kms' GBM
+ backend names
+
+The MSM DRM subsystem now exposes two driver names: 'msm' (legacy
+combined GPU+KMS driver) and 'msm-kms' (new KMS-only driver used on
+KGSL-based platforms). Mesa's GBM backend auto-detection looks for
+'<drm_driver_name>_gbm.so', so both names must be resolvable.
+
+Build the library as 'msm-kms_gbm.so' and install a compatibility
+symlink 'msm_gbm.so -> msm-kms_gbm.so' so that both driver names
+resolve to the correct MSM GBM backend without requiring the
+GBM_BACKEND environment variable to be set explicitly.
+
+Signed-off-by: Yash Gupta <quic_ygupt@quicinc.com>
+Upstream-Status: Pending
+---
+ src/meson.build | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index f94d665..ec0d1d1 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -22,7 +22,7 @@ src = [
+     'schema_parser.h',
+ ]
+ 
+-msm_gbm = library('msm_gbm',
++msm_gbm = library('msm-kms_gbm',
+     src,
+     dependencies : [
+         gbm,
+@@ -44,3 +44,7 @@ install_data(
+ )
+ 
+ install_headers('gbm_msm.h')
++
++meson.add_install_script('sh', '-c',
++    'ln -sf msm-kms_gbm.so "$MESON_INSTALL_DESTDIR_PREFIX/lib/gbm/msm_gbm.so"'
++)
+-- 
+2.34.1
+

--- a/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
+++ b/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
@@ -10,14 +10,16 @@ SRCREV = "d2f771e8c80698a18b16f14ea60d5d55abede683"
 
 SRC_URI = "git://git.codelinaro.org/clo/le/display/libgbm.git;protocol=https;branch=display.qclinux.1.0.r1-rel \
            file://0002-QCOM-libgbm-use-sysconfdir-to-install-configuration-.patch \
-           file://0003-QCOM-libgbm-set-install-paths-for-backend-library-co.patch "
+           file://0003-QCOM-libgbm-set-install-paths-for-backend-library-co.patch \
+           file://0004-QCOM-libgbm-rename-GBM-backend-library-from-msm_gbm-.patch \
+"
 
 inherit meson pkgconfig features_check
 
 DEPENDS = "mesa libdrm libxml2"
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-FILES:${PN} = "${libdir}/gbm/msm_gbm.so* ${sysconfdir}/gbm/default_fmt_alignment.xml"
+FILES:${PN} = "${libdir}/gbm/msm*.so* ${sysconfdir}/gbm/default_fmt_alignment.xml"
 
-# libgbm uses dlopen() to load msm_gbm.so at runtime, so the .so file must be in the main package.
+# libgbm uses dlopen() to load msm_gbm.so or msm-kms_gbm.so at runtime, so the .so file must be in the main package.
 INSANE_SKIP:${PN} += "dev-so"


### PR DESCRIPTION
The DRM driver name was updated from 'msm' to 'msm-kms'. Mesa's GBM backend selection uses the DRM driver name to auto-discover the backend library by looking for '<drm_driver_name>_gbm.so' in GBM_BACKENDS_PATH or the default path (/usr/lib/gbm/).

With the old library name 'msm_gbm.so', Mesa cannot find the backend for driver 'msm-kms' and silently falls back to the generic 'dri' backend

Rename the library to 'msm-kms_gbm.so' so that Mesa's auto-detection picks the correct MSM GBM backend without requiring the GBM_BACKEND environment variable to be set explicitly.

KERNEL Commit ID for reference: - 217ed15bd399980981f90f4332bc7ad4b05baa7e