### PR TITLE
systemd: enable non-root access to /dev/dma_heap/system via dmaheap group

### DIFF
--- a/recipes-core/systemd/systemd/99-dma-heap.rules
+++ b/recipes-core/systemd/systemd/99-dma-heap.rules
@@ -1,0 +1,2 @@
+# Assign /dev/dma_heap/system to the dmaheap group
+SUBSYSTEM=="dma_heap", KERNEL=="system", GROUP="dmaheap", MODE="0660"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom = " file://99-dma-heap.rules"
+
+# Create a group dmaheap and add this group to /dev/dma_heap/system through
+# dma-heap rules.
+GROUPADD_PARAM:udev:append:qcom = "; -r dmaheap"
+
+do_install:append:qcom() {
+    install -d ${D}${nonarch_libdir}/udev/rules.d
+    install -m 0644 ${UNPACKDIR}/99-dma-heap.rules \
+        ${D}${nonarch_libdir}/udev/rules.d/
+}
+
+FILES:${PN}-udev-rules:append:qcom = " ${nonarch_libdir}/udev/rules.d/99-dma-heap.rules"


### PR DESCRIPTION
Services such as camera-service and gstd cannot access /dev/dma_heap/system because the device is created with restrictive default permissions. This prevents these services from allocating DMA‑Heap buffers unless they run as root, which is not desirable from a security or deployment perspective.

This PR introduces a dedicated dmaheap system group and adds a udev rule that assigns /dev/dma_heap/system to this group with mode 0660. Services that require DMA‑Heap access can be added to this group, enabling safe, non‑root access while maintaining appropriate permission isolation.