### PR TITLE
qcom-ptool: update revision

### DIFF
--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "509133553f095292f2d9b691a29239d75d083392"
+SRCREV = "28c6e9792121cb1c4e8ba74ee3c61e5041b9f861"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

feat(gen_partition)!: physical parts everywhere
feat(gen_partition): Add --phys-part flag
fix(platforms/iq-8275-evk/emmc)!: Revamp parts
feat(platforms): Add qcs8275-monza/emmc
gen_partition: convert partition_entries_dict into list
gen_partition: improve how disk parameters are parsed
gen_partition: improve parsing and managing partitions
platforms: update product names for mainline builds
tests: check-missing-files: add file used by SM8750-MTP
sm8750-mtp: update partition conf for sm8750-mtp