### PR TITLE
weston-init: Move Qdemo launcher entries to external weston.ini

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -5,6 +5,7 @@ DEFAULTBACKEND:qcom ?= "drm"
 SRC_URI:append:qcom = " \
     file://additional-devices.conf \
     file://weston-start.sh \
+    file://weston-qdemo-launcher.ini \
 "
 
 do_compile:append:qcom() {
@@ -20,6 +21,10 @@ do_install:append:qcom() {
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/sources/weston-start.sh \
         ${D}${bindir}/weston-start.sh
+   
+    install -d ${D}${sysconfdir}/xdg/weston
+    echo "" >> ${D}${sysconfdir}/xdg/weston/weston.ini
+    cat ${WORKDIR}/sources/weston-qdemo-launcher.ini >> ${D}${sysconfdir}/xdg/weston/weston.ini
 }
 
 FILES:${PN} += "${systemd_system_unitdir}/weston.service.d/additional-devices.conf"

--- a/recipes-graphics/wayland/weston-init/weston-qdemo-launcher.ini
+++ b/recipes-graphics/wayland/weston-init/weston-qdemo-launcher.ini
@@ -1,0 +1,8 @@
+[launcher]
+icon=/usr/share/weston/terminal.png
+path=/usr/bin/weston-terminal
+
+[launcher]
+icon=/usr/share/qdemo/Qdemo.png
+path=/usr/bin/Qdemo
+


### PR DESCRIPTION
weston-init: Move Qdemo launcher entries to external weston.ini and append during install

Move Qdemo launcher definitions into a separate weston.ini - qdemo-launcher-weston.ini file and append it during do_install for cleaner separation and easier maintenance. This will enable the Qdemo.png image to be displayed on the wayland display. Upon clicking this icon, gst-gui-launcher-app.py application will run.