### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260309

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260306
-SRCREV ?= "3fb7ebac4f5bfb105d77b473ed4eb53b3bb0aba4"
+# tag: qcom-6.18.y-20260309
+SRCREV ?= "06f8ab99cf04dd7ce71861f57f7b516004a9b5e2"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260309

Changelog:
FROMLIST: arm64: dts: qcom: lemans-evk: Add IFP Mezzanine
Revert "FROMLIST: arm64: dts: qcom: lemans-evk: Add Mezzanine"
Revert "FROMLIST: arm64: dts: qcom: Enable lvds panel-DV215FHM-R01 for lemans-evk Mezzanine"
UPSTREAM: arm64: defconfig: Enable configs for Fairphone 3, 4, 5 smartphones
FROMLIST: arm64: dts: qcom: monaco-evk: Add IFP Mezzanine
Revert "FROMLIST: arm64: dts: qcom: monaco-evk: Add Mezzanine"
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: use DP controller native HPD
WORKAROUND: clk: qcom: gcc-qcs8300: Use PWRSTS_RET_ON for USB GDSCs
WORKAROUND: clk: qcom: gcc-sa8775p: Use PWRSTS_RET_ON for USB GDSCs
FROMLIST: arm64: dts: qcom: talos: Mark usb controllers are wakeup capable devices
FROMLIST: arm64: dts: qcom: talos: Flatten usb controller nodes
FROMGIT: arm64: dts: qcom: qcs6490-rb3gen2: Enable CAN bus controller
FROMGIT: dt-bindings: can: microchip,mcp251xfd: allow gpio-hog child nodes
FROMLIST: dt-bindings: can: mcp251xfd: add gpio-controller property
FROMLIST: can: mcp251xfd: add gpio functionality
FROMLIST: can: mcp251xfd: only configure PIN1 when rx_int is set
FROMLIST: can: mcp251xfd: add workaround for errata 5
FROMLIST: can: mcp251xfd: utilize gather_write function for all non-CRC writes
FROMLIST: can: mcp251xfd: move chip sleep mode into runtime pm
QCLINUX: prune.config: Enable MCP251XFD CAN for Kodiak
FROMLIST: arm64: configs: Update defconfig for DSI-LVDS bridge support
FROMLIST: drm/bridge: add support for lontium lt9211c bridge
FROMLIST: dt-bindings: bridge: lt9211: Add bindings
FROMLIST: bus: mhi: host: pci_generic: Add Qualcomm SDX35 modem