### PR TITLE
workflows: update lava-test-plans to ed073ae

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -29,7 +29,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: d5b19bcc4d038a40849fe3de0847d4277d5c1305
+          ref: ed073ae1233bd6548134185d9673fb30bdde56ad
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Update lava-test-plans reference to include pre-merge-audio test support.

Changes in ed073ae:
- Add pre-merge-audio test with 10 configs 
- 5 AudioPlayback tests (Config01, 03, 05, 07, 09)
- 5 AudioRecord tests (Config01, 03, 05, 07, 09)
- AudioClips deployed once via overlay instead of per-test
- Includes "expected" keyword for all audio tests

Related: qualcomm-linux/lava-test-plans#20