### PR TITLE
image_types_qcom: add multiple storage build support in qcomflash

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -44,52 +44,49 @@ deploy_partition_files() {
     fi
 }
 
-create_qcomflash_pkg() {
+deploy_images() {
+    local dest_dir=$1
+
     # esp image
-    [ -n "${QCOM_ESP_FILE}" ] && install -m 0644 ${QCOM_ESP_FILE} efi.bin
+    [ -n "${QCOM_ESP_FILE}" ] && install -m 0644 ${QCOM_ESP_FILE} ${dest_dir}/efi.bin
 
     # dtb image
     if [ -n "${QCOM_DTB_DEFAULT}" ] && \
                 [ -f "${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat" ]; then
         # default image
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat ${QCOM_DTB_FILE}
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat ${dest_dir}/${QCOM_DTB_FILE}
         # copy all images so they can be made available via the same tarball
         for dtbimg in ${DEPLOY_DIR_IMAGE}/dtb-*-image.vfat; do
-            install -m 0644 ${dtbimg} .
+            install -m 0644 ${dtbimg} ${dest_dir}
         done
     fi
 
     # vmlinux
     [ -e "${DEPLOY_DIR_IMAGE}/vmlinux" -a \
         ! -e "vmlinux" ] && \
-        install -m 0644 "${DEPLOY_DIR_IMAGE}/vmlinux" vmlinux
+        install -m 0644 "${DEPLOY_DIR_IMAGE}/vmlinux" ${dest_dir}/vmlinux
 
     # Legacy boot images
     if [ -n "${QCOM_DTB_DEFAULT}" ]; then
         [ -e "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" -a \
             ! -e "boot.img" ] && \
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" boot.img
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-initramfs-${QCOM_DTB_DEFAULT}-${MACHINE}.img" ${dest_dir}/boot.img
         [ -e "${DEPLOY_DIR_IMAGE}/boot-${QCOM_DTB_DEFAULT}-${MACHINE}.img" -a \
             ! -e "boot.img" ] && \
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${QCOM_DTB_DEFAULT}-${MACHINE}.img" boot.img
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${QCOM_DTB_DEFAULT}-${MACHINE}.img" ${dest_dir}/boot.img
     fi
     [ -e "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" -a \
         ! -e "boot.img" ] && \
-        install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" boot.img
+        install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" ${dest_dir}/boot.img
 
     # rootfs image
-    install -m 0644 ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} rootfs.img
-
-    # partition bins/xml files
-    if [ -n "${QCOM_PARTITION_FILES_SUBDIR}" ]; then
-        deploy_partition_files ${DEPLOY_DIR_IMAGE}/${QCOM_PARTITION_FILES_SUBDIR} .
-    fi
+    install -m 0644 ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} ${dest_dir}/rootfs.img
 
     if [ -n "${QCOM_BOOT_FILES_SUBDIR}" ]; then
         # install CDT file if present,for targets with spinor, CDT file
         # will be in spinor subfolder instead of root folder
         if [ -n "${QCOM_CDT_FILE}" ] && [ -e "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_CDT_FILE}.bin" ]; then
-            install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_CDT_FILE}.bin cdt.bin
+            install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_CDT_FILE}.bin ${dest_dir}/cdt.bin
         fi
 
         # boot firmware
