### PR TITLE
qcm6490-idp: add phone capability via MACHINE_FEATURES

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \


### PR DESCRIPTION
This change adds the 'phone' capability to MACHINE_FEATURES for the
qcm6490-idp machine.

The intention is to advertise telephony support at the machine level,
allowing higher layers to enable cellular-related components capabilities.