### PR TITLE
Adds BSP layer download mirrors

### DIFF
--- a/ci/mirror-download-disable.yml
+++ b/ci/mirror-download-disable.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+# This fragment should be used in a clean DL_DIR running all the bitbake fetch tasks
+# bitbake --runall fetch world
+
+header:
+  version: 14
+
+local_conf_header:
+  download_mirror_disable: |
+    INHERIT:remove = "qli-mirrors"

--- a/ci/mirror-download-test.yml
+++ b/ci/mirror-download-test.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+# This fragment should be used in a clean DL_DIR running all the bitbake fetch tasks
+# bitbake --runall fetch world
+
+header:
+  version: 14
+
+local_conf_header:
+  download_mirror_test: |
+    BB_FETCH_PREMIRRORONLY = "1"
+    PREMIRRORS += "${QLI_MIRRORS}"

--- a/classes/qli-mirrors.bbclass
+++ b/classes/qli-mirrors.bbclass
@@ -1,0 +1,25 @@
+# Qualcomm Linux download mirrors to minimize reproducibility issues
+#
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+
+QLI_MIRRORS_URI ?= "https://artifacts.codelinaro.org/aritfactory/qli-ci/downloads/${QLI_BASELINE}"
+
+QLI_MIRRORS ?= " \
+svn://.*/.*     ${QLI_MIRRORS_URI}/ \
+git://.*/.*     ${QLI_MIRRORS_URI}/ \
+gitsm://.*/.*   ${QLI_MIRRORS_URI}/ \
+hg://.*/.*      ${QLI_MIRRORS_URI}/ \
+p4://.*/.*      ${QLI_MIRRORS_URI}/ \
+https?://.*/.*  ${QLI_MIRRORS_URI}/ \
+ftp://.*/.*     ${QLI_MIRRORS_URI}/ \
+npm://.*/?.*    ${QLI_MIRRORS_URI}/ \
+s3://.*/.*      ${QLI_MIRRORS_URI}/ \
+crate://.*/.*   ${QLI_MIRRORS_URI}/ \
+gs://.*/.*      ${QLI_MIRRORS_URI}/ \
+"
+
+# Add Qualcomm Linux mirror so we can fallback to it
+MIRRORS += "${QLI_MIRRORS}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,6 +28,9 @@ BBFILES_DYNAMIC += " \
     selinux:${LAYERDIR}/dynamic-layers/selinux/*/*/*.bbappend \
 "
 
+# Qualcomm Linux baseline
+QLI_BASELINE = "main"
+
 # Set default provider for virtual-diag-router to avoid warnings
 # when both diag and diag-router are available
 PREFERRED_RPROVIDER_virtual-diag-router ?= "diag"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,6 +31,8 @@ BBFILES_DYNAMIC += " \
 # Qualcomm Linux baseline
 QLI_BASELINE = "main"
 
+INHERIT += "qli-mirrors"
+
 # Set default provider for virtual-diag-router to avoid warnings
 # when both diag and diag-router are available
 PREFERRED_RPROVIDER_virtual-diag-router ?= "diag"


### PR DESCRIPTION
Adds the official mirror of the BSP, which contains the necessary artifacts to minimize reproducibility issues as much as possible. The mirror uses the MIRRORS and thus works in fallback mode; when the official source is not available, the mirror is used.