### PR TITLE
gst-plugins-imsdk: Update SRCREV to include qtiqmmfsrc improvements

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
@@ -10,14 +10,14 @@ inherit cmake features_check pkgconfig
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-SRC_URI = "git://github.com/qualcomm/gst-plugins-imsdk;branch=main;protocol=https"
+SRC_URI = "git://github.com/qualcomm/gst-plugins-imsdk;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "268dc4daa7fb3813bdfd481ff15e38f8d844105c"
-PV = "0.0+git"
+SRCREV = "538ab4e1ab048e619b08f82f8a737621f60d6d32"
 
 DEPENDS += "\
     gstreamer1.0 \
     gstreamer1.0-plugins-base \
+    json-glib \
     virtual/egl \
     virtual/libgbm \
     virtual/libgles2 \


### PR DESCRIPTION
This SRCREV bump pulls below key changes:
- Improve the JSON utility library with minor enhancements. 
- Update the HAL pixel formats in the qtiqmmfsrc plugin. 
- Apply minor updates in qtiqmmfsrc to maintain backward compatibility. 
- Update the qtiqmmfsrc allocator to use the DMABUF allocator for compatibility with open‑source plugins.