### PR TITLE
Add firmware binaries to qcom-armv8a machine

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -85,6 +85,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-dragonboard820c-firmware \
     packagegroup-dragonboard845c-firmware \
     packagegroup-iq-8275-evk-firmware \
+    packagegroup-iq-9075-evk-firmware \
     packagegroup-rb1-firmware \
     packagegroup-rb2-firmware \
     packagegroup-rb3gen2-firmware \


### PR DESCRIPTION
Firmware binaries required for the iq-8275 and iq-9075 platform are not included by default in images built for qcom-armv8a. 
Since the firmware package is not part of the machine’s essential recommendations, systems may boot without the necessary firmware, leading to incomplete hardware support at runtime.
This change adds firmware packagegroup to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS. 
By doing so, the required firmware binaries for the iq-8275 platform are automatically pulled into the image, ensuring they are available by default on qcom-armv8a builds.