### PR TITLE
gst-plugins-imsdk: qtismartvencbin: add runtime dependency

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
@@ -42,3 +42,6 @@ PACKAGECONFIG[videoproc]    = "-DENABLE_GST_VIDEOPROC_PLUGINS=1, -DENABLE_GST_VI
 
 # The TFLite plugin loads the TensorFlow Lite library at runtime using dlopen(). To ensure runtime availability, added runtime dependency on 'tensorflow-lite'.
 RDEPENDS:${PN}-qtimltflite += "tensorflow-lite"
+
+# The Smart Video Encoder plugin loads the libVideoCtrl library at runtime using dlopen(). To ensure runtime availability, added runtime dependency on 'smart-venc-ctrl-algo'.
+RDEPENDS:${PN}-qtismartvencbin += "smart-venc-ctrl-algo"


### PR DESCRIPTION
Ensure that the Smart Video Encoder plugin can load the libVideoCtrl library at runtime by adding a runtime dependency on smart-venc-ctrl-algo. The plugin uses dlopen() to load this library, so the dependency guarantees its availability during execution.