### PR TITLE
CI: reenable db820c tests

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -86,7 +86,8 @@ runs:
           echo "ROOTFS_URL=${BUILD_URL}/${{ inputs.distro_name }}${{ inputs.kernel }}/${{ inputs.machine }}/${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
           if [ "${{ inputs.machine }}" = "qcom-armv8a" ]; then
-              #echo "ROOTFS_IMG_FILE=${IMAGE_TYPE}-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
+              echo "ROOTFS_IMG_FILE=${IMAGE_TYPE}-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
+
               #cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-410c.ini
               #echo "DEVICE_TYPE=dragonboard-410c" >> dragonboard-410c.ini
               #echo "BOOT_IMG_FILE=boot-apq8016-sbc-qcom-armv8a.img" >> dragonboard-410c.ini


### PR DESCRIPTION
The commit b427b1b074e2 ("CI: disable db410c tests") dropped ROOTFS_IMG_FILE from gh-variables because it got mixed into db410c changes. Restore the variable to reenable tests on db820c.

Fixes: b427b1b074e2 ("CI: disable db410c tests")