### PR TITLE
Monthly cleanup

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -8,6 +8,7 @@ jobs:
   sstate-cache-cleanup:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, gen-qlnx-prd-u2404-x64-sm-od-ephe]
+    timeout-minutes: 720
     steps:
       - name: Clean up the persistant sstate-cache dir
         run: |


### PR DESCRIPTION
The last monthly cleanup job timed out, and failed to delete all files from the cache. a few changes to improve how we manage the sstate cache.