### PR TITLE
fastrpc: upgrade 1.0.3 -> 1.0.4

### DIFF
--- a/recipes-support/fastrpc/fastrpc_1.0.4.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.4.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b67986b6880754696d418dbaa2cf51d1"
 DEPENDS = "libbsd libyaml"
 
-SRCREV = "3ac74f68dfcc5aa3a9524d1700a4c0d6a92316a8"
+SRCREV = "8572ae1c45d38a4dc8853b1b9b6738207ab1ce94"
 SRC_URI = "\
     git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
     file://run-ptest \


### PR DESCRIPTION
Upgrade FastRPC from version 1.0.3 to 1.0.4

### Top-Level Changelog
**Core Enhancements**

- Refactored memory mapping with DSP address tracking for improved
correctness and robustness.
- Added help functionality to dsprpcd for better usability.
- Added support for the qcs615-ride target in Talos.

**CI/CD Improvements**

- Added nightly kernel build workflow with weekly artifact uploads.
- Introduced precompiled kernel workflow with S3-based artifact reuse.
- Enabled ABI compatibility checker in CI.
- Switched to generic overlay without kselftest and env-based test method.
- Updated production S3 bucket for FastRPC artifacts.

**Build & Tooling Improvements**

- Moved -ldl, -lm, and $(USE_LOG) from LDFLAGS to *_LIBADD
for correct linkage semantics.
- Added cross-compilation dependency installation instructions.

**Code Cleanup & Maintenance**

- Removed stale asynchronous FastRPC code.
- Dropped unsupported ADSP_AVS_* environment handling from path resolver.
- Updated .gitignore to include .dirstamp.

**Documentation Improvements**

- Converted PNG images to Mermaid diagrams in README for better
maintainability and clarity.

Full Changelog: [v1.0.3...v1.0.4](https://github.com/qualcomm/fastrpc/compare/v1.0.3...v1.0.4)