### PR TITLE
Add systemd service to format persist partition.

### DIFF
--- a/recipes-bsp/partition/mount-tee-partition/check-tee-partition-fs.sh
+++ b/recipes-bsp/partition/mount-tee-partition/check-tee-partition-fs.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+set -e
+
+DEV=/dev/disk/by-partlabel/persist
+[ -b "$DEV" ] || exit 0
+
+export PATH=/sbin:/usr/sbin
+
+# Check if ext4 filesystem exists
+if [ "$(blkid -o value -s TYPE "$DEV" 2>/dev/null)" != "ext4" ]; then
+    echo "$DEV: no valid ext4 filesystem found, creating ext4"
+    mkfs.ext4 -F "$DEV"
+    exit 0
+fi
+
+# Run a read-only fsck check to detect corruptions
+e2fsck -n "$DEV" >/dev/null 2>&1
+err=$?
+if [ "$err" -gt 4 ]; then
+    echo "$DEV: filesystem corrupted (e2fsck error=$err), recreating"
+    mkfs.ext4 -F "$DEV"
+    exit 0
+else
+    echo "$DEV: filesystem is OK"
+fi

--- a/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
+++ b/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
@@ -1,0 +1,20 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+[Unit]
+Description=Create ext4 filesystem on persist partition if missing
+Requires=dev-disk-by\x2dpartlabel-persist.device
+After=dev-disk-by\x2dpartlabel-persist.device
+ConditionPathExists=/dev/disk/by-partlabel/persist
+Before=var-lib-tee.mount
+Wants=var-lib-tee.mount
+ConditionPathIsMountPoint=!/var/lib/tee
+
+[Service]
+Type=oneshot
+ExecStart=@sbindir@/check-tee-partition-fs.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=local-fs-pre.target

--- a/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
+++ b/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
@@ -5,6 +5,8 @@
 [Unit]
 Description=Mount persist partition at /var/lib/tee
 Before=local-fs.target
+Requires=format-tee-partition.service
+After=format-tee-partition.service
 
 [Mount]
 DirectoryMode=0755

--- a/recipes-bsp/partition/mount-tee-partition_1.0.bb
+++ b/recipes-bsp/partition/mount-tee-partition_1.0.bb
@@ -4,9 +4,13 @@ encryped data and support security functions"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
 
-SRC_URI = "file://var-lib-tee.mount"
+SRC_URI = " \
+    file://var-lib-tee.mount \
+    file://check-tee-partition-fs.sh \
+    file://format-tee-partition.service \
+"
 
-inherit allarch features_check systemd
+inherit features_check systemd
 REQUIRED_DISTRO_FEATURES = "systemd"
 
 INHIBIT_DEFAULT_DEPS = "1"
@@ -17,9 +21,17 @@ do_compile[noexec] = "1"
 
 do_install() {
     install -Dm 0644 ${UNPACKDIR}/var-lib-tee.mount \
-            ${D}${systemd_unitdir}/system/var-lib-tee.mount
+            ${D}${systemd_system_unitdir}/var-lib-tee.mount
+    install -Dm 0755 ${UNPACKDIR}/check-tee-partition-fs.sh \
+            ${D}${sbindir}/check-tee-partition-fs.sh
+    install -Dm 0644 ${UNPACKDIR}/format-tee-partition.service \
+            ${D}${systemd_system_unitdir}/format-tee-partition.service
+    sed -i -e "s,@sbindir@,${sbindir},g" \
+            ${D}${systemd_system_unitdir}/format-tee-partition.service
 }
 
 PACKAGES = "${PN}"
 
-SYSTEMD_SERVICE:${PN} = "var-lib-tee.mount"
+SYSTEMD_SERVICE:${PN} = "var-lib-tee.mount format-tee-partition.service"
+
+RDEPENDS:${PN} += "e2fsprogs-e2fsck e2fsprogs-mke2fs util-linux-blkid"


### PR DESCRIPTION
QTEE requires a valid filesystem on the persist partition mounted at `/var/lib/tee` to store encrypted data. If the partition is unformatted, mounting fails and dependent services such as qtee_supplicant cannot function correctly.

Add a systemd oneshot service that checks for an existing filesystem on the persist partition and formats it as ext4 when missing. The service runs once in early boot before `var-lib-tee.mount` unit, to ensure a valid filesystem is available at `/var/lib/tee` and disables itself after successful execution.