### PR TITLE
gst-plugins-imsdk: enable plugin-tools

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
@@ -29,7 +29,7 @@ DEPENDS += "\
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
 
-PACKAGECONFIG ??= "sw videoproc"
+PACKAGECONFIG ??= "sw tools videoproc"
 
 PACKAGECONFIG[messaging]    = "-DENABLE_GST_MESSAGING_PLUGINS=1, -DENABLE_GST_MESSAGING_PLUGINS=0, librdkafka mosquitto"
 PACKAGECONFIG[ml]           = "-DENABLE_GST_ML_PLUGINS=1, -DENABLE_GST_ML_PLUGINS=0, cairo json-glib opencv qairt-sdk, qairt-sdk"
@@ -38,6 +38,7 @@ PACKAGECONFIG[redissink]    = "-DENABLE_GST_PLUGIN_REDISSINK=1, -DENABLE_GST_PLU
 PACKAGECONFIG[sample-apps]  = "-DENABLE_GST_SAMPLE_APPS=1, -DENABLE_GST_SAMPLE_APPS=0, opencv cairo json-glib camera-service"
 PACKAGECONFIG[sw]           = "-DENABLE_GST_SOFTWARE_PLUGINS=1, -DENABLE_GST_SOFTWARE_PLUGINS=0, gstreamer1.0-rtsp-server smart-venc-ctrl-algo"
 PACKAGECONFIG[tflite]       = "-DENABLE_GST_PLUGIN_MLTFLITE=1, -DENABLE_GST_PLUGIN_MLTFLITE=0, tensorflow-lite"
+PACKAGECONFIG[tools]        = "-DENABLE_GST_PLUGIN_TOOLS=1, -DENABLE_GST_PLUGIN_TOOLS=0, gstreamer1.0-rtsp-server"
 PACKAGECONFIG[videoproc]    = "-DENABLE_GST_VIDEOPROC_PLUGINS=1, -DENABLE_GST_VIDEOPROC_PLUGINS=0, cairo"
 
 # The TFLite plugin loads the TensorFlow Lite library at runtime using dlopen(). To ensure runtime availability, added runtime dependency on 'tensorflow-lite'.


### PR DESCRIPTION
This brings in applications needed to test multimedia pipeline functionality, including scenarios such as camera rotation, cropping, image capture, dynamic frame‑rate  changes, and validating RTP network‑streaming capabilities on the target device.