### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260306

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.7"
+LINUX_VERSION ?= "6.18.12"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260220
-SRCREV ?= "0e842c87bef399ca8ceee751c8c0073fd463bac6"
+# tag: qcom-6.18.y-20260306
+SRCREV ?= "3fb7ebac4f5bfb105d77b473ed4eb53b3bb0aba4"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260306

Changelog:

QCLINUX: arm64: configs: Enable configs for uPD720201 and GL3590
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable uPD720201 and GL3590
FROMGIT: arm64: dts: qcom: add basic devicetree for Ayaneo Pocket S2 gaming console
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2-industrial-mezzanine: Add second TC9563 PCIe switch node for PCIe1
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2-industrial-mezzanine: Add TC9563 PCIe switch node for PCIe0
FROMLIST: arm64: dts: qcom: sm8650: Add sound DAI prefix for DP
FROMLIST: dt-bindings: arm: qcom: document the Ayaneo Pocket S2
FROMLIST: dt-binding: vendor-prefixes: document the Ayaneo brand
FROMLIST: arm64: defconfig: enable pci-pwrctrl-generic as module
FROMLIST: pci: pwrctrl: generic: support for the UPD720201/UPD720202 USB 3.0 xHCI Host Controller
FROMLIST: misc: fastrpc: Add reference counting for fastrpc_user structure Add reference counting using kref to the fastrpc_user structure to prevent use-after-free issues when contexts are freed from workqueue after device release
BACKPORT: media: v4l2: Add description for V4L2_PIX_FMT_AV1 in v4l_fill_fmtdesc()
BACKPORT: media: uapi: videodev2: Add support for AV1 stateful decoder
BACKPORT: media: venus: vdec: restrict EOS addr quirk to IRIS2 only
BACKPORT: media: iris: Define AV1-specific platform capabilities and properties
BACKPORT: media: iris: Add support for AV1 format in iris decoder
BACKPORT: media: iris: Add internal buffer calculation for AV1 decoder
QCLINUX: arm64: dts: qcom: lemans: Add CamX EL2 overlay
FROMLIST: arm64: dts: qcom: Enable lvds panel-DV215FHM-R01 for lemans-evk Mezzanine
FROMLIST: pci: pwrctrl: rename pci-pwrctrl-slot as generic
FROMLIST: pci: pwrctrl: slot: fix dev_err_probe() usage
FROMLIST: dt-bindings: usb: document the Renesas UPD720201/UPD720202 USB 3.0 xHCI Host Controller
FROMLIST: regulator: core: Remove regulator supply_name length limit
FROMLIST: PCI: qcom: Add .get_ltssm() helper
QCLINUX: qcom.config: enable the ICE related config
WORKAROUND: arm64: dts: qcom: talos-evk-som: Enable ethernet node
BACKPORT: arm64: dts: qcom: monaco-evk: Enable primary USB controller in host mode
FROMLIST: arm64: dts: qcom: monaco-evk: Enable the tertiary USB controller
FROMLIST: arm64: dts: qcom: monaco-evk: Enable GPIO expander interrupt for Monaco EVK
BACKPORT: arm64: dts: qcom: qcs615: Update 'model' string for qcs615 ride
FROMLIST: arm64: dts: qcom: lemans-evk: Enable wakeup for primary USB controller
FROMLIST: usb: typec: hd3ss3220: Add wakeup support from system suspend
FROMLIST: arm64: dts: qcom: qcs615-ride: Enable ethernet node
FROMLIST: arm64: dts: qcom: talos: add ethernet node
FROMLIST: net: stmmac: Inverse the phy-mode definition
WORKAROUND: PCI: Disable L1ss through quirk for HMT & Cologne
BACKPORT: driver: bluetooth: hci_qca: Fix SSR (SubSystem Restart) fail when BT_EN is pulled up by hw
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable USB2 controller Micro-USB OTG
FROMLIST: arm64: dts: qcom: lemans-evk: Enable the tertiary USB controller
FROMLIST: arm64: dts: qcom: lemans-evk: Enable GPIO expander interrupt for Lemans EVK
FROMLIST: usb: typec: hd3ss3220: Enable VBUS based on role state
FROMLIST: arm64: dts: qcom: lemans-evk: Enable secondary USB controller in host mode
FROMLIST: arm64: dts: qcom: lemans-evk: Rename hd3ss3220_ instance for primary port controller
FROMLIST: usb: misc: onboard_usb_hub: Add Genesys Logic GL3590 hub support
FROMLIST: dt-bindings: usb: Add binding for Genesys Logic GL3590 hub
UPSTREAM: arm64: dts: qcom: lemans-evk: Add OTG support for primary USB controller
UPSTREAM: usb: typec: hd3ss3220: Enable VBUS based on ID pin state
UPSTREAM: dt-bindings: usb: ti,hd3ss3220: Add support for VBUS based on ID state
FROMLIST: iommu/arm-smmu-qcom: Restore ACTLR settings for MDSS on sa8775p
FROMGIT: iommu/arm-smmu-qcom: add actlr settings for mdss on Qualcomm platforms

PR Test Results  : 
| Test Case | [qcs615](https://lava.infra.foundries.io/scheduler/job/155211) | [qcs615_prop](https://lava.infra.foundries.io/scheduler/job/155423) | [rb3gen2](https://lava.infra.foundries.io/scheduler/job/155209) | [rb3gen2_prop](https://lava.infra.foundries.io/scheduler/job/155451) | [rb8](https://lava.infra.foundries.io/scheduler/job/155210) | [rb8_prop](https://lava.infra.foundries.io/scheduler/job/155422) |
| --- | --- | --- | --- | --- | --- | --- |
| adsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| AudioRecord | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ❌ Fail |
| BT_ON_OFF | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| cdsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| CPUFreq_Validation | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| DSP_AudioPD | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Ethernet | ✅ Pass | ⚠️ Skip | ⚠️ Skip | ⚠️ Skip | ⚠️ Skip | ✅ Pass |
| hotplug | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Interrupts | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| irq | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| OpenCV | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_Firmware_Driver | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_OnOff | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |

AudioRecord failure corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1664 

Kernel Test Team Report: 

Base Build : 
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass |
Audio Record | Pass | Pass | Pass | NA |  
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encoder H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Pass | Pass | Pass | Pass |  
Graphics | Pass | Pass | Pass | Pass |  
DSP | Pass | Pass | Pass | Pass |  
Open CV | Pass | Pass | Pass | Pass |  

Overlay build : 
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass | 
Audio Record | Pass | Pass | Pass | NA |  During audio Tests , restarting  PipeWire sometimes takes more time
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encode H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Pass | Pass | Pass | Pass |  
Graphics | Pass | Pass | Pass | Pass |  
DSP | Pass | Pass | Pass | Pass |  
FastCV | Pass | Pass | Pass | Pass |  