@@ -101,7 +98,7 @@ create_qcomflash_pkg() {
                 -name 'cdt_*.bin' -o \
                 -name 'logfs_*.bin' -o \
                 -name 'sec.dat'` ; do
-            install -m 0644 ${bfw} .
+            install -m 0644 ${bfw} ${dest_dir}
         done
 
         # xbl_config
@@ -111,7 +108,7 @@ create_qcomflash_pkg() {
         fi
 
         if [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" ]; then
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" xbl_config.elf
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" ${dest_dir}/xbl_config.elf
         fi
 
         # bootloader selection
@@ -123,44 +120,83 @@ create_qcomflash_pkg() {
                 ;;
         esac
         if [ -f "${bootloader_bin}" ]; then
-            install -m 0644 "${bootloader_bin}" uefi.elf
+            install -m 0644 "${bootloader_bin}" ${dest_dir}/uefi.elf
         fi
 
         # sail nor firmware
         if [ -d "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/sail_nor" ]; then
-            install -d sail_nor
-            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/sail_nor" -maxdepth 1 -type f -exec install -m 0644 {} sail_nor \;
+            install -d ${dest_dir}/sail_nor
+            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/sail_nor" -maxdepth 1 -type f -exec install -m 0644 {} ${dest_dir}/sail_nor \;
         fi
 
         # SPI-NOR firmware, partition bins, CDT etc.
         if [ -d "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" ]; then
-            install -d spinor
-            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" -maxdepth 1 -type f -exec install -m 0644 {} spinor \;
-
-            # partition bins/xml files
-            if [ -n "${QCOM_PARTITION_FILES_SUBDIR_SPINOR}" ]; then
-                deploy_partition_files ${DEPLOY_DIR_IMAGE}/${QCOM_PARTITION_FILES_SUBDIR_SPINOR} spinor
-            fi
-
-            # cdt file
-            if [ -n "${QCOM_CDT_FILE}" ]; then
-                install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor/${QCOM_CDT_FILE}.bin spinor/cdt.bin
-            fi
-
-            # dtb image
-            if [ -n "${QCOM_DTB_FILE}" ]; then
-                install -m 0644 ${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat spinor/${QCOM_DTB_FILE}
-            fi
-
             # copy programer to support flash of HLOS images
-            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" -maxdepth 1 -type f -name 'xbl_s_devprg_ns.melf' -exec install -m 0644 {} . \;
+            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" -maxdepth 1 -type f -name 'xbl_s_devprg_ns.melf' -exec install -m 0644 {} ${dest_dir} \;
         fi
+
     fi
 
     # abl2esp
     if [ -e "${DEPLOY_DIR_IMAGE}/abl2esp-${ABL_SIGNATURE_VERSION}.elf" ]; then
-        install -m 0644 "${DEPLOY_DIR_IMAGE}/abl2esp-${ABL_SIGNATURE_VERSION}.elf" .
+        install -m 0644 "${DEPLOY_DIR_IMAGE}/abl2esp-${ABL_SIGNATURE_VERSION}.elf" ${dest_dir}
     fi
+}
+
+create_qcomflash_pkg() {
+    # Flag to identify the first storage type in the list
+    local is_first="true"
+
+    # Iterate through all partition subdirectories defined in QCOM_PARTITION_FILES_SUBDIR
+    for subdir in ${QCOM_PARTITION_FILES_SUBDIR}; do
+        # Get the storage type name (e.g., ufs, nvme, spinor) from the path
+        local storage_type=$(basename "${subdir}")
+        local dest_dir
+
+        # Determine the destination path based on iteration order
+        if [ "$is_first" = "true" ]; then
+            # The first one will be deployed to the root directory
+            dest_dir="."
+            is_first="false"
+        else
+            # For subsequent storage types, create and use a dedicated subdirectory
+            dest_dir="${storage_type}"
+            install -d "${dest_dir}"
+        fi
+
+        case "$storage_type" in
+            spinor)
+                # SPI-NOR firmware, partition bins, CDT etc.
+                if [ -d "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" ]; then
+                    install -d spinor
+                    find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" -maxdepth 1 -type f -exec install -m 0644 {} "${dest_dir}" \;
+
+                    # partition bins/xml files
+                    if [ -n "${subdir}" ]; then
+                        deploy_partition_files ${DEPLOY_DIR_IMAGE}/${subdir} "${dest_dir}"
+                    fi
+
+                    # cdt file
+                    if [ -n "${QCOM_CDT_FILE}" ]; then
+                        install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor/${QCOM_CDT_FILE}.bin "${dest_dir}"/cdt.bin
+                    fi
+
+                    # dtb image
+                    if [ -n "${QCOM_DTB_FILE}" ]; then
+                        install -m 0644 ${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat "${dest_dir}"/${QCOM_DTB_FILE}
+                    fi
+                fi
+                ;;
+            *)
+                # Deploy common images
+                deploy_images ${dest_dir}
+                # Partition bins/xml files
+                if [ -n "${subdir}" ]; then
+                    deploy_partition_files ${DEPLOY_DIR_IMAGE}/${subdir} ${dest_dir}
+                fi
+                ;;
+        esac
+    done
 
     # Create symlink to ${QCOMFLASH_DIR} dir
     ln -rsf ${QCOMFLASH_DIR} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -17,7 +17,6 @@ QCOM_DTB_FILE ?= "dtb.bin"
 
 QCOM_BOOT_FILES_SUBDIR ?= ""
 QCOM_PARTITION_FILES_SUBDIR ??= "${QCOM_BOOT_FILES_SUBDIR}"
-QCOM_PARTITION_FILES_SUBDIR_SPINOR ??= ""
 
 QCOM_PARTITION_CONF ?= "qcom-partition-conf"
 
@@ -173,11 +172,6 @@ create_qcomflash_pkg() {
                     ! -name 'uefi_dtbs*.xz'` ; do
                 install -m 0644 ${bfw} spinor
             done
-
-            # partition bins/xml files
-            if [ -n "${QCOM_PARTITION_FILES_SUBDIR_SPINOR}" ]; then
-                deploy_partition_files ${DEPLOY_DIR_IMAGE}/${QCOM_PARTITION_FILES_SUBDIR_SPINOR} spinor
-            fi
 
             # cdt file
             if [ -n "${QCOM_CDT_FILE}" ]; then

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -88,8 +88,22 @@ create_qcomflash_pkg() {
     install -m 0644 ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} rootfs.img
 
     # partition bins/xml files
+    # QCOM_PARTITION_FILES_SUBDIR may list more than one subdir for machines
+    # that build partition files for multiple storage targets. The first
+    # entry's files land in the package root (legacy behavior); any further
+    # entries land in a subdir named after their basename.
     if [ -n "${QCOM_PARTITION_FILES_SUBDIR}" ]; then
-        deploy_partition_files ${DEPLOY_DIR_IMAGE}/${QCOM_PARTITION_FILES_SUBDIR} .
+        first_subdir="true"
+        for subdir in ${QCOM_PARTITION_FILES_SUBDIR}; do
+            if [ "${first_subdir}" = "true" ]; then
+                dest_dir="."
+                first_subdir="false"
+            else
+                dest_dir="$(basename "${subdir}")"
+                install -d "${dest_dir}"
+            fi
+            deploy_partition_files ${DEPLOY_DIR_IMAGE}/${subdir} "${dest_dir}"
+        done
     fi
 
     if [ -n "${QCOM_BOOT_FILES_SUBDIR}" ]; then

--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -30,8 +30,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "cdt_glymur_crd_0.1.0"
 QCOM_BOOT_FILES_SUBDIR = "glymur-crd"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/glymur-crd/nvme"
-QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/glymur-crd/spinor"
+QCOM_PARTITION_FILES_SUBDIR ?= " \
+    partitions/glymur-crd/nvme \
+    partitions/glymur-crd/spinor \
+"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-glymur"
 QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-glymur"

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -26,8 +26,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 # IQ-X5121 and IQ-x7181 share the same partition configuration.
 QCOM_CDT_FILE = "IQ_X_EVK_CDT"
 QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
-QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
+QCOM_PARTITION_FILES_SUBDIR ?= " \
+    partitions/iq-x7181-evk/ufs \
+    partitions/iq-x7181-evk/spinor \
+"
 
 # IQ-X5121 and IQ-x7181 share the same boot firmware and CDT firmware.
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -19,8 +19,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "IQ_X_EVK_CDT"
 QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
-QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
+QCOM_PARTITION_FILES_SUBDIR ?= " \
+    partitions/iq-x7181-evk/ufs \
+    partitions/iq-x7181-evk/spinor \
+"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
 

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -27,8 +27,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_CDT_FILE = "IQ_X_EVK_CDT"
 QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
-QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
+QCOM_PARTITION_FILES_SUBDIR ?= " \
+    partitions/iq-x7181-evk/ufs \
+    partitions/iq-x7181-evk/spinor \
+"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
 QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-iq-x7181"


### PR DESCRIPTION
## Summary
This PR update the `image_types_qcom` bbclass to allow generating flash packages for multiple storage targets (e.g., eMMC, NVMe, UFS and SPI-NOR) in a single build run. 

Previously, the `create_qcomflash_pkg` function handled standard images in the root directory and used a separate variable (`QCOM_PARTITION_FILES_SUBDIR_SPINOR`) for SPI-NOR. By refactoring the deployment logic into a reusable `deploy_images` function, we can now loop through multiple paths defined in `QCOM_PARTITION_FILES_SUBDIR` and dynamically create subdirectories based on the storage type: 

- The first storage target defined in the list is deployed directly to the root directory of the flash package. 
- Subsequent storage targets are organized into dedicated subdirectories named after their storage type (e.g., nvme/, spinor/).

**Multiple storage build example:** 
``` bitbake 
QCOM_PARTITION_FILES_SUBDIR ?= " \
    partitions/iq-x7181-evk/ufs \   # the first one as the default build
    partitions/iq-x7181-evk/nvme \
    partitions/iq-x7181-evk/spinor \
"
```

```
build/tmp/deploy/images/iq-x7181-evk/qcom-multimedia-image-iq-x7181-evk.rootfs.qcomflash/
├── dtb.bin
├── dtb-hamoa-iot-evk-image.vfat
├── efi.bin
├── gpt_backup0.bin
├── gpt_both0.bin
├── gpt_main0.bin
├── nvme
│   ├── dtb.bin
│   ├── dtb-hamoa-iot-evk-image.vfat
│   ├── efi.bin
│   ├── gpt_backup0.bin
│   ├── gpt_both0.bin
│   ├── gpt_main0.bin
│   ├── patch0.xml
│   ├── rawprogram0.xml
│   ├── rootfs.img
│   ├── xbl_s_devprg_ns.melf
│   ├── zeros_1sector.bin
│   └── zeros_33sectors.bin
├── patch0.xml
├── rawprogram0.xml
├── rootfs.img
├── spinor
│   ├── adsp_dtbs.elf
│   ├── adsp_lite.lzma
│   ├── aop_devcfg.mbn
│   ├── aop.mbn
│   ├── cdt.bin
│   ├── contents.xml
│   ├── cpucp_dtbs.elf
│   ├── cpucp.elf
│   ├── devcfg_iot.mbn
│   ├── dtb.bin
│   ├── gpt_backup0.bin
│   ├── gpt_both0.bin
│   ├── gpt_main0.bin
│   ├── hypvm.mbn
│   ├── imagefv.elf
│   ├── IQ_X_EVK_CDT.bin
│   ├── multi_image.mbn
│   ├── patch0.xml
│   ├── qupv3fw.elf
│   ├── rawprogram0.xml
│   ├── shrm.elf
│   ├── tz.mbn
│   ├── uefi_dtbs.xz
│   ├── uefi.elf
│   ├── uefi_sec.mbn
│   ├── xbl_config.elf
│   ├── XblRamdump.xz
│   ├── xbl_s_devprg_ns.melf
│   ├── xbl_s.melf
│   ├── zeros_1sector.bin
│   ├── zeros_33sectors.bin
│   └── zeros_5sectors.bin
├── vmlinux
├── xbl_s_devprg_ns.melf
├── zeros_1sector.bin
├── zeros_33sectors.bin
└── zeros_5sectors.bin
```
**Single storage build example:**
``` bitbake
QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs9100-ride-sx/ufs"
```
```
build/tmp/deploy/images/qcs9100-ride-sx/qcom-multimedia-image-qcs9100-ride-sx.rootfs.qcomflash
├── aop.mbn
├── cdt.bin
├── cdt_rb8_core_kit.bin
├── cdt_ride_sx.bin
├── contents.xml
├── cpucp.elf
├── devcfg_iot.mbn
├── dtb.bin
├── dtb-qcs9100-ride-image.vfat
├── dtb-qcs9100-ride-r3-image.vfat
├── dtb-sa8775p-ride-image.vfat
├── dtb-sa8775p-ride-r3-image.vfat
├── efi.bin
├── gpt_backup0.bin
├── gpt_backup1.bin
├── gpt_backup2.bin
├── gpt_backup3.bin
├── gpt_backup4.bin
├── gpt_backup5.bin
├── gpt_both0.bin
├── gpt_both1.bin
├── gpt_both2.bin
├── gpt_both3.bin
├── gpt_both4.bin
├── gpt_both5.bin
├── gpt_main0.bin
├── gpt_main1.bin
├── gpt_main2.bin
├── gpt_main3.bin
├── gpt_main4.bin
├── gpt_main5.bin
├── hypvm.mbn
├── imagefv.elf
├── multi_image.mbn
├── multi_image_qti.mbn
├── patch0.xml
├── patch1.xml
├── patch2.xml
├── patch3.xml
├── patch4.xml
├── patch5.xml
├── prog_firehose_ddr.elf
├── prog_firehose_lite.elf
├── rawprogram0.xml
├── rawprogram1.xml
├── rawprogram2.xml
├── rawprogram3.xml
├── rawprogram4.xml
├── rawprogram5.xml
├── rootfs.img
├── sail_nor
│   ├── gpt_backup0.bin
│   ├── gpt_main0.bin
│   ├── patch0.xml
│   ├── prog_firehose_ddr.elf
│   ├── rawprogram0.xml
│   ├── sailhyp.elf
│   └── sailsw1.elf
├── shrm.elf
├── tools.fv
├── tz.mbn
├── uefi.elf
├── uefi_sec.mbn
├── vmlinux
├── xbl_config.elf
├── xbl.elf
├── XblRamdump.elf
├── zeros_1sector.bin
├── zeros_33sectors.bin
└── zeros_5sectors.bin
```

## Key Changes
- **`image_types_qcom.bbclass`**:
  - Extracted core image installation logic into a parameterized `deploy_images` function.
  - Modified `create_qcomflash_pkg` to iterate over `QCOM_PARTITION_FILES_SUBDIR`.
  - Dynamically isolates artifacts into `ufs/`, `spinor/`, or other storage type directories based on the path basename.
- **`iq-x7181-evk.conf`**:
  - Combined `ufs` and `spinor` partition subdirectories into a single space-separated `QCOM_PARTITION_FILES_SUBDIR` variable.
  - Removed the deprecated `QCOM_PARTITION_FILES_SUBDIR_SPINOR` variable.

