### PR TITLE
modemmanager: enable qrtr and add TA SMS functionalities for ModemManager.

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-iface-modem-messaging-sms-Add-TA-storage-support-for.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-iface-modem-messaging-sms-Add-TA-storage-support-for.patch
@@ -1,0 +1,956 @@
+From adfe788fae96ed01f0e4278c974d429058684f7d Mon Sep 17 00:00:00 2001
+From: Akula Susmitha <quic_asusmith@quicinc.com>
+Date: Tue, 5 Nov 2024 15:03:07 +0530
+Subject: [PATCH 01/10] iface-modem-messaging,sms: Add TA storage support for
+ SMS
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+Signed-off-by: Akula Susmitha <quic_asusmith@quicinc.com>
+---
+ .gitlab-ci.yml                 |   3 +-
+ meson.build                    |   1 +
+ src/meson.build                |   4 +
+ src/mm-broadband-modem-qmi.c   | 156 +++++++++++++--
+ src/mm-iface-modem-messaging.c |  12 ++
+ src/mm-sms-part-3gpp.c         |   6 +-
+ src/mm-sms-part.c              |  21 ++
+ src/mm-sms-part.h              |   5 +
+ src/mm-sms-qmi.c               |  73 ++++++-
+ src/mm-sms-storage.c           | 341 +++++++++++++++++++++++++++++++++
+ src/mm-sms-storage.h           |  47 +++++
+ 11 files changed, 642 insertions(+), 27 deletions(-)
+ create mode 100644 src/mm-sms-storage.c
+ create mode 100644 src/mm-sms-storage.h
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index ca4c1ef6..c8341fca 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -13,7 +13,7 @@ stages:
+   variables:
+     FDO_UPSTREAM_REPO: mobile-broadband/ModemManager
+     FDO_DISTRIBUTION_VERSION: '20.04'
+-    FDO_DISTRIBUTION_TAG: '2023-01-03.1'
++    FDO_DISTRIBUTION_TAG: '2023-01-03.2'
+     FDO_DISTRIBUTION_PACKAGES: ca-certificates git gcc meson ninja-build gawk
+                                libgettextpo-dev libgirepository1.0-dev libglib2.0-dev
+                                libgudev-1.0-dev python3-dbus python3-gi autopoint
+@@ -21,6 +21,7 @@ stages:
+                                gobject-introspection python-is-python3 libsystemd-dev
+                                libpolkit-gobject-1-dev valac libdbus-1-dev
+                                bash-completion udev policykit-1 help2man findutils
++                               libjson-glib-dev
+     LIBQMI_BRANCH: 'main'
+     LIBQRTR_BRANCH: 'main'
+     LIBMBIM_BRANCH: 'main'
+diff --git a/meson.build b/meson.build
+index 99cb6fcc..2a0b9734 100644
+--- a/meson.build
++++ b/meson.build
+@@ -76,6 +76,7 @@ cc = meson.get_compiler('c')
+ config_h = configuration_data()
+ config_h.set_quoted('PACKAGE_VERSION', mm_version)
+ config_h.set_quoted('VERSION', mm_version)
++config_h.set_quoted('PKGSYSCONFDIR', mm_pkgsysconfdir)
+ 
+ # Globally define_GNU_SOURCE and therefore enable the GNU extensions
+ config_h.set('_GNU_SOURCE', true)
+diff --git a/src/meson.build b/src/meson.build
+index f2a53625..5f7439e8 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -300,14 +300,18 @@ sources = files(
+   'mm-private-boxed-types.c',
+   'mm-sms-list.c',
+   'mm-sleep-context.c',
++  'mm-sms-storage.c',
+ )
+ 
+ sources += daemon_enums_sources
+ 
++json_glib_dep = dependency('json-glib-1.0', version: '>= 1.0')
++
+ deps = [
+   gmodule_dep,
+   libport_dep,
+   libqcdm_dep,
++  json_glib_dep
+ ]
+ 
+ if enable_tests
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 7ce39d59..746d98f7 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -52,6 +52,7 @@
+ #include "mm-sms-part-cdma.h"
+ #include "mm-call-qmi.h"
+ #include "mm-call-list.h"
++#include "mm-sms-storage.h"
+ 
+ static void iface_modem_init                      (MMIfaceModemInterface                   *iface);
+ static void iface_modem_3gpp_init                 (MMIfaceModem3gppInterface               *iface);
+@@ -7592,6 +7593,8 @@ messaging_load_supported_storages_finish (MMIfaceModemMessaging *_self,
+     }
+     supported = MM_SMS_STORAGE_ME;
+     g_array_append_val (*mem1, supported);
++    supported = MM_SMS_STORAGE_TA;
++    g_array_append_val (*mem1, supported);
+     *mem2 = g_array_ref (*mem1);
+     *mem3 = g_array_ref (*mem1);
+     return TRUE;
+@@ -7667,22 +7670,50 @@ wms_get_routes_ready (QmiClientWms *client,
+         g_prefix_error (&error, "got invalid SMS routes: ");
+         g_task_return_error (task, error);
+     } else {
++        MMSmsStorage storage_type = MM_SMS_STORAGE_UNKNOWN;
++
+         for (i = 0; i < route_list->len; i++) {
+             QmiMessageWmsGetRoutesOutputRouteListElement *route;
+ 
+             route = &g_array_index (route_list, QmiMessageWmsGetRoutesOutputRouteListElement, i);
+-
+-            if ((route->message_class == QMI_WMS_MESSAGE_CLASS_0 ||
+-                 route->message_class == QMI_WMS_MESSAGE_CLASS_1) &&
+-                 (route->receipt_action == QMI_WMS_RECEIPT_ACTION_STORE_AND_NOTIFY)) {
+-                storage = mm_sms_storage_from_qmi_storage_type (route->storage);
++            if (route->storage != QMI_WMS_STORAGE_TYPE_NONE) {
++                if (route->message_class == QMI_WMS_MESSAGE_CLASS_1 ||
++                    route->message_class == QMI_WMS_MESSAGE_CLASS_3 ||
++                    route->message_class == QMI_WMS_MESSAGE_CLASS_NONE) {
++                    storage = mm_sms_storage_from_qmi_storage_type (route->storage);
++                    break;
++                }
++            }
++        }
++        mm_obj_dbg (self, "Default route defined for SMS Messaging is set to store at: %s",
++                    mm_sms_storage_get_string (storage));
++
++        /* Modem Report None either on fresh boot or When user set to TA.
++         * To distinguish between fresh boot or normal boot, validate
++         * storage_type variable in storage.
++         * storage_type variable will be Unknown only in first boot after flash.
++         * Thus storage variable can be initialized to UNKNOWN and will
++         * be set to default_storage variable to ME while Enabling. */
++        if (storage == MM_SMS_STORAGE_UNKNOWN) {
++            if (!mm_sms_get_default_storage_type (&storage_type, &error)) {
++                mm_obj_info (self, "could not get storage_type from storage: %s", error->message);
++                g_error_free (error);
++            } else {
++                /* As Modem reports None for TA Storage, set the
++                 * * storage to TA and update. */
++                if (storage_type == MM_SMS_STORAGE_TA) {
++                    storage = MM_SMS_STORAGE_TA;
++                }
+             }
+-            mm_obj_dbg (self, "Default route defined for SMS Messaging is set to store at: %s",
+-                        mm_sms_storage_get_string (storage));
++        }
++
++        /* Update the storage_type in storage */
++        if (!mm_sms_update_default_storage_type (storage, &error)) {
++            mm_obj_warn (self, "could not update storage_type in storage: %s", error->message);
++            g_error_free (error);
+         }
+         g_task_return_int (task, storage);
+     }
+-
+     g_object_unref (task);
+ }
+ 
+@@ -7816,17 +7847,36 @@ messaging_set_default_storage (MMIfaceModemMessaging *_self,
+                                       callback, user_data))
+         return;
+ 
+-    /* Build routes array and add it as input
+-     * Just worry about Class 0 and Class 1 messages for now */
++    /* Build routes array and add it as input */
+     input = qmi_message_wms_set_routes_input_new ();
+-    routes_array = g_array_sized_new (FALSE, FALSE, sizeof (route), 2);
++    routes_array = g_array_sized_new (FALSE, FALSE, sizeof (route), 5);
++
+     route.message_type = QMI_WMS_MESSAGE_TYPE_POINT_TO_POINT;
+-    route.message_class = QMI_WMS_MESSAGE_CLASS_0;
+     route.storage = mm_sms_storage_to_qmi_storage_type (storage);
+-    route.receipt_action = QMI_WMS_RECEIPT_ACTION_STORE_AND_NOTIFY;
++
++    if (storage != MM_SMS_STORAGE_TA) {
++        route.receipt_action = QMI_WMS_RECEIPT_ACTION_STORE_AND_NOTIFY;
++    } else {
++        route.receipt_action =  QMI_WMS_RECEIPT_ACTION_TRANSFER_ONLY;
++    }
++
++    route.message_class = QMI_WMS_MESSAGE_CLASS_0;
+     g_array_append_val (routes_array, route);
++
+     route.message_class = QMI_WMS_MESSAGE_CLASS_1;
+     g_array_append_val (routes_array, route);
++
++    route.message_class = QMI_WMS_MESSAGE_CLASS_3;
++    g_array_append_val (routes_array, route);
++
++    route.message_class = QMI_WMS_MESSAGE_CLASS_NONE;
++    g_array_append_val (routes_array, route);
++
++    route.message_class = QMI_WMS_MESSAGE_CLASS_2;
++    /* Class 2 messages are stored in SIM */
++    route.storage = QMI_WMS_STORAGE_TYPE_UIM;
++    g_array_append_val (routes_array, route);
++
+     qmi_message_wms_set_routes_input_set_route_list (input, routes_array, NULL);
+ 
+     mm_obj_dbg (self, "setting default messaging routes...");
+@@ -8112,6 +8162,70 @@ wms_list_messages_ready (QmiClientWms *client,
+     ctx->i = 0;
+     read_next_sms_part (task);
+ }
++#if 0
++static MMSmsPart *
++mm_create_sms_part_from_pdu (guint        index,
++                             const gchar  *hexpdu,
++                             MMSmsState   state,
++                             gpointer     log_object,
++                             GError       **error)
++{
++    g_autofree guint8 *pdu = NULL;
++    gsize              pdu_len;
++
++    /* Convert PDU from hex to binary */
++    pdu = mm_utils_hexstr2bin (hexpdu, -1, &pdu_len, error);
++    if (!pdu) {
++        g_prefix_error (error, "Couldn't convert 3GPP PDU from hex to binary: ");
++        return NULL;
++    }
++
++    return mm_sms_part_3gpp_new_from_binary_pdu (index, pdu, pdu_len, log_object,
++                                                    state == MM_SMS_STATE_RECEIVED, error);
++}
++#endif
++static void
++load_messages_from_ta_storage (GTask *task)
++{
++    MMBroadbandModemQmi *self;
++    LoadInitialSmsPartsContext *ctx;
++    GList *indexs, *l;
++    gchar *pdu;
++    MMSmsState state;
++    g_autoptr(GError)  error = NULL;
++
++    self = g_task_get_source_object (task);
++    ctx = g_task_get_task_data (task);
++    mm_obj_dbg (self, "load_messages_from_ta_storage");
++    /* read all indexes from storage */
++    indexs = mm_sms_storage_read_all_indexes (&error);
++
++    for (l = indexs; l; l = g_list_next (l))
++    {
++        guint msg_index = GPOINTER_TO_UINT (l->data);
++        if (mm_sms_storage_read_message (msg_index, &pdu, &state, &error)) {
++
++            MMSmsPart *part;
++            part = mm_create_sms_part_from_pdu (msg_index, (const char *)pdu, state, self, &error);
++            if (part) {
++                mm_obj_dbg (self, "correctly parsed PDU (%d)", msg_index);
++                mm_iface_modem_messaging_take_part (MM_IFACE_MODEM_MESSAGING (self),
++                                                    mm_broadband_modem_create_sms (MM_BROADBAND_MODEM (MM_IFACE_MODEM_MESSAGING(self))),
++                                                    part,
++                                                    state != MM_SMS_STATE_UNKNOWN ? state: MM_SMS_STATE_STORED,
++                                                    ctx->storage,
++                                                    &error);
++            } else {
++                /* Don't treat the error as critical */
++                mm_obj_dbg (self, "error parsing PDU (%d): %s", msg_index, error->message);
++            }
++        } else {
++            mm_obj_warn (self, "Failed to read the messages");
++        }
++   }
++
++   g_task_return_boolean (task, TRUE);
++}
+ 
+ static void
+ load_initial_sms_parts_step (GTask *task)
+@@ -8277,19 +8391,25 @@ load_initial_sms_parts (MMIfaceModemMessaging *_self,
+         return iface_modem_messaging_parent->load_initial_sms_parts (_self, storage, callback, user_data);
+     }
+ 
++    ctx = g_slice_new0 (LoadInitialSmsPartsContext);
++    ctx->storage = storage;
++
++    task = g_task_new (self, NULL, callback, user_data);
++    g_task_set_task_data (task, ctx, (GDestroyNotify)load_initial_sms_parts_context_free);
++
++    if (ctx->storage == MM_SMS_STORAGE_TA) {
++        load_messages_from_ta_storage (task);
++        return;
++    }
++
+     if (!mm_shared_qmi_ensure_client (MM_SHARED_QMI (self),
+                                       QMI_SERVICE_WMS, &client,
+                                       callback, user_data))
+         return;
+ 
+-    ctx = g_slice_new0 (LoadInitialSmsPartsContext);
+     ctx->client = QMI_CLIENT_WMS (g_object_ref (client));
+-    ctx->storage = storage;
+     ctx->step = LOAD_INITIAL_SMS_PARTS_STEP_FIRST;
+ 
+-    task = g_task_new (self, NULL, callback, user_data);
+-    g_task_set_task_data (task, ctx, (GDestroyNotify)load_initial_sms_parts_context_free);
+-
+     load_initial_sms_parts_step (task);
+ }
+ 
+diff --git a/src/mm-iface-modem-messaging.c b/src/mm-iface-modem-messaging.c
+index 98e859a9..593cc95b 100644
+--- a/src/mm-iface-modem-messaging.c
++++ b/src/mm-iface-modem-messaging.c
+@@ -22,6 +22,7 @@
+ #include "mm-sms-list.h"
+ #include "mm-error-helpers.h"
+ #include "mm-log-object.h"
++#include "mm-sms-storage.h"
+ 
+ #define SUPPORT_CHECKED_TAG "messaging-support-checked-tag"
+ #define SUPPORTED_TAG       "messaging-supported-tag"
+@@ -410,6 +411,11 @@ handle_set_default_storage_ready (MMIfaceModemMessaging          *self,
+                   MM_IFACE_MODEM_MESSAGING_SMS_DEFAULT_STORAGE, ctx->storage,
+                   NULL);
+ 
++    if (!mm_sms_update_default_storage_type (ctx->storage, &error)) {
++        mm_obj_warn (self, "could not update current_storage in storage: %s", error->message);
++        g_error_free (error);
++    }
++
+     mm_obj_info (self, "set the default storage successfully");
+     mm_gdbus_modem_messaging_complete_set_default_storage (ctx->skeleton, ctx->invocation);
+     handle_set_default_storage_context_free (ctx);
+@@ -1040,6 +1046,7 @@ interface_enabling_step (GTask *task)
+ 
+     case ENABLING_STEP_STORAGE_DEFAULTS: {
+         MMSmsStorage default_storage;
++        GError *error = NULL;
+ 
+         /* Get default storage that is set by init_current_storage */
+         g_object_get (self,
+@@ -1061,6 +1068,11 @@ interface_enabling_step (GTask *task)
+                           NULL);
+         }
+ 
++        /* Update storage with default_storage variable */
++        if (!mm_sms_update_default_storage_type (default_storage, &error)) {
++          mm_obj_warn (self, "could not update default_storage in storage: %s", error->message);
++        }
++
+         if (default_storage == MM_SMS_STORAGE_UNKNOWN)
+             mm_obj_warn (self, "cannot set default storage, none of the suggested ones supported");
+         else if (MM_IFACE_MODEM_MESSAGING_GET_IFACE (self)->set_default_storage &&
+diff --git a/src/mm-sms-part-3gpp.c b/src/mm-sms-part-3gpp.c
+index d91946c7..404b441b 100644
+--- a/src/mm-sms-part-3gpp.c
++++ b/src/mm-sms-part-3gpp.c
+@@ -391,6 +391,7 @@ mm_sms_part_3gpp_new_from_binary_pdu (guint         index,
+     guint tp_user_data_len_offset = 0;
+     MMSmsEncoding user_data_encoding = MM_SMS_ENCODING_UNKNOWN;
+     gchar *address;
++    GByteArray *byte_array;
+ 
+     /* Create the new MMSmsPart */
+     sms_part = mm_sms_part_new (index, MM_SMS_PDU_TYPE_UNKNOWN);
+@@ -812,7 +813,10 @@ mm_sms_part_3gpp_new_from_binary_pdu (guint         index,
+             }
+         }
+     }
+-
++    byte_array = g_byte_array_append (g_byte_array_sized_new (pdu_len),
++                                     pdu,
++                                     pdu_len);
++    mm_sms_part_set_pdu (sms_part, byte_array);
+     return sms_part;
+ }
+ 
+diff --git a/src/mm-sms-part.c b/src/mm-sms-part.c
+index ee2cd9f0..25dc3bee 100644
+--- a/src/mm-sms-part.c
++++ b/src/mm-sms-part.c
+@@ -37,6 +37,7 @@ struct _MMSmsPart {
+     gchar *text;
+     MMSmsEncoding encoding;
+     GByteArray *data;
++    GByteArray *pdu;
+     gint  class;
+     guint validity_relative;
+     gboolean delivery_report_request;
+@@ -163,6 +164,26 @@ mm_sms_part_take_data (MMSmsPart *self,
+     self->data = value;
+ }
+ 
++PART_GET_FUNC (const GByteArray *, pdu)
++
++void
++mm_sms_part_set_pdu (MMSmsPart *self,
++                      GByteArray *value)
++{
++    if (self->pdu)
++        g_byte_array_unref (self->pdu);
++    self->pdu = (value ? g_byte_array_ref (value) : NULL);
++}
++
++void
++mm_sms_part_take_pdu (MMSmsPart *self,
++                       GByteArray *value)
++{
++    if (self->pdu)
++        g_byte_array_unref (self->pdu);
++    self->pdu = value;
++}
++
+ gboolean
+ mm_sms_part_should_concat (MMSmsPart *self)
+ {
+diff --git a/src/mm-sms-part.h b/src/mm-sms-part.h
+index 2ea44a85..b346820d 100644
+--- a/src/mm-sms-part.h
++++ b/src/mm-sms-part.h
+@@ -105,6 +105,11 @@ void              mm_sms_part_set_data               (MMSmsPart *part,
+ void              mm_sms_part_take_data              (MMSmsPart *part,
+                                                       GByteArray *data);
+ 
++const GByteArray *mm_sms_part_get_pdu               (MMSmsPart *part);
++void              mm_sms_part_set_pdu               (MMSmsPart *part,
++                                                      GByteArray *data);
++void              mm_sms_part_take_pdu              (MMSmsPart *part,
++                                                      GByteArray *data);
+ MMSmsEncoding     mm_sms_part_get_encoding           (MMSmsPart *part);
+ void              mm_sms_part_set_encoding           (MMSmsPart *part,
+                                                       MMSmsEncoding encoding);
+diff --git a/src/mm-sms-qmi.c b/src/mm-sms-qmi.c
+index 3db0512e..bae2f4ca 100644
+--- a/src/mm-sms-qmi.c
++++ b/src/mm-sms-qmi.c
+@@ -33,6 +33,7 @@
+ #include "mm-sms-part-3gpp.h"
+ #include "mm-sms-part-cdma.h"
+ #include "mm-log-object.h"
++#include "mm-sms-storage.h"
+ 
+ G_DEFINE_TYPE (MMSmsQmi, mm_sms_qmi, MM_TYPE_BASE_SMS)
+ 
+@@ -191,7 +192,7 @@ store_ready (QmiClientWms *client,
+ static void
+ sms_store_next_part (GTask *task)
+ {
+-    MMSmsQmi *self;
++    MMBaseSms *self;
+     SmsStoreContext *ctx;
+     QmiMessageWmsRawWriteInput *input;
+     guint8 *pdu = NULL;
+@@ -199,6 +200,7 @@ sms_store_next_part (GTask *task)
+     guint msgstart = 0;
+     GArray *array;
+     GError *error = NULL;
++    const GByteArray *array_pdu;
+ 
+     self = g_task_get_source_object (task);
+     ctx = g_task_get_task_data (task);
+@@ -210,11 +212,22 @@ sms_store_next_part (GTask *task)
+         return;
+     }
+ 
+-    /* Get PDU */
+-    if (MM_SMS_PART_IS_3GPP ((MMSmsPart *)ctx->current->data))
+-        pdu = mm_sms_part_3gpp_get_submit_pdu ((MMSmsPart *)ctx->current->data, &pdulen, &msgstart, self, &error);
+-    else if (MM_SMS_PART_IS_CDMA ((MMSmsPart *)ctx->current->data))
+-        pdu = mm_sms_part_cdma_get_submit_pdu ((MMSmsPart *)ctx->current->data, &pdulen, self, &error);
++    if (mm_sms_part_get_pdu ((MMSmsPart *)ctx->current->data)) {
++        mm_obj_dbg (self, "sms_store_next_part, PDU is present in sms part");
++        array_pdu = mm_sms_part_get_pdu((MMSmsPart *)ctx->current->data);
++        mm_obj_dbg (self, "sms_store_next_part, PDU is present in sms part lenn:%d",
++                    array_pdu->len);
++        pdu = (guint8 *)array_pdu->data;
++        pdulen = array_pdu->len;
++    } else {
++        /* Get PDU */
++        if (MM_SMS_PART_IS_3GPP ((MMSmsPart *)ctx->current->data))
++            pdu = mm_sms_part_3gpp_get_submit_pdu ((MMSmsPart *)ctx->current->data,
++                                                    &pdulen, &msgstart, self, &error);
++        else if (MM_SMS_PART_IS_CDMA ((MMSmsPart *)ctx->current->data))
++            pdu = mm_sms_part_cdma_get_submit_pdu ((MMSmsPart *)ctx->current->data, &pdulen,
++                                                    self, &error);
++    }
+ 
+     if (!pdu) {
+         if (error)
+@@ -232,6 +245,36 @@ sms_store_next_part (GTask *task)
+         return;
+     }
+ 
++    /* Save the message in local data base */
++    if(ctx->storage == MM_SMS_STORAGE_TA) {
++        guint32 idx;
++        gchar *sms_pdu;
++        GError *err = NULL;
++        MMSmsState state;
++
++        mm_obj_dbg (self, "sms_store_next_part, storing in TA");
++        state = mm_gdbus_sms_get_state (MM_GDBUS_SMS (self));
++        sms_pdu = mm_create_sms_pdu(pdu, pdulen);
++
++        if (!mm_sms_storage_store_message(sms_pdu, state, &idx, &err)) {
++            g_task_return_error (task, err);
++            g_object_unref (task);
++            g_free (sms_pdu);
++            return;
++        } else {
++            GList *parts;
++            /* Set the index in the part we hold */
++            parts = mm_base_sms_get_parts (self);
++            mm_sms_part_set_index ((MMSmsPart *)parts->data, (guint)idx);
++
++            /* Go on with next one */
++            ctx->current = g_list_next (ctx->current);
++            g_free (sms_pdu);
++            sms_store_next_part (task);
++            return;
++        }
++    }
++
+     /* Convert to GArray */
+     array = g_array_append_vals (g_array_sized_new (FALSE, FALSE, sizeof (guint8), pdulen),
+                                  pdu,
+@@ -617,7 +660,8 @@ sms_send (MMBaseSms *self,
+                   NULL);
+ 
+     /* If the SMS is STORED, try to send from storage */
+-    ctx->from_storage = (mm_base_sms_get_storage (self) != MM_SMS_STORAGE_UNKNOWN);
++    ctx->from_storage = ((mm_base_sms_get_storage (self) != MM_SMS_STORAGE_UNKNOWN) &&
++                         (mm_base_sms_get_storage (self) != MM_SMS_STORAGE_TA));
+ 
+     ctx->current = mm_base_sms_get_parts (self);
+ 
+@@ -729,6 +773,21 @@ delete_next_part (GTask *task)
+         return;
+     }
+ 
++    /* If the storage is TA delete the message from local storage */
++    if (mm_base_sms_get_storage (self) == MM_SMS_STORAGE_TA) {
++        GError *error = NULL;
++        mm_obj_dbg (self, "delete_next_part, deleteing in TA");
++        if(!mm_sms_storage_delete_message (
++                (guint32)mm_sms_part_get_index ((MMSmsPart *)ctx->current->data), &error))
++            ctx->n_failed++;
++        /* We reset the index, as there is no longer that part */
++        mm_sms_part_set_index ((MMSmsPart *)ctx->current->data, SMS_PART_INVALID_INDEX);
++
++        ctx->current = g_list_next (ctx->current);
++        delete_next_part (task);
++        return;
++    }
++
+     input = qmi_message_wms_delete_input_new ();
+     qmi_message_wms_delete_input_set_memory_storage (
+         input,
+diff --git a/src/mm-sms-storage.c b/src/mm-sms-storage.c
+new file mode 100644
+index 00000000..67a2262d
+--- /dev/null
++++ b/src/mm-sms-storage.c
+@@ -0,0 +1,341 @@
++/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
++/*
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details:
++ *
++ * SPDX-License-Identifier:  LGPL-2.0
++ * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#include <ctype.h>
++#include <string.h>
++
++#include <glib.h>
++
++#include <ModemManager.h>
++#define _LIBMM_INSIDE_MM
++#include <libmm-glib.h>
++#include "config.h"
++#include "json-glib/json-glib.h"
++#include "mm-common-helpers.h"
++#include "mm-sms-part-3gpp.h"
++#include "mm-sms-storage.h"
++
++static const gchar *dbname = PKGSYSCONFDIR "/smsdb.json";
++
++/** Store message in local storage in "pdu,state" format*/
++gboolean
++mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError **error)
++{
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    guint msg_ref = 0;
++    g_autoptr(JsonNode) root = NULL;
++    JsonObject *root_object;
++    JsonObject *object = NULL;
++    g_autoptr(JsonReader) reader = NULL;
++    g_autoptr(JsonGenerator) generator = NULL;
++    gboolean no_data = TRUE;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        if (inner_error->code != G_FILE_ERROR_NOENT) {
++            g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
++            *error = inner_error;
++            return FALSE;
++        }
++        g_clear_error (&inner_error);
++    } else {
++        root = json_parser_get_root (parser);
++        if( JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
++            no_data = FALSE;
++            reader = json_reader_new (root);
++            root_object = json_node_get_object (root);
++            if(json_reader_read_member (reader, "msg_ref")) {
++              msg_ref = json_reader_get_int_value (reader);
++            }
++            json_reader_end_member (reader);
++        }
++    }
++
++    if (no_data) {
++        root = json_node_new (JSON_NODE_OBJECT);
++        root_object = json_object_new ();
++    }
++
++    msg_ref++;
++    json_object_set_int_member (root_object, "msg_ref", msg_ref);
++    object = json_object_new ();
++    json_object_set_string_member (object, "pdu", pdu);
++    json_object_set_int_member (object, "state", state);
++    json_object_set_object_member (root_object, g_strdup_printf ("%u", msg_ref), object);
++    json_node_take_object (root, root_object);
++
++    generator = json_generator_new ();
++    json_generator_set_root (generator, root);
++
++    // Write the data to JSON
++    if (!json_generator_to_file (generator, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "DB write operation failed");
++        *error = inner_error;
++        return FALSE;
++    }
++
++    *idx = msg_ref;
++    return TRUE;
++}
++
++/* Delete a message of given index from the storage */
++gboolean
++mm_sms_storage_delete_message (guint index, GError **error)
++{
++
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    g_autoptr(JsonNode) root = NULL;
++    JsonObject *root_object;
++    g_autoptr(JsonReader) reader = NULL;
++    g_autoptr(JsonGenerator) generator = NULL;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
++        return FALSE;
++    }
++    g_clear_error (&inner_error);
++
++    root = json_parser_get_root (parser);
++
++    if (JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
++        reader = json_reader_new (root);
++        root_object = json_node_get_object (root);
++    } else {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_FAILED,
++                     "No messages present in the DB");
++        return FALSE;
++    }
++
++    //Delete message
++    json_object_remove_member (root_object, g_strdup_printf ("%u", index));
++    generator = json_generator_new ();
++    json_generator_set_root (generator, root);
++
++    // Write the data to JSON
++    if (!json_generator_to_file (generator, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "DB write operation failed");
++        return FALSE;
++    }
++
++    return TRUE;
++}
++
++/* Read a message of given idex from stoarge */
++gboolean
++mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError **error)
++{
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    g_autoptr(JsonNode) root = NULL;
++    JsonObject *root_object;
++    g_autoptr(JsonReader) reader = NULL;
++    JsonNode *node = NULL;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
++        return FALSE;
++    }
++
++    root = json_parser_get_root (parser);
++
++    if (JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
++        reader = json_reader_new (root);
++        root_object = json_node_get_object (root);
++    } else {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_FAILED,
++                     "No messages present in the DB");
++        return FALSE;
++    }
++
++    node = json_object_get_member (root_object, g_strdup_printf ("%u", index));
++
++    if (node) {
++        JsonObject *obj = json_node_get_object (node);
++        if (pdu)
++            *pdu = g_strdup (json_object_get_string_member (obj, "pdu"));
++        if (state)
++            *state = json_object_get_int_member (obj, "state");
++    }
++
++    return TRUE;
++}
++
++/* Return all valid indexces */
++GList *
++mm_sms_storage_read_all_indexes (GError **error)
++{
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    g_autoptr(JsonNode) root = NULL;
++    JsonObject *root_object;
++    g_autoptr(JsonReader) reader = NULL;
++    GList *list = NULL;
++    GList *memberNames = NULL;
++    gulong msg_ref;
++    GList *iter;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
++        return NULL;
++    }
++
++    root = json_parser_get_root (parser);
++
++    if (JSON_NODE_TYPE(root) == JSON_NODE_OBJECT) {
++        reader = json_reader_new (root);
++        root_object = json_node_get_object (root);
++    } else {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_FAILED,
++                     "No messages present in the DB");
++        return NULL;
++    }
++
++    memberNames = json_object_get_members (root_object);
++
++    for (iter = memberNames; iter != NULL; iter = iter->next) {
++        const gchar *memberName = (const gchar *)iter->data;
++        msg_ref = g_ascii_strtoll (memberName, NULL, 10);
++        list = g_list_append (list, GUINT_TO_POINTER (msg_ref));
++    }
++
++    return list;
++}
++
++/* Store deafault_storage in local storage to persist across boot */
++gboolean
++mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error)
++{
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    g_autoptr(JsonNode) root = NULL;
++    JsonObject *root_object;
++    gboolean no_data = TRUE;
++    g_autoptr(JsonGenerator) generator = NULL;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        if (inner_error->code != G_FILE_ERROR_NOENT) {
++            g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
++            return FALSE;
++        }
++        g_clear_error (&inner_error);
++    } else {
++        root = json_parser_get_root (parser);
++        if (JSON_NODE_TYPE(root) == JSON_NODE_OBJECT) {
++            no_data = FALSE;
++            root_object = json_node_get_object (root);
++            json_object_set_string_member (root_object, "default_storage",
++                                           mm_sms_storage_get_string(storage));
++        }
++    }
++
++    if (no_data) {
++        root = json_node_new (JSON_NODE_OBJECT);
++        root_object = json_object_new ();
++        json_object_set_string_member (root_object, "default_storage",
++                                       mm_sms_storage_get_string(storage));
++        json_node_take_object (root, root_object);
++    }
++
++    generator = json_generator_new ();
++    json_generator_set_root (generator, root);
++
++    // Write the data to Json
++    if (!json_generator_to_file (generator, dbname, &inner_error)) {
++        g_propagate_prefixed_error (error, inner_error, "DB write operation failed");
++
++        return FALSE;
++    }
++
++    return TRUE;
++}
++
++gboolean
++mm_sms_get_default_storage_type (guint32 *storage, GError **error)
++{
++    g_autoptr(JsonParser) parser = NULL;
++    GError *inner_error = NULL;
++    guint storage_ref = 0; //Default value MM_SMS_STORAGE_UNKNOWN = 0
++    g_autoptr(JsonNode) root = NULL;
++    g_autoptr(JsonReader) reader = NULL;
++
++    parser = json_parser_new ();
++
++    if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
++        g_object_unref (parser);
++        g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file");
++        return FALSE;
++    } else {
++        root = json_parser_get_root (parser);
++        if (JSON_NODE_TYPE(root) == JSON_NODE_OBJECT) {
++            reader = json_reader_new (root);
++
++            // read the member default_storage
++            if (json_reader_read_member (reader, "default_storage")) {
++                storage_ref = mm_common_get_sms_storage_from_string (json_reader_get_string_value (reader),
++                                                                    NULL);
++            }
++            json_reader_end_member (reader);
++        }
++    }
++
++    *storage = storage_ref;
++    return TRUE;
++}
++
++MMSmsPart *
++mm_create_sms_part_from_pdu (guint       index,
++                             const gchar *hexpdu,
++                             MMSmsState  state,
++                             gpointer    log_object,
++                             GError      **error)
++{
++    g_autofree guint8 *pdu = NULL;
++    gsize              pdu_len;
++
++    /* Convert PDU from hex to binary */
++    pdu = mm_utils_hexstr2bin (hexpdu, -1, &pdu_len, error);
++    if (!pdu) {
++        g_prefix_error (error, "Couldn't convert 3GPP PDU from hex to binary: ");
++        return NULL;
++    }
++
++    return mm_sms_part_3gpp_new_from_binary_pdu (index, pdu, pdu_len, log_object,
++                                                    state == MM_SMS_STATE_RECEIVED, error);
++}
++
++gchar *
++mm_create_sms_pdu (const guint8 *pdu,
++                   gsize        pdulen)
++{
++    return mm_utils_bin2hexstr (pdu, pdulen);
++}
+diff --git a/src/mm-sms-storage.h b/src/mm-sms-storage.h
+new file mode 100644
+index 00000000..4aa014be
+--- /dev/null
++++ b/src/mm-sms-storage.h
+@@ -0,0 +1,47 @@
++/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
++/*
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details:
++ *
++ * SPDX-License-Identifier:  LGPL-2.0
++ * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#ifndef MM_SMS_STORAGE_H
++#define MM_SMS_STORAGE_H
++
++#include <glib.h>
++#include <ModemManager.h>
++
++gboolean
++mm_sms_storage_store_message(gchar *pdu,
++                             MMSmsState state, guint32 *idx, GError **error);
++gboolean
++mm_sms_storage_delete_message (guint index, GError **error);
++
++gboolean
++mm_sms_storage_read_message (guint index,
++                             gchar **pdu, MMSmsState *state, GError **error);
++GList *
++mm_sms_storage_read_all_indexes (GError **error);
++
++gboolean
++mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error);
++
++gboolean
++mm_sms_get_default_storage_type (guint32 *storage, GError **error);
++
++MMSmsPart *
++mm_create_sms_part_from_pdu (guint index, const gchar *hexpdu, MMSmsState state,
++                                         gpointer log_object, GError **error);
++
++gchar *
++mm_create_sms_pdu (const guint8 *pdu, gsize pdulen);
++#endif /* MM_SMS_STORAGE_H */
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0002-fixup-move-json-glib-dep-to-root-meson.build-add-to-.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0002-fixup-move-json-glib-dep-to-root-meson.build-add-to-.patch
@@ -1,0 +1,27 @@
+From 3011b7aaf23fb526ee9264fbaed937fec3b38512 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Tue, 17 Jun 2025 08:32:24 -0500
+Subject: [PATCH 02/10] fixup: move json-glib dep to root meson.build; add to
+ libmmbase deps
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ meson.build | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 2a0b9734..eda009ce 100644
+--- a/meson.build
++++ b/meson.build
+@@ -296,6 +296,8 @@ if enable_gir
+   dependency('gobject-introspection-1.0', version: '>= 0.9.6')
+ endif
+ 
++json_glib_dep = dependency('json-glib-1.0', version: '>= 1.0')
++
+ # vala support
+ enable_vapi = get_option('vapi')
+ 
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0003-whitespace-cleanup.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0003-whitespace-cleanup.patch
@@ -1,0 +1,26 @@
+From aa13b855374e86acf61aedc6ba14c274e386a1f0 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 09:45:06 -0500
+Subject: [PATCH 03/10] whitespace cleanup
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-iface-modem-messaging.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mm-iface-modem-messaging.c b/src/mm-iface-modem-messaging.c
+index 593cc95b..6b184c9e 100644
+--- a/src/mm-iface-modem-messaging.c
++++ b/src/mm-iface-modem-messaging.c
+@@ -1070,7 +1070,7 @@ interface_enabling_step (GTask *task)
+ 
+         /* Update storage with default_storage variable */
+         if (!mm_sms_update_default_storage_type (default_storage, &error)) {
+-          mm_obj_warn (self, "could not update default_storage in storage: %s", error->message);
++            mm_obj_warn (self, "could not update default_storage in storage: %s", error->message);
+         }
+ 
+         if (default_storage == MM_SMS_STORAGE_UNKNOWN)
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0004-whitespace-cleanup-fix-error-freeing.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0004-whitespace-cleanup-fix-error-freeing.patch
@@ -1,0 +1,102 @@
+From 94b072b2bfc766b9c8d2288d324d77d3a4ebcef6 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 09:46:01 -0500
+Subject: [PATCH 04/10] whitespace cleanup; fix error freeing
+
+Need to have the error freed each element of the list, rather than once
+for all of them.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-broadband-modem-qmi.c | 66 ++++++++++++++++++++----------------
+ 1 file changed, 37 insertions(+), 29 deletions(-)
+
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 746d98f7..6c871458 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -8187,44 +8187,52 @@ mm_create_sms_part_from_pdu (guint        index,
+ static void
+ load_messages_from_ta_storage (GTask *task)
+ {
+-    MMBroadbandModemQmi *self;
++    MMBroadbandModemQmi        *self;
+     LoadInitialSmsPartsContext *ctx;
+-    GList *indexs, *l;
+-    gchar *pdu;
+-    MMSmsState state;
+-    g_autoptr(GError)  error = NULL;
++    GList                      *indexes, *l;
++    gchar                      *pdu;
++    MMSmsState                  state;
+ 
+     self = g_task_get_source_object (task);
+     ctx = g_task_get_task_data (task);
+     mm_obj_dbg (self, "load_messages_from_ta_storage");
++
+     /* read all indexes from storage */
+-    indexs = mm_sms_storage_read_all_indexes (&error);
++    indexes = mm_sms_storage_read_all_indexes (&error);
++    for (l = indexes; l; l = g_list_next (l)) {
++        guint              msg_index = GPOINTER_TO_UINT (l->data);
++        MMSmsPart         *part;
++        g_autoptr(GError)  error = NULL;
++
++        if (!mm_sms_storage_read_message (msg_index, &pdu, &state, &error)) {
++            mm_obj_warn (self,
++                         "Failed to read the SMS (%d) from storage: %s",
++                         msg_index,
++                         error->message);
++            continue;
++        }
+ 
+-    for (l = indexs; l; l = g_list_next (l))
+-    {
+-        guint msg_index = GPOINTER_TO_UINT (l->data);
+-        if (mm_sms_storage_read_message (msg_index, &pdu, &state, &error)) {
+-
+-            MMSmsPart *part;
+-            part = mm_create_sms_part_from_pdu (msg_index, (const char *)pdu, state, self, &error);
+-            if (part) {
+-                mm_obj_dbg (self, "correctly parsed PDU (%d)", msg_index);
+-                mm_iface_modem_messaging_take_part (MM_IFACE_MODEM_MESSAGING (self),
+-                                                    mm_broadband_modem_create_sms (MM_BROADBAND_MODEM (MM_IFACE_MODEM_MESSAGING(self))),
+-                                                    part,
+-                                                    state != MM_SMS_STATE_UNKNOWN ? state: MM_SMS_STATE_STORED,
+-                                                    ctx->storage,
+-                                                    &error);
+-            } else {
+-                /* Don't treat the error as critical */
+-                mm_obj_dbg (self, "error parsing PDU (%d): %s", msg_index, error->message);
+-            }
+-        } else {
+-            mm_obj_warn (self, "Failed to read the messages");
++        part = mm_create_sms_part_from_pdu (msg_index, pdu, state, self, &error);
++        if (!part) {
++            /* Don't treat the error as critical */
++            mm_obj_dbg (self, "error parsing SMS (%d) PDU: %s", msg_index, error->message);
++            continue;
+         }
+-   }
+ 
+-   g_task_return_boolean (task, TRUE);
++        mm_obj_dbg (self, "parsed SMS (%d) PDU", msg_index);
++        if (!mm_iface_modem_messaging_take_part (MM_IFACE_MODEM_MESSAGING (self),
++                                                 part,
++                                                 state != MM_SMS_STATE_UNKNOWN ? state : MM_SMS_STATE_STORED,
++                                                 ctx->storage)) {
++            /* Don't treat the error as critical */
++            mm_obj_dbg (self,
++                        "error adding SMS (%d): %s",
++                        msg_index,
++                        error->message);
++        }
++    }
++
++    g_task_return_boolean (task, TRUE);
+ }
+ 
+ static void
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0005-remove-dead-code.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0005-remove-dead-code.patch
@@ -1,0 +1,46 @@
+From 6fe58b58a302696625082bba48b3cbb70684c551 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 09:47:24 -0500
+Subject: [PATCH 05/10] remove dead code
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-broadband-modem-qmi.c | 21 ---------------------
+ 1 file changed, 21 deletions(-)
+
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 6c871458..76761c20 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -8162,28 +8162,7 @@ wms_list_messages_ready (QmiClientWms *client,
+     ctx->i = 0;
+     read_next_sms_part (task);
+ }
+-#if 0
+-static MMSmsPart *
+-mm_create_sms_part_from_pdu (guint        index,
+-                             const gchar  *hexpdu,
+-                             MMSmsState   state,
+-                             gpointer     log_object,
+-                             GError       **error)
+-{
+-    g_autofree guint8 *pdu = NULL;
+-    gsize              pdu_len;
+-
+-    /* Convert PDU from hex to binary */
+-    pdu = mm_utils_hexstr2bin (hexpdu, -1, &pdu_len, error);
+-    if (!pdu) {
+-        g_prefix_error (error, "Couldn't convert 3GPP PDU from hex to binary: ");
+-        return NULL;
+-    }
+ 
+-    return mm_sms_part_3gpp_new_from_binary_pdu (index, pdu, pdu_len, log_object,
+-                                                    state == MM_SMS_STATE_RECEIVED, error);
+-}
+-#endif
+ static void
+ load_messages_from_ta_storage (GTask *task)
+ {
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0006-qmi-error-free-fixup.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0006-qmi-error-free-fixup.patch
@@ -1,0 +1,38 @@
+From eaff75d8dacaf438dd0cceaadbc071d4baa14af0 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 10:34:16 -0500
+Subject: [PATCH 06/10] qmi error free fixup
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-broadband-modem-qmi.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 76761c20..1a0040d8 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -8171,13 +8171,19 @@ load_messages_from_ta_storage (GTask *task)
+     GList                      *indexes, *l;
+     gchar                      *pdu;
+     MMSmsState                  state;
++    g_autoptr(GError)           read_error = NULL;
+ 
+     self = g_task_get_source_object (task);
+     ctx = g_task_get_task_data (task);
+     mm_obj_dbg (self, "load_messages_from_ta_storage");
+ 
+     /* read all indexes from storage */
+-    indexes = mm_sms_storage_read_all_indexes (&error);
++    indexes = mm_sms_storage_read_all_indexes (&read_error);
++    if (read_error) {
++        mm_obj_warn (self, "Failed to load SMS storage: %s", read_error->message);
++        return;
++    }
++
+     for (l = indexes; l; l = g_list_next (l)) {
+         guint              msg_index = GPOINTER_TO_UINT (l->data);
+         MMSmsPart         *part;
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0007-whitespace-fixes-some-memory-leak-fixes.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0007-whitespace-fixes-some-memory-leak-fixes.patch
@@ -1,0 +1,224 @@
+From 7234411ec873496a850b80233b4ed6b17f5c3389 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 15:55:07 -0500
+Subject: [PATCH 07/10] whitespace fixes; some memory leak fixes
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-sms-storage.c | 86 ++++++++++++++++++++++----------------------
+ 1 file changed, 43 insertions(+), 43 deletions(-)
+
+diff --git a/src/mm-sms-storage.c b/src/mm-sms-storage.c
+index 67a2262d..297f0b66 100644
+--- a/src/mm-sms-storage.c
++++ b/src/mm-sms-storage.c
+@@ -37,6 +37,7 @@ mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+     guint msg_ref = 0;
++    g_autofree gchar *msg_ref_str = NULL;
+     g_autoptr(JsonNode) root = NULL;
+     JsonObject *root_object;
+     JsonObject *object = NULL;
+@@ -49,18 +50,17 @@ mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError
+     if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
+         if (inner_error->code != G_FILE_ERROR_NOENT) {
+             g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file:");
+-            *error = inner_error;
+             return FALSE;
+         }
+         g_clear_error (&inner_error);
+     } else {
+         root = json_parser_get_root (parser);
+-        if( JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
++        if (JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
+             no_data = FALSE;
+             reader = json_reader_new (root);
+             root_object = json_node_get_object (root);
+-            if(json_reader_read_member (reader, "msg_ref")) {
+-              msg_ref = json_reader_get_int_value (reader);
++            if (json_reader_read_member (reader, "msg_ref")) {
++                msg_ref = json_reader_get_int_value (reader);
+             }
+             json_reader_end_member (reader);
+         }
+@@ -76,7 +76,8 @@ mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError
+     object = json_object_new ();
+     json_object_set_string_member (object, "pdu", pdu);
+     json_object_set_int_member (object, "state", state);
+-    json_object_set_object_member (root_object, g_strdup_printf ("%u", msg_ref), object);
++    msg_ref_str = g_strdup_printf ("%u", msg_ref);
++    json_object_set_object_member (root_object, msg_ref_str, object);
+     json_node_take_object (root, root_object);
+ 
+     generator = json_generator_new ();
+@@ -97,13 +98,13 @@ mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError
+ gboolean
+ mm_sms_storage_delete_message (guint index, GError **error)
+ {
+-
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+     g_autoptr(JsonNode) root = NULL;
+     JsonObject *root_object;
+     g_autoptr(JsonReader) reader = NULL;
+     g_autoptr(JsonGenerator) generator = NULL;
++    g_autofree gchar *msg_ref_str = NULL;
+ 
+     parser = json_parser_new ();
+ 
+@@ -115,10 +116,7 @@ mm_sms_storage_delete_message (guint index, GError **error)
+ 
+     root = json_parser_get_root (parser);
+ 
+-    if (JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
+-        reader = json_reader_new (root);
+-        root_object = json_node_get_object (root);
+-    } else {
++    if (JSON_NODE_TYPE (root) != JSON_NODE_OBJECT) {
+         g_set_error (error,
+                      MM_CORE_ERROR,
+                      MM_CORE_ERROR_FAILED,
+@@ -126,8 +124,12 @@ mm_sms_storage_delete_message (guint index, GError **error)
+         return FALSE;
+     }
+ 
+-    //Delete message
+-    json_object_remove_member (root_object, g_strdup_printf ("%u", index));
++    reader = json_reader_new (root);
++    root_object = json_node_get_object (root);
++
++    // Delete message
++    msg_ref_str = g_strdup_printf ("%u", index);
++    json_object_remove_member (root_object, msg_ref_str);
+     generator = json_generator_new ();
+     json_generator_set_root (generator, root);
+ 
+@@ -150,6 +152,7 @@ mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError
+     JsonObject *root_object;
+     g_autoptr(JsonReader) reader = NULL;
+     JsonNode *node = NULL;
++    g_autofree gchar *msg_ref_str = NULL;
+ 
+     parser = json_parser_new ();
+ 
+@@ -160,10 +163,7 @@ mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError
+ 
+     root = json_parser_get_root (parser);
+ 
+-    if (JSON_NODE_TYPE (root) == JSON_NODE_OBJECT) {
+-        reader = json_reader_new (root);
+-        root_object = json_node_get_object (root);
+-    } else {
++    if (JSON_NODE_TYPE (root) != JSON_NODE_OBJECT) {
+         g_set_error (error,
+                      MM_CORE_ERROR,
+                      MM_CORE_ERROR_FAILED,
+@@ -171,8 +171,10 @@ mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError
+         return FALSE;
+     }
+ 
+-    node = json_object_get_member (root_object, g_strdup_printf ("%u", index));
+-
++    reader = json_reader_new (root);
++    root_object = json_node_get_object (root);
++    msg_ref_str = g_strdup_printf ("%u", index);
++    node = json_object_get_member (root_object, msg_ref_str);
+     if (node) {
+         JsonObject *obj = json_node_get_object (node);
+         if (pdu)
+@@ -206,30 +208,24 @@ mm_sms_storage_read_all_indexes (GError **error)
+     }
+ 
+     root = json_parser_get_root (parser);
+-
+-    if (JSON_NODE_TYPE(root) == JSON_NODE_OBJECT) {
+-        reader = json_reader_new (root);
+-        root_object = json_node_get_object (root);
+-    } else {
+-        g_set_error (error,
+-                     MM_CORE_ERROR,
+-                     MM_CORE_ERROR_FAILED,
+-                     "No messages present in the DB");
++    if (JSON_NODE_TYPE (root) != JSON_NODE_OBJECT)
+         return NULL;
+-    }
+ 
++    reader = json_reader_new (root);
++    root_object = json_node_get_object (root);
+     memberNames = json_object_get_members (root_object);
+-
+     for (iter = memberNames; iter != NULL; iter = iter->next) {
+         const gchar *memberName = (const gchar *)iter->data;
++
+         msg_ref = g_ascii_strtoll (memberName, NULL, 10);
+         list = g_list_append (list, GUINT_TO_POINTER (msg_ref));
+     }
++    g_list_free (memberNames);
+ 
+     return list;
+ }
+ 
+-/* Store deafault_storage in local storage to persist across boot */
++/* Store default_storage in local storage to persist across boot */
+ gboolean
+ mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error)
+ {
+@@ -272,7 +268,6 @@ mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error)
+     // Write the data to Json
+     if (!json_generator_to_file (generator, dbname, &inner_error)) {
+         g_propagate_prefixed_error (error, inner_error, "DB write operation failed");
+-
+         return FALSE;
+     }
+ 
+@@ -284,29 +279,34 @@ mm_sms_get_default_storage_type (guint32 *storage, GError **error)
+ {
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+-    guint storage_ref = 0; //Default value MM_SMS_STORAGE_UNKNOWN = 0
++    guint storage_ref = 0; // Default value MM_SMS_STORAGE_UNKNOWN = 0
+     g_autoptr(JsonNode) root = NULL;
+     g_autoptr(JsonReader) reader = NULL;
+ 
+     parser = json_parser_new ();
+ 
+     if (!json_parser_load_from_file (parser, dbname, &inner_error)) {
+-        g_object_unref (parser);
+         g_propagate_prefixed_error (error, inner_error, "Unable to open JSON file");
+         return FALSE;
+-    } else {
+-        root = json_parser_get_root (parser);
+-        if (JSON_NODE_TYPE(root) == JSON_NODE_OBJECT) {
+-            reader = json_reader_new (root);
++    }
+ 
+-            // read the member default_storage
+-            if (json_reader_read_member (reader, "default_storage")) {
+-                storage_ref = mm_common_get_sms_storage_from_string (json_reader_get_string_value (reader),
+-                                                                    NULL);
+-            }
+-            json_reader_end_member (reader);
++    root = json_parser_get_root (parser);
++    if (JSON_NODE_TYPE(root) != JSON_NODE_OBJECT) {
++        *storage = MM_SMS_STORAGE_UNKNOWN;
++        return TRUE;
++    }
++
++    // read the member default_storage
++    reader = json_reader_new (root);
++    if (json_reader_read_member (reader, "default_storage")) {
++        storage_ref = mm_common_get_sms_storage_from_string (json_reader_get_string_value (reader),
++                                                             &inner_error);
++        if (inner_error) {
++            storage_ref = 0;
++            g_clear_error (&inner_error);
+         }
+     }
++    json_reader_end_member (reader);
+ 
+     *storage = storage_ref;
+     return TRUE;
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch
@@ -1,0 +1,303 @@
+From 2ec1f5f17812b51f212ecf81d97120eebd4f7365 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Mon, 23 Jun 2025 16:18:31 -0500
+Subject: [PATCH 08/10] whitespace fixes and adjust some sms storage function
+ return values
+
+In general, if we can return a significant value rather than passing
+it in via reference to accept a return value, we should do that to
+simplify the function's signature and logic.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+---
+ src/mm-broadband-modem-qmi.c | 26 +++++------
+ src/mm-sms-storage.c         | 84 ++++++++++++++++++++----------------
+ src/mm-sms-storage.h         | 52 +++++++++++-----------
+ 3 files changed, 89 insertions(+), 73 deletions(-)
+
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 1a0040d8..10b3d82d 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -7670,8 +7670,6 @@ wms_get_routes_ready (QmiClientWms *client,
+         g_prefix_error (&error, "got invalid SMS routes: ");
+         g_task_return_error (task, error);
+     } else {
+-        MMSmsStorage storage_type = MM_SMS_STORAGE_UNKNOWN;
+-
+         for (i = 0; i < route_list->len; i++) {
+             QmiMessageWmsGetRoutesOutputRouteListElement *route;
+ 
+@@ -7685,28 +7683,31 @@ wms_get_routes_ready (QmiClientWms *client,
+                 }
+             }
+         }
+-        mm_obj_dbg (self, "Default route defined for SMS Messaging is set to store at: %s",
++        mm_obj_dbg (self, "Found modem default SMS storage route %s",
+                     mm_sms_storage_get_string (storage));
+ 
+-        /* Modem Report None either on fresh boot or When user set to TA.
++        /* Modem Report None either on fresh boot or when user set to TA.
+          * To distinguish between fresh boot or normal boot, validate
+          * storage_type variable in storage.
+          * storage_type variable will be Unknown only in first boot after flash.
+          * Thus storage variable can be initialized to UNKNOWN and will
+          * be set to default_storage variable to ME while Enabling. */
+         if (storage == MM_SMS_STORAGE_UNKNOWN) {
+-            if (!mm_sms_get_default_storage_type (&storage_type, &error)) {
++            /* Try to read local saved SMS storage */
++            storage = mm_sms_get_default_storage_type (&error);
++            if (error) {
+                 mm_obj_info (self, "could not get storage_type from storage: %s", error->message);
+                 g_error_free (error);
+-            } else {
+-                /* As Modem reports None for TA Storage, set the
+-                 * * storage to TA and update. */
+-                if (storage_type == MM_SMS_STORAGE_TA) {
+-                    storage = MM_SMS_STORAGE_TA;
+-                }
+             }
+         }
+ 
++        /* If neither modem nor local storage has a route; store locally */
++        if (storage == MM_SMS_STORAGE_UNKNOWN)
++            storage = MM_SMS_STORAGE_TA;
++
++        mm_obj_dbg (self, "Set default SMS storage route to %s",
++                    mm_sms_storage_get_string (storage));
++
+         /* Update the storage_type in storage */
+         if (!mm_sms_update_default_storage_type (storage, &error)) {
+             mm_obj_warn (self, "could not update storage_type in storage: %s", error->message);
+@@ -8189,7 +8190,8 @@ load_messages_from_ta_storage (GTask *task)
+         MMSmsPart         *part;
+         g_autoptr(GError)  error = NULL;
+ 
+-        if (!mm_sms_storage_read_message (msg_index, &pdu, &state, &error)) {
++        pdu = mm_sms_storage_read_message (msg_index, &state, &error);
++        if (!pdu) {
+             mm_obj_warn (self,
+                          "Failed to read the SMS (%d) from storage: %s",
+                          msg_index,
+diff --git a/src/mm-sms-storage.c b/src/mm-sms-storage.c
+index 297f0b66..867f43af 100644
+--- a/src/mm-sms-storage.c
++++ b/src/mm-sms-storage.c
+@@ -32,7 +32,10 @@ static const gchar *dbname = PKGSYSCONFDIR "/smsdb.json";
+ 
+ /** Store message in local storage in "pdu,state" format*/
+ gboolean
+-mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError **error)
++mm_sms_storage_store_message (gchar       *pdu,
++                              MMSmsState   state,
++                              guint32     *idx,
++                              GError     **error)
+ {
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+@@ -96,7 +99,8 @@ mm_sms_storage_store_message (gchar *pdu, MMSmsState state, guint32 *idx, GError
+ 
+ /* Delete a message of given index from the storage */
+ gboolean
+-mm_sms_storage_delete_message (guint index, GError **error)
++mm_sms_storage_delete_message (guint    index,
++                               GError **error)
+ {
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+@@ -142,17 +146,20 @@ mm_sms_storage_delete_message (guint index, GError **error)
+     return TRUE;
+ }
+ 
+-/* Read a message of given idex from stoarge */
+-gboolean
+-mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError **error)
++/* Read a message of given index from stoarge and return its PDU */
++gchar *
++mm_sms_storage_read_message (guint        index,
++                             MMSmsState  *state,
++                             GError     **error)
+ {
+-    g_autoptr(JsonParser) parser = NULL;
+-    GError *inner_error = NULL;
+-    g_autoptr(JsonNode) root = NULL;
+-    JsonObject *root_object;
+-    g_autoptr(JsonReader) reader = NULL;
+-    JsonNode *node = NULL;
+-    g_autofree gchar *msg_ref_str = NULL;
++    g_autoptr(JsonParser)  parser = NULL;
++    GError                *inner_error = NULL;
++    g_autoptr(JsonNode)    root = NULL;
++    JsonObject            *root_object;
++    g_autoptr(JsonReader)  reader = NULL;
++    JsonNode              *node = NULL;
++    g_autofree gchar      *msg_ref_str = NULL;
++    JsonObject            *obj;
+ 
+     parser = json_parser_new ();
+ 
+@@ -175,15 +182,20 @@ mm_sms_storage_read_message (guint index, gchar **pdu, MMSmsState *state, GError
+     root_object = json_node_get_object (root);
+     msg_ref_str = g_strdup_printf ("%u", index);
+     node = json_object_get_member (root_object, msg_ref_str);
+-    if (node) {
+-        JsonObject *obj = json_node_get_object (node);
+-        if (pdu)
+-            *pdu = g_strdup (json_object_get_string_member (obj, "pdu"));
+-        if (state)
+-            *state = json_object_get_int_member (obj, "state");
++    if (!node) {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_NOT_FOUND,
++                     "Message index %d not found in storage",
++                     index);
++        return FALSE;
+     }
+ 
+-    return TRUE;
++    obj = json_node_get_object (node);
++    if (state)
++        *state = json_object_get_int_member (obj, "state");
++
++    return g_strdup (json_object_get_string_member (obj, "pdu"));
+ }
+ 
+ /* Return all valid indexces */
+@@ -227,7 +239,8 @@ mm_sms_storage_read_all_indexes (GError **error)
+ 
+ /* Store default_storage in local storage to persist across boot */
+ gboolean
+-mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error)
++mm_sms_update_default_storage_type (MMSmsStorage   storage,
++                                    GError       **error)
+ {
+     g_autoptr(JsonParser) parser = NULL;
+     GError *inner_error = NULL;
+@@ -274,14 +287,14 @@ mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error)
+     return TRUE;
+ }
+ 
+-gboolean
+-mm_sms_get_default_storage_type (guint32 *storage, GError **error)
++MMSmsStorage
++mm_sms_get_default_storage_type (GError  **error)
+ {
+-    g_autoptr(JsonParser) parser = NULL;
+-    GError *inner_error = NULL;
+-    guint storage_ref = 0; // Default value MM_SMS_STORAGE_UNKNOWN = 0
+-    g_autoptr(JsonNode) root = NULL;
+-    g_autoptr(JsonReader) reader = NULL;
++    g_autoptr(JsonParser)  parser = NULL;
++    GError                *inner_error = NULL;
++    MMSmsStorage           storage = MM_SMS_STORAGE_UNKNOWN;
++    g_autoptr(JsonNode)    root = NULL;
++    g_autoptr(JsonReader)  reader = NULL;
+ 
+     parser = json_parser_new ();
+ 
+@@ -291,25 +304,22 @@ mm_sms_get_default_storage_type (guint32 *storage, GError **error)
+     }
+ 
+     root = json_parser_get_root (parser);
+-    if (JSON_NODE_TYPE(root) != JSON_NODE_OBJECT) {
+-        *storage = MM_SMS_STORAGE_UNKNOWN;
+-        return TRUE;
+-    }
++    if (JSON_NODE_TYPE(root) != JSON_NODE_OBJECT)
++        return storage;
+ 
+     // read the member default_storage
+     reader = json_reader_new (root);
+     if (json_reader_read_member (reader, "default_storage")) {
+-        storage_ref = mm_common_get_sms_storage_from_string (json_reader_get_string_value (reader),
+-                                                             &inner_error);
++        storage = mm_common_get_sms_storage_from_string (json_reader_get_string_value (reader),
++                                                         &inner_error);
+         if (inner_error) {
+-            storage_ref = 0;
++            storage = MM_SMS_STORAGE_UNKNOWN;
+             g_clear_error (&inner_error);
+         }
+     }
+     json_reader_end_member (reader);
+ 
+-    *storage = storage_ref;
+-    return TRUE;
++    return storage;
+ }
+ 
+ MMSmsPart *
+@@ -335,7 +345,7 @@ mm_create_sms_part_from_pdu (guint       index,
+ 
+ gchar *
+ mm_create_sms_pdu (const guint8 *pdu,
+-                   gsize        pdulen)
++                   gsize         pdulen)
+ {
+     return mm_utils_bin2hexstr (pdu, pdulen);
+ }
+diff --git a/src/mm-sms-storage.h b/src/mm-sms-storage.h
+index 4aa014be..5a452885 100644
+--- a/src/mm-sms-storage.h
++++ b/src/mm-sms-storage.h
+@@ -20,28 +20,32 @@
+ #include <glib.h>
+ #include <ModemManager.h>
+ 
+-gboolean
+-mm_sms_storage_store_message(gchar *pdu,
+-                             MMSmsState state, guint32 *idx, GError **error);
+-gboolean
+-mm_sms_storage_delete_message (guint index, GError **error);
+-
+-gboolean
+-mm_sms_storage_read_message (guint index,
+-                             gchar **pdu, MMSmsState *state, GError **error);
+-GList *
+-mm_sms_storage_read_all_indexes (GError **error);
+-
+-gboolean
+-mm_sms_update_default_storage_type (MMSmsStorage storage, GError **error);
+-
+-gboolean
+-mm_sms_get_default_storage_type (guint32 *storage, GError **error);
+-
+-MMSmsPart *
+-mm_create_sms_part_from_pdu (guint index, const gchar *hexpdu, MMSmsState state,
+-                                         gpointer log_object, GError **error);
+-
+-gchar *
+-mm_create_sms_pdu (const guint8 *pdu, gsize pdulen);
++gboolean     mm_sms_storage_store_message       (gchar       *pdu,
++                                                 MMSmsState   state,
++                                                 guint32     *idx,
++                                                 GError     **error);
++
++gboolean     mm_sms_storage_delete_message      (guint    index,
++                                                 GError **error);
++
++gchar *      mm_sms_storage_read_message        (guint        index,
++                                                 MMSmsState  *state,
++                                                 GError     **error);
++
++GList *      mm_sms_storage_read_all_indexes    (GError **error);
++
++gboolean     mm_sms_update_default_storage_type (MMSmsStorage   storage,
++                                                 GError       **error);
++
++MMSmsStorage mm_sms_get_default_storage_type    (GError **error);
++
++MMSmsPart *  mm_create_sms_part_from_pdu        (guint         index,
++                                                 const gchar  *hexpdu,
++                                                 MMSmsState    state,
++                                                 gpointer      log_object,
++                                                 GError      **error);
++
++gchar *      mm_create_sms_pdu                  (const guint8 *pdu,
++                                                 gsize         pdulen);
++
+ #endif /* MM_SMS_STORAGE_H */
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch
@@ -1,0 +1,303 @@
+From 99e2aab4e330eef5cfe17c99feb5f0a31f43a6b3 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Wed, 25 Jun 2025 14:12:13 -0500
+Subject: [PATCH 09/10] sms-storage: do hex<->binary conversion in sms-storage
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+Signed-off-by: Dan Williams <dan@ioncontrol.co>
+---
+ src/mm-broadband-modem-qmi.c | 14 ++++--
+ src/mm-sms-qmi.c             | 35 ++++++--------
+ src/mm-sms-storage.c         | 91 ++++++++++++++++++------------------
+ src/mm-sms-storage.h         | 25 ++++------
+ 4 files changed, 80 insertions(+), 85 deletions(-)
+
+diff --git a/src/mm-broadband-modem-qmi.c b/src/mm-broadband-modem-qmi.c
+index 10b3d82d..f91c2092 100644
+--- a/src/mm-broadband-modem-qmi.c
++++ b/src/mm-broadband-modem-qmi.c
+@@ -8170,8 +8170,6 @@ load_messages_from_ta_storage (GTask *task)
+     MMBroadbandModemQmi        *self;
+     LoadInitialSmsPartsContext *ctx;
+     GList                      *indexes, *l;
+-    gchar                      *pdu;
+-    MMSmsState                  state;
+     g_autoptr(GError)           read_error = NULL;
+ 
+     self = g_task_get_source_object (task);
+@@ -8186,11 +8184,14 @@ load_messages_from_ta_storage (GTask *task)
+     }
+ 
+     for (l = indexes; l; l = g_list_next (l)) {
++        g_autofree guint8 *pdu;
++        gsize              pdu_len = 0;
++        MMSmsState         state = MM_SMS_STATE_UNKNOWN;
+         guint              msg_index = GPOINTER_TO_UINT (l->data);
+         MMSmsPart         *part;
+         g_autoptr(GError)  error = NULL;
+ 
+-        pdu = mm_sms_storage_read_message (msg_index, &state, &error);
++        pdu = mm_sms_storage_read_message (msg_index, &state, &pdu_len, &error);
+         if (!pdu) {
+             mm_obj_warn (self,
+                          "Failed to read the SMS (%d) from storage: %s",
+@@ -8199,7 +8200,12 @@ load_messages_from_ta_storage (GTask *task)
+             continue;
+         }
+ 
+-        part = mm_create_sms_part_from_pdu (msg_index, pdu, state, self, &error);
++        part = mm_sms_part_3gpp_new_from_binary_pdu (msg_index,
++                                                     pdu,
++                                                     pdu_len,
++                                                     self,
++                                                     state == MM_SMS_STATE_RECEIVED,
++                                                     &error);
+         if (!part) {
+             /* Don't treat the error as critical */
+             mm_obj_dbg (self, "error parsing SMS (%d) PDU: %s", msg_index, error->message);
+diff --git a/src/mm-sms-qmi.c b/src/mm-sms-qmi.c
+index bae2f4ca..81120e8b 100644
+--- a/src/mm-sms-qmi.c
++++ b/src/mm-sms-qmi.c
+@@ -246,33 +246,28 @@ sms_store_next_part (GTask *task)
+     }
+ 
+     /* Save the message in local data base */
+-    if(ctx->storage == MM_SMS_STORAGE_TA) {
+-        guint32 idx;
+-        gchar *sms_pdu;
+-        GError *err = NULL;
+-        MMSmsState state;
++    if (ctx->storage == MM_SMS_STORAGE_TA) {
++        guint32     idx;
++        MMSmsState  state;
++        GList      *parts;
+ 
+         mm_obj_dbg (self, "sms_store_next_part, storing in TA");
+         state = mm_gdbus_sms_get_state (MM_GDBUS_SMS (self));
+-        sms_pdu = mm_create_sms_pdu(pdu, pdulen);
+ 
+-        if (!mm_sms_storage_store_message(sms_pdu, state, &idx, &err)) {
+-            g_task_return_error (task, err);
++        if (!mm_sms_storage_store_message (pdu, pdulen, state, &idx, &error)) {
++            g_task_return_error (task, error);
+             g_object_unref (task);
+-            g_free (sms_pdu);
+-            return;
+-        } else {
+-            GList *parts;
+-            /* Set the index in the part we hold */
+-            parts = mm_base_sms_get_parts (self);
+-            mm_sms_part_set_index ((MMSmsPart *)parts->data, (guint)idx);
+-
+-            /* Go on with next one */
+-            ctx->current = g_list_next (ctx->current);
+-            g_free (sms_pdu);
+-            sms_store_next_part (task);
+             return;
+         }
++
++        /* Set the index in the part we hold */
++        parts = mm_base_sms_get_parts (self);
++        mm_sms_part_set_index ((MMSmsPart *)parts->data, (guint)idx);
++
++        /* Go on with next one */
++        ctx->current = g_list_next (ctx->current);
++        sms_store_next_part (task);
++        return;
+     }
+ 
+     /* Convert to GArray */
+diff --git a/src/mm-sms-storage.c b/src/mm-sms-storage.c
+index 867f43af..bdd9361d 100644
+--- a/src/mm-sms-storage.c
++++ b/src/mm-sms-storage.c
+@@ -32,21 +32,23 @@ static const gchar *dbname = PKGSYSCONFDIR "/smsdb.json";
+ 
+ /** Store message in local storage in "pdu,state" format*/
+ gboolean
+-mm_sms_storage_store_message (gchar       *pdu,
+-                              MMSmsState   state,
+-                              guint32     *idx,
+-                              GError     **error)
++mm_sms_storage_store_message (const guint8  *pdu,
++                              gsize          pdu_len,
++                              MMSmsState     state,
++                              guint32       *idx,
++                              GError       **error)
+ {
+-    g_autoptr(JsonParser) parser = NULL;
+-    GError *inner_error = NULL;
+-    guint msg_ref = 0;
+-    g_autofree gchar *msg_ref_str = NULL;
+-    g_autoptr(JsonNode) root = NULL;
+-    JsonObject *root_object;
+-    JsonObject *object = NULL;
+-    g_autoptr(JsonReader) reader = NULL;
++    g_autoptr(JsonParser)    parser = NULL;
++    GError                  *inner_error = NULL;
++    guint                    msg_ref = 0;
++    g_autofree gchar        *msg_ref_str = NULL;
++    g_autofree gchar        *hexpdu = NULL;
++    g_autoptr(JsonNode)      root = NULL;
++    JsonObject              *root_object;
++    JsonObject              *object = NULL;
++    g_autoptr(JsonReader)    reader = NULL;
+     g_autoptr(JsonGenerator) generator = NULL;
+-    gboolean no_data = TRUE;
++    gboolean                 no_data = TRUE;
+ 
+     parser = json_parser_new ();
+ 
+@@ -76,11 +78,16 @@ mm_sms_storage_store_message (gchar       *pdu,
+ 
+     msg_ref++;
+     json_object_set_int_member (root_object, "msg_ref", msg_ref);
++
+     object = json_object_new ();
+-    json_object_set_string_member (object, "pdu", pdu);
+     json_object_set_int_member (object, "state", state);
++
++    hexpdu = mm_utils_bin2hexstr (pdu, pdu_len);
++    json_object_set_string_member (object, "pdu", hexpdu);
++
+     msg_ref_str = g_strdup_printf ("%u", msg_ref);
+     json_object_set_object_member (root_object, msg_ref_str, object);
++
+     json_node_take_object (root, root_object);
+ 
+     generator = json_generator_new ();
+@@ -146,10 +153,11 @@ mm_sms_storage_delete_message (guint    index,
+     return TRUE;
+ }
+ 
+-/* Read a message of given index from stoarge and return its PDU */
+-gchar *
++/* Read a message of given index from stoarge and return its binary PDU */
++guint8 *
+ mm_sms_storage_read_message (guint        index,
+                              MMSmsState  *state,
++                             gsize       *out_pdu_len,
+                              GError     **error)
+ {
+     g_autoptr(JsonParser)  parser = NULL;
+@@ -160,6 +168,10 @@ mm_sms_storage_read_message (guint        index,
+     JsonNode              *node = NULL;
+     g_autofree gchar      *msg_ref_str = NULL;
+     JsonObject            *obj;
++    guint8                *pdu;
++    const gchar           *hexpdu;
++
++    g_assert (out_pdu_len != NULL);
+ 
+     parser = json_parser_new ();
+ 
+@@ -192,10 +204,27 @@ mm_sms_storage_read_message (guint        index,
+     }
+ 
+     obj = json_node_get_object (node);
++    hexpdu = json_object_get_string_member (obj, "pdu");
++    if (!hexpdu) {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_NOT_FOUND,
++                     "Message index %d had no PDU in storage",
++                     index);
++        return FALSE;
++    }
++
++    /* Convert PDU from hex to binary */
++    pdu = mm_utils_hexstr2bin (hexpdu, -1, out_pdu_len, error);
++    if (!pdu) {
++        g_prefix_error (error, "Couldn't convert 3GPP PDU from hex to binary: ");
++        return NULL;
++    }
++
+     if (state)
+         *state = json_object_get_int_member (obj, "state");
+ 
+-    return g_strdup (json_object_get_string_member (obj, "pdu"));
++    return pdu;
+ }
+ 
+ /* Return all valid indexces */
+@@ -321,31 +350,3 @@ mm_sms_get_default_storage_type (GError  **error)
+ 
+     return storage;
+ }
+-
+-MMSmsPart *
+-mm_create_sms_part_from_pdu (guint       index,
+-                             const gchar *hexpdu,
+-                             MMSmsState  state,
+-                             gpointer    log_object,
+-                             GError      **error)
+-{
+-    g_autofree guint8 *pdu = NULL;
+-    gsize              pdu_len;
+-
+-    /* Convert PDU from hex to binary */
+-    pdu = mm_utils_hexstr2bin (hexpdu, -1, &pdu_len, error);
+-    if (!pdu) {
+-        g_prefix_error (error, "Couldn't convert 3GPP PDU from hex to binary: ");
+-        return NULL;
+-    }
+-
+-    return mm_sms_part_3gpp_new_from_binary_pdu (index, pdu, pdu_len, log_object,
+-                                                    state == MM_SMS_STATE_RECEIVED, error);
+-}
+-
+-gchar *
+-mm_create_sms_pdu (const guint8 *pdu,
+-                   gsize         pdulen)
+-{
+-    return mm_utils_bin2hexstr (pdu, pdulen);
+-}
+diff --git a/src/mm-sms-storage.h b/src/mm-sms-storage.h
+index 5a452885..d2bb22d4 100644
+--- a/src/mm-sms-storage.h
++++ b/src/mm-sms-storage.h
+@@ -20,17 +20,19 @@
+ #include <glib.h>
+ #include <ModemManager.h>
+ 
+-gboolean     mm_sms_storage_store_message       (gchar       *pdu,
+-                                                 MMSmsState   state,
+-                                                 guint32     *idx,
+-                                                 GError     **error);
++gboolean     mm_sms_storage_store_message       (const guint8  *pdu,
++                                                 gsize          pdu_len,
++                                                 MMSmsState     state,
++                                                 guint32       *idx,
++                                                 GError       **error);
+ 
+ gboolean     mm_sms_storage_delete_message      (guint    index,
+                                                  GError **error);
+ 
+-gchar *      mm_sms_storage_read_message        (guint        index,
+-                                                 MMSmsState  *state,
+-                                                 GError     **error);
++guint8 *      mm_sms_storage_read_message        (guint        index,
++                                                  MMSmsState  *state,
++                                                  gsize       *out_pdu_len,
++                                                  GError     **error);
+ 
+ GList *      mm_sms_storage_read_all_indexes    (GError **error);
+ 
+@@ -39,13 +41,4 @@ gboolean     mm_sms_update_default_storage_type (MMSmsStorage   storage,
+ 
+ MMSmsStorage mm_sms_get_default_storage_type    (GError **error);
+ 
+-MMSmsPart *  mm_create_sms_part_from_pdu        (guint         index,
+-                                                 const gchar  *hexpdu,
+-                                                 MMSmsState    state,
+-                                                 gpointer      log_object,
+-                                                 GError      **error);
+-
+-gchar *      mm_create_sms_pdu                  (const guint8 *pdu,
+-                                                 gsize         pdulen);
+-
+ #endif /* MM_SMS_STORAGE_H */
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch
@@ -1,0 +1,73 @@
+From 672beb9e6ceba7e36fef7d25d700192567af1064 Mon Sep 17 00:00:00 2001
+From: Akula Susmitha <quic_asusmith@quicinc.com>
+Date: Tue, 28 Oct 2025 18:18:00 +0530
+Subject: [PATCH 10/10] sms-storage: Add slot info for TA SMS in DB
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1263]
+Signed-off-by: Akula Susmitha <quic_asusmith@quicinc.com>
+---
+ src/mm-sms-qmi.c     | 3 ++-
+ src/mm-sms-storage.c | 5 ++++-
+ src/mm-sms-storage.h | 3 ++-
+ 3 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/src/mm-sms-qmi.c b/src/mm-sms-qmi.c
+index 81120e8b..fa112567 100644
+--- a/src/mm-sms-qmi.c
++++ b/src/mm-sms-qmi.c
+@@ -250,11 +250,12 @@ sms_store_next_part (GTask *task)
+         guint32     idx;
+         MMSmsState  state;
+         GList      *parts;
++        guint32    slot_id = 0; // currently default slot_id is 0
+ 
+         mm_obj_dbg (self, "sms_store_next_part, storing in TA");
+         state = mm_gdbus_sms_get_state (MM_GDBUS_SMS (self));
+ 
+-        if (!mm_sms_storage_store_message (pdu, pdulen, state, &idx, &error)) {
++        if (!mm_sms_storage_store_message (pdu, pdulen, state, slot_id, &idx, &error)) {
+             g_task_return_error (task, error);
+             g_object_unref (task);
+             return;
+diff --git a/src/mm-sms-storage.c b/src/mm-sms-storage.c
+index bdd9361d..24bf1916 100644
+--- a/src/mm-sms-storage.c
++++ b/src/mm-sms-storage.c
+@@ -35,8 +35,9 @@ gboolean
+ mm_sms_storage_store_message (const guint8  *pdu,
+                               gsize          pdu_len,
+                               MMSmsState     state,
++                              guint32        slot_id,
+                               guint32       *idx,
+-                              GError       **error)
++                              GError        **error)
+ {
+     g_autoptr(JsonParser)    parser = NULL;
+     GError                  *inner_error = NULL;
+@@ -85,6 +86,8 @@ mm_sms_storage_store_message (const guint8  *pdu,
+     hexpdu = mm_utils_bin2hexstr (pdu, pdu_len);
+     json_object_set_string_member (object, "pdu", hexpdu);
+ 
++    json_object_set_int_member (object, "slot_id", slot_id);
++
+     msg_ref_str = g_strdup_printf ("%u", msg_ref);
+     json_object_set_object_member (root_object, msg_ref_str, object);
+ 
+diff --git a/src/mm-sms-storage.h b/src/mm-sms-storage.h
+index d2bb22d4..a2b49515 100644
+--- a/src/mm-sms-storage.h
++++ b/src/mm-sms-storage.h
+@@ -23,8 +23,9 @@
+ gboolean     mm_sms_storage_store_message       (const guint8  *pdu,
+                                                  gsize          pdu_len,
+                                                  MMSmsState     state,
++                                                 guint32        slot_id,
+                                                  guint32       *idx,
+-                                                 GError       **error);
++                                                 GError        **error);
+ 
+ gboolean     mm_sms_storage_delete_message      (guint    index,
+                                                  GError **error);
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom = " qrtr"

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,1 +1,18 @@
+FILESEXTRAPATHS:append:qcom := "${THISDIR}/files:"
+
 PACKAGECONFIG:append:qcom = " qrtr"
+
+DEPENDS:append:qcom = " json-glib"
+
+SRC_URI:append:qcom = " \
+    file://0001-iface-modem-messaging-sms-Add-TA-storage-support-for.patch \
+    file://0002-fixup-move-json-glib-dep-to-root-meson.build-add-to-.patch \
+    file://0003-whitespace-cleanup.patch \
+    file://0004-whitespace-cleanup-fix-error-freeing.patch \
+    file://0005-remove-dead-code.patch \
+    file://0006-qmi-error-free-fixup.patch \
+    file://0007-whitespace-fixes-some-memory-leak-fixes.patch \
+    file://0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch \
+    file://0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch \
+    file://0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch \
+"


### PR DESCRIPTION
Enable the qrtr support in modemmanager to allow communication with the
modem.

Add support to store SMS messages on the device so they remain available
across reboots, modem resets and SIM changes.