### PR TITLE
camera-service: Update latest source code

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_0.1.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_0.1.0.bb
@@ -5,13 +5,9 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
 
 HOMEPAGE = "https://github.com/qualcomm/camera-service"
 
-SRC_URI = "\
-    git://github.com/qualcomm/camera-service.git;branch=main;protocol=https \
-"
+SRC_URI = "git://github.com/qualcomm/camera-service;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "9ac3ead12ee10ae5485f12d01ea89970205b3cf0"
-
-PV = "0.0+git"
+SRCREV = "f6bb57c06fb1430f398e7f5aaf1a14726777dff9"
 
 # Limit this recipe to ARMv8 (aarch64) only, because it depends
 # on camxcommon-headers which is explicitly restricted to ARMv8 (aarch64).


### PR DESCRIPTION
This SRCREV bump pulls below key changes:
Enable the soc ID changes for Talos family to open correct lib for CAMX.
Create vendor tag descriptor in Connect API to get vendor tags access.
Updated tag to 0.1.0.
