### PR TITLE
kgsl-dlkm: update KGSL tip

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
 PV = "0.0+git"
-SRCREV = "6aa5a97573c59f729f1451e32f3b29c16269fa20"
+SRCREV = "e6acc292411162018f3dd24c61b607386b0328d3"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https \
     file://kgsl.rules \


### PR DESCRIPTION
Update the SRCREV to point to the latest commit in the KGSL source code repository. This update brings in few upgrades and fixes:

- Add UBWC config API support and refactor hbb handling
- Add support for A702 GPU with standard DT bindings
- Update performance state handling for NoGMU/RGMU on standard kernels
- Revert "kgsl: pwrctrl: Skip waiting for CX GDSC collapse during slumber"