### PR TITLE
modemmanager: add patch for QRTR + QCOM SoC plugin with external M.2 attach through MHI ports

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch
@@ -1,0 +1,209 @@
+From 564c0da9313562981c847eb447f2bd08ef843f8b Mon Sep 17 00:00:00 2001
+From: Mrigank Dembla <mdembla@qti.qualcomm.com>
+Date: Thu, 9 Apr 2026 18:05:30 +0530
+Subject: [PATCH] qcom-soc: add QRTR+mhi_net support for PCIe-attached SDX
+ modems
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On platforms with a PCIe-attached Qualcomm modem (e.g. SDX35 on
+QCS6490/RB3 Gen2), the modem is controlled via QRTR through the MHI
+IPCR channel. ModemManager currently has no way to associate the QRTR
+control path with the mhi_net data interface, so the modem is not
+detected.
+
+This patch adds four changes:
+
+  1. Routes PCIe mhi_net interfaces to the qcom-soc plugin via udev,
+     guarded by ENV{ID_BUS}=="pci" to exclude USB MHI modems.
+
+  2. Adds a dedicated QMI data endpoint handler for mhi_net that sets
+     endpoint type PCIE with interface number 4, matching the PCIe
+     data path expected by the modem firmware.
+
+  3. Skips wwan control ports when the MHI IPCR channel (*_IPCR) is
+     bound to a QRTR driver. The presence of a bound IPCR channel is
+     the definitive runtime evidence that QRTR is the active control
+     path. Platforms where the same PCIe modem uses WWAN/MBIM (e.g.
+     X13s with SDX55) do not expose an *_IPCR channel and are
+     unaffected. Platform modems (qcom-q6v5-mss) have no MHI device
+     in their physdev and are also unaffected.
+
+  4. Enables multiplexed bearers (REQUESTED) over mhi_net.
+
+The wwan port exclusion is timing-independent: the IPCR channel
+binding is established before wwan ports appear. It requires no
+vendor ID, no physdev path heuristics, and no firmware type
+detection.
+
+Without this enablement, ModemManager cannot detect MHI‑attached
+external modems on these platforms, preventing cellular data bring‑up
+on otherwise supported hardware configurations.
+
+Acknowledged limitation: this patch carries the single-modem
+assumption already present in the qcom-soc plugin. Proper multi-modem
+support requires binding QRTR nodes to net interfaces at runtime,
+which depends on kernel QRTR_REPORT_ENDPOINT support currently under
+verification. A follow-up MR will address that once the kernel side
+is ready.
+
+Tested on Rb3Gen2, Rb4 and Rb8 kits with SDX35 PCIe modem:
+  mhi0_IPCR → driver: qcom_mhi_qrtr (wwan ports correctly skipped)
+
+This downstream patch reuses the logic introduced in ModemManager MR!1443
+but is carried as a temporary workaround for Qualcomm single SDX MHI
+modem configurations.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1443]
+Signed-off-by: Mrigank Dembla <mdembla@qti.qualcomm.com>
+---
+ src/mm-bearer-qmi.c                           |  4 +-
+ src/mm-device.c                               | 49 +++++++++++++++++++
+ src/plugins/qcom-soc/77-mm-qcom-soc.rules     |  1 +
+ .../mm-broadband-modem-qmi-qcom-soc.c         | 29 +++++++++++
+ 4 files changed, 82 insertions(+), 1 deletion(-)
+
+diff --git a/src/mm-bearer-qmi.c b/src/mm-bearer-qmi.c
+index 64d983eb..79c9be24 100644
+--- a/src/mm-bearer-qmi.c
++++ b/src/mm-bearer-qmi.c
+@@ -2438,13 +2438,15 @@ load_settings_from_bearer (MMBearerQmi         *self,
+     if (!max_multiplexed_bearers)
+         multiplex_supported = FALSE;
+ 
+-    /* If no multiplex setting given by the user, assume none; unless in IPA */
++    /* If no multiplex setting given by the user, assume none; unless in IPA or MHI */
+     ctx->multiplex = mm_bearer_properties_get_multiplex (properties);
+     if (ctx->multiplex == MM_BEARER_MULTIPLEX_SUPPORT_UNKNOWN) {
+         if (mm_context_get_test_multiplex_requested ())
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUESTED;
+         else if (!g_strcmp0 (data_port_driver, "ipa"))
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUIRED;
++	    else if (!g_strcmp0 (data_port_driver, "mhi_net"))
++	        ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUESTED;	
+         else
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_NONE;
+     }
+diff --git a/src/mm-device.c b/src/mm-device.c
+index b991f18d..da7f7040 100644
+--- a/src/mm-device.c
++++ b/src/mm-device.c
+@@ -224,6 +224,55 @@ mm_device_grab_port (MMDevice       *self,
+     MMPortProbe    *probe;
+     MMKernelDevice *lower_port;
+ 
++    /* Skip wwan control ports when the MHI IPCR channel is bound to a QRTR
++     * driver. The presence of a bound *_IPCR MHI channel is the definitive
++     * runtime evidence that QRTR is the active control path for the modem
++     * (e.g. SDX35 on QCS6490 via qcom_mhi_qrtr). In that case, the wwan
++     * control ports (mhi_wwan_ctrl) are redundant and probing them causes
++     * unnecessary delays that interfere with QRTR-based initialization.
++     *
++     * Platforms where the same PCIe modem uses WWAN/MBIM (e.g. X13s with
++     * SDX55) do not expose an *_IPCR channel and are unaffected. Platform
++     * modems (qcom-q6v5-mss) have no MHI device in their physdev and are
++     * also unaffected. */
++    if (!g_strcmp0 (mm_kernel_device_get_subsystem (kernel_port), "wwan") &&
++        !g_strcmp0 (mm_kernel_device_get_property  (kernel_port, "DEVTYPE"), "wwan_port") &&
++        self->priv->physdev) {
++        GDir        *dir;
++        const gchar *name;
++        gboolean     qrtr_found = FALSE;
++
++        dir = g_dir_open (self->priv->physdev, 0, NULL);
++        if (dir) {
++            while ((name = g_dir_read_name (dir)) != NULL && !qrtr_found) {
++                if (g_str_has_prefix (name, "mhi")) {
++                    g_autofree gchar *mhi_path = g_build_filename (self->priv->physdev, name, NULL);
++                    GDir *mhi_dir = g_dir_open (mhi_path, 0, NULL);
++                    if (mhi_dir) {
++                        const gchar *ch;
++                        while ((ch = g_dir_read_name (mhi_dir)) != NULL) {
++                            if (g_str_has_suffix (ch, "_IPCR")) {
++                                g_autofree gchar *drv = g_build_filename (mhi_path, ch, "driver", NULL);
++                                if (g_file_test (drv, G_FILE_TEST_EXISTS)) {
++                                    qrtr_found = TRUE;
++                                    break;
++                                }
++                            }
++                        }
++                        g_dir_close (mhi_dir);
++                    }
++                }
++            }
++            g_dir_close (dir);
++        }
++
++        if (qrtr_found) {
++            mm_obj_dbg (self, "ignoring wwan port %s: MHI IPCR channel present, modem uses QRTR",
++                        mm_kernel_device_get_name (kernel_port));
++            return FALSE;
++        }
++    }
++
+     if (mm_device_owns_port (self, kernel_port))
+         return TRUE;
+ 
+diff --git a/src/plugins/qcom-soc/77-mm-qcom-soc.rules b/src/plugins/qcom-soc/77-mm-qcom-soc.rules
+index 9719f96f..2284c3e8 100644
+--- a/src/plugins/qcom-soc/77-mm-qcom-soc.rules
++++ b/src/plugins/qcom-soc/77-mm-qcom-soc.rules
+@@ -5,6 +5,7 @@ ACTION!="add|change|move|bind", GOTO="mm_qcom_soc_end"
+ # Process only known wwan, net and rpmsg ports
+ SUBSYSTEM=="net",   DRIVERS=="bam-dmux",      GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="net",   DRIVERS=="ipa",           GOTO="mm_qcom_soc_process"
++SUBSYSTEM=="net",   DRIVERS=="mhi_net", ENV{ID_BUS}=="pci", GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="wwan",  DRIVERS=="qcom-q6v5-mss", GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="rpmsg", DRIVERS=="qcom-q6v5-mss", GOTO="mm_qcom_soc_process"
+ GOTO="mm_qcom_soc_end"
+diff --git a/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c b/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
+index fa19bd4d..48fe1850 100644
+--- a/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
++++ b/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
+@@ -110,6 +110,32 @@ peek_port_qmi_for_data_ipa (MMBroadbandModemQmi  *self,
+     return found;
+ }
+ 
++static MMPortQmi *
++peek_port_qmi_for_data_mhi (MMBroadbandModemQmi  *self,
++                            MMPort               *data,
++                            MMQmiDataEndpoint    *out_endpoint,
++                            GError              **error)
++{
++    MMPortQmi *found = NULL;
++
++    found = mm_broadband_modem_qmi_peek_port_qmi (self);
++    if (!found) {
++        g_set_error (error,
++                     MM_CORE_ERROR,
++                     MM_CORE_ERROR_NOT_FOUND,
++                     "Couldn't find any QMI port for 'net/%s'",
++                     mm_port_get_device (data));
++        return NULL;
++    }
++    
++    if (out_endpoint) {
++       out_endpoint->type = QMI_DATA_ENDPOINT_TYPE_PCIE;
++       out_endpoint->interface_number = 4; 
++    }
++
++    return found;
++}
++
+ static MMPortQmi *
+ peek_port_qmi_for_data (MMBroadbandModemQmi  *self,
+                         MMPort               *data,
+@@ -127,6 +153,9 @@ peek_port_qmi_for_data (MMBroadbandModemQmi  *self,
+ 
+     if (g_strcmp0 (net_port_driver, "ipa") == 0)
+         return peek_port_qmi_for_data_ipa (self, data, out_endpoint, error);
++    
++    if (g_strcmp0 (net_port_driver, "mhi_net") == 0)
++        return peek_port_qmi_for_data_mhi (self, data, out_endpoint, error);
+ 
+     if (g_strcmp0 (net_port_driver, "bam-dmux") == 0)
+         return peek_port_qmi_for_data_bam_dmux (self, data, out_endpoint, error);
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -15,4 +15,5 @@ SRC_URI:append:qcom = " \
     file://0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch \
     file://0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch \
     file://0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch \
+    file://0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch \
 "


### PR DESCRIPTION
**Scope and intent**

This change is intended only for Qualcomm SoC industrial platforms (RB3 Gen2/QCS6490, RB4/QCS8300, RB8/QCS9100) running meta-qcom/QLI. In this environment, ModemManager is not enabled globally; it is enabled only on targets that explicitly declare MACHINE_FEATURES += "phone" (added via PR #1861).

**Problem**

On Qualcomm SoC platforms with a PCIe-attached SDX modem (e.g. SDX35/55 on QCS6490), the modem is controlled via QRTR through the MHI IPCR channel. ModemManager currently has no way to associate the QRTR control path with the mhi_net data interface, so the modem is not detected.

**What this patch adds**

- Routes PCIe mhi_net interfaces to the qcom-soc plugin via udev, guarded by ENV{ID_BUS}=="pci".
- Adds a dedicated QMI data endpoint handler for mhi_net (PCIe endpoint, interface number 4).
- Skips wwan control ports only when the MHI IPCR channel is bound to a QRTR driver. The presence of a bound *_IPCR   MHI channel is the definitive runtime evidence that QRTR is the active control path. 
- Enables multiplexed bearers (REQUESTED) for the QRTR + mhi_net case.

Without this enablement, ModemManager cannot detect MHI-attached external modems on these platforms, preventing cellular data bring-up on otherwise supported hardware configurations.

**Why this is not a general-purpose solution**

The current implementation intentionally targets single external modem configurations, which are sufficient to enable cellular data functionality on the above platforms for this release. A more generic solution covering multiple concurrently attached SDX modems requires additional kernel and ModemManager changes and broader hardware validation, and is being worked on separately.

For this reason, the patch is marked Upstream-Status: Inappropriate and is carried strictly as a downstream, Qualcomm SoC-specific workaround. A generic upstream solution requires kernel-level support to bind QRTR nodes to network interfaces at runtime and will be proposed separately once that support is ready.

**Testing and feature validation usecases**

The wwan port exclusion fires only when an *_IPCR MHI channel with a driver bound is found under the device's physdev path. This check is timing-independent: the IPCR channel binding is established before wwan ports appear.

The following configurations have been analyzed and are unaffected:

- Qualcomm SoC platforms (RB3 Gen2, RB4, RB8) with PCIe-attached SDX modems: mhi0_IPCR is present and bound to qcom_mhi_qrtr. Wwan ports are correctly skipped. Verified on RB3 Gen2 with SDX35.
- ARM laptops (X13s/SC8280XP) with PCIe-attached SDX55 (T99W175): the MHI device exposes channels DIAG, DUN, IP_HW0_MBIM, LOOPBACK, MBIM but no *_IPCR channel. WWAN/MBIM control path is unaffected.
- x86/AMD hosts with M.2 modems (Telit FN990, Sierra EM9xxx, and similar Qualcomm-chipset modules): these modems use WWAN/MBIM and do not expose an *_IPCR channel. The check does not fire.
- Platform modems (qcom-q6v5-mss): the physdev path contains no MHI device. The directory scan finds no mhi* entry and the check does not fire.
- USB-attached MHI modems: the physdev path is a USB device path with no MHI device at the physdev level. The check does not fire.
- Non-Qualcomm PCIe modems: no MHI device, no *_IPCR channel. The check does not fire.
- Virtual devices: physdev is NULL. The NULL guard prevents the check from running.

This change provides minimal, platform-scoped support for the current meta-qcom release, without precluding future refinement as multi-modem support is stabilized.