### PR TITLE
alsa-ucm-conf: Update channel setting lemans/monaco

### DIFF
--- a/recipes-multimedia/alsa/alsa-ucm-conf/0001-Qualcomm-qcs615-Remove-JackControl-from-TALOS-EVK-Hi.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0001-Qualcomm-qcs615-Remove-JackControl-from-TALOS-EVK-Hi.patch
@@ -1,0 +1,43 @@
+From 3e414225c90de8a9371076bcdd33693dfe8e54c2 Mon Sep 17 00:00:00 2001
+From: Le Qi <le.qi@oss.qualcomm.com>
+Date: Thu, 12 Feb 2026 15:16:41 +0800
+Subject: [PATCH] Qualcomm: qcs615: Remove JackControl from TALOS EVK HiFi
+ config
+
+The EVK board does not support headset or jack detection.
+Keeping JackControl entries prevents PipeWire (wpctl) from
+exposing sinks and sources correctly.
+
+Remove JackControl from Headphones and Headset devices so
+PipeWire can enumerate playback and capture nodes normally.
+
+Upstream-Status: Backport
+[https://github.com/alsa-project/alsa-ucm-conf/pull/704]
+Signed-off-by: Le Qi <le.qi@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ ucm2/Qualcomm/qcs615/HiFi.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/ucm2/Qualcomm/qcs615/HiFi.conf b/ucm2/Qualcomm/qcs615/HiFi.conf
+index 8978b2cb539d..a20fc89fa8f4 100644
+--- a/ucm2/Qualcomm/qcs615/HiFi.conf
++++ b/ucm2/Qualcomm/qcs615/HiFi.conf
+@@ -20,7 +20,6 @@ SectionDevice."Headphones" {
+ 		PlaybackPCM "hw:${CardId},0"
+ 		PlaybackMixer "default:${CardId}"
+ 		PlaybackMixerElem "HP Digital"
+-		JackControl "Headphone Jack"
+ 	}
+ }
+ 
+@@ -33,7 +32,6 @@ SectionDevice."Headset" {
+ 	Value {
+ 		CapturePriority 100
+ 		CapturePCM "hw:${CardId},1"
+-		JackControl "Mic Jack"
+ 		JackHWMute "Mic"
+ 	}
+ }
+-- 
+2.34.1

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0001-ucm2-Qualcomm-sa8775p-Remove-Fixed-channel-setting-f.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0001-ucm2-Qualcomm-sa8775p-Remove-Fixed-channel-setting-f.patch
@@ -1,0 +1,32 @@
+From ba4126955f3e145d3a70171b5e8a23aafa157052 Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Fri, 23 Jan 2026 15:26:17 +0530
+Subject: [PATCH 01/02] ucm2: Qualcomm: sa8775p: Remove Fixed channel setting
+ for lemans-evk
+
+Remove Fixed channel setting for lemans-evk to support stereo
+capture.
+
+Upstream-Status: Backport
+[https://github.com/alsa-project/alsa-ucm-conf/commit/ba4126955f3e145d3a70171b5e8a23aafa157052]
+Closes: https://github.com/alsa-project/alsa-ucm-conf/pull/694
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ ucm2/Qualcomm/sa8775p/lemans-evk/HiFi.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/ucm2/Qualcomm/sa8775p/lemans-evk/HiFi.conf b/ucm2/Qualcomm/sa8775p/lemans-evk/HiFi.conf
+index 5915d1c..f2be928 100644
+--- a/ucm2/Qualcomm/sa8775p/lemans-evk/HiFi.conf
++++ b/ucm2/Qualcomm/sa8775p/lemans-evk/HiFi.conf
+@@ -25,6 +25,5 @@ SectionDevice."Mic" {
+ 	Value {
+ 		CapturePriority 100
+ 		CapturePCM "hw:${CardId},1"
+-		CaptureChannels 1
+ 	}
+ }
+-- 
+2.34.1
+

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0002-ucm2-Qualcomm-qcs8300-Remove-Fixed-channel-setting-f.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0002-ucm2-Qualcomm-qcs8300-Remove-Fixed-channel-setting-f.patch
@@ -1,0 +1,32 @@
+From 5c7b40c96b6cefd4d1d545d89b6d030248f0bb1c Mon Sep 17 00:00:00 2001
+From: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Date: Fri, 23 Jan 2026 15:31:34 +0530
+Subject: [PATCH 02/02] ucm2: Qualcomm: qcs8300: Remove Fixed channel setting
+ for monaco-evk
+
+Remove Fixed channel setting for monaco-evk to support stereo
+capture.
+
+Upstream-Status: Backport
+[https://github.com/alsa-project/alsa-ucm-conf/commit/5c7b40c96b6cefd4d1d545d89b6d030248f0bb1c]
+Closes: https://github.com/alsa-project/alsa-ucm-conf/pull/694
+Signed-off-by: Mohammad Rafi Shaik <mohammad.rafi.shaik@oss.qualcomm.com>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf b/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf
+index 8345129..b60a310 100644
+--- a/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf
++++ b/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf
+@@ -25,6 +25,5 @@ SectionDevice."Mic" {
+ 	Value {
+ 		CapturePriority 100
+ 		CapturePCM "hw:${CardId},1"
+-		CaptureChannels 1
+ 	}
+ }
+-- 
+2.34.1
+

--- a/recipes-multimedia/alsa/alsa-ucm-conf_%.bbappend
+++ b/recipes-multimedia/alsa/alsa-ucm-conf_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-ucm2-Qualcomm-sa8775p-Remove-Fixed-channel-setting-f.patch \
+    file://0002-ucm2-Qualcomm-qcs8300-Remove-Fixed-channel-setting-f.patch \
+    file://0001-Qualcomm-qcs615-Remove-JackControl-from-TALOS-EVK-Hi.patch \
+"


### PR DESCRIPTION
Remove Fixed channel setting for lemans and monaco evk to support stereo capture.
Remove JackControl from Headphones and Headset devices so PipeWire can enumerate playback and capture nodes normally.
Patches sent to OE-core.

Link: https://lore.kernel.org/openembedded-core/20260306062704.3647403-1-mohammad.rafi.shaik@oss.qualcomm.com/T/#u
Link: https://lore.kernel.org/openembedded-core/20260305031518.4120410-1-le.qi@oss.qualcomm.com/T/#u
Link: https://github.com/alsa-project/alsa-ucm-conf/commit/ba4126955f3e145d3a70171b5e8a23aafa157052
Link: https://github.com/alsa-project/alsa-ucm-conf/commit/5c7b40c96b6cefd4d1d545d89b6d030248f0bb1c
Link: https://github.com/alsa-project/alsa-ucm-conf/commit/e513b19d223f1559f43579e881ba86c618c142a9