### PR TITLE
iris-video-dlkm: update iris driver to v1.0.1

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.1.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.1.bb
@@ -3,14 +3,12 @@ LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
-PV = "0.0+git"
-
 SRC_URI = " \
-    git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.main \
+    git://github.com/qualcomm-linux/video-driver.git;protocol=https;branch=video.qclinux.main;tag=v${PV} \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "0e0fe75fb1910e011358485b078ea207a5c5f3e7"
+SRCREV  = "224c671c84c082e96e3afa9a4844b31ad2703761"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.1 brings a below updates for Qcom Iris
- Aligns compose selection values with crop for non‑scaling IRIS variants
- Fixes FRMIVAL stepwise denominators by converting Q16 frame‑rate values
- Align encoder input resolution to fix green lines at the bottom