### PR TITLE
build-yocto: run the yocto-run-checks in parallel with compile warm up

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -86,7 +86,7 @@ jobs:
           ci/kas-container-shell-helper.sh ci/yocto-patchreview.sh
 
   compile_warm_up:
-    needs: [kas-setup, yocto-run-checks]
+    needs: kas-setup
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:


### PR DESCRIPTION
We need to find a way to optimize yocto-check-layer, it takes around 20 minutes currently. From some analyses the biggest time consumers (top 5):

 test_machine_signatures — 9m 25.067s
 test_machine_world — 7m 4.832s
 test_world_inherit_class — 32.777s
 test_signatures — 32.661s
 test_world — 21.964s

When reduced to only one machine it takes about 3m41.149s in total.

Debugging continues to understand what we can change to fix this.
However, we will run yocto-check-layer in parallel, thus removing ~20 minutes from the total build time.