### PR TITLE
rb3gen2-core-kit: declare TPM2 machine feature

### DIFF
--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -4,7 +4,8 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES += "efi pci"
+# NOTE: TPM hardware is only present on rb3gen2-industrial kit
+MACHINE_FEATURES += "efi pci tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \


### PR DESCRIPTION
The rb3gen2 MACHINE configuration is updated to expose TPM2 capability through MACHINE_FEATURES. This allows the meta-security layer (and in particular meta-tpm) to correctly include TPM2 userspace components, kernel config fragments, and system integration units.

meta-security enablement was part of PR #1504 

the build now automatically enables:
- TPM2 userspace stack (tpm2-tss)
- TPM2 tooling (tpm2-tools)
- TPM2 resource manager integration
- Associated kernel configuration fragments from meta-security
- EFI/PCI dependencies required for TPM2 initialization paths

These features ensure proper TPM2 support on rb3gen2 platforms where a dTPM is exposed over SPI.

This change is specific to rb3gen2 and does not affect other machines.