### PR TITLE
qc-image-unpacker: add a fix for strrchr() conformance to C23

### DIFF
--- a/recipes-devtools/qc-image-unpacker/qc-image-unpacker/0001-utils-fix-strrchr-conformance-to-C23.patch
+++ b/recipes-devtools/qc-image-unpacker/qc-image-unpacker/0001-utils-fix-strrchr-conformance-to-C23.patch
@@ -1,0 +1,32 @@
+From 00eebb468fdf573c9c6a1bf88765e6dcb4165afb Mon Sep 17 00:00:00 2001
+From: Viswanath Kraleti <viswanath.kraleti@oss.qualcomm.com>
+Date: Fri, 13 Mar 2026 22:59:07 +0530
+Subject: [PATCH] utils: fix strrchr() conformance to C23
+
+ISO C23 specifies search functions such as strrchr() as generic,
+returning a const pointer when the input argument is const.
+Assigning this return value to a non-const pointer results in build
+errors with glibc 2.43 and above versions.
+
+Update utils_fileBasename() to use a const pointer for the strrchr()
+return value, restoring C23 conformance and fixing build issues.
+
+Signed-off-by: Viswanath Kraleti <viswanath.kraleti@oss.qualcomm.com>
+Upstream-Status: Pending
+---
+ src/utils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/utils.c b/src/utils.c
+index 414679b..e22ec94 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -216,7 +216,7 @@ void *utils_crealloc(void *ptr, size_t old_sz, size_t new_sz) {
+ }
+ 
+ char *utils_fileBasename(char const *path) {
+-  char *s = strrchr(path, '/');
++  const char *s = strrchr(path, '/');
+   if (!s) {
+     return strdup(path);
+   } else {

--- a/recipes-devtools/qc-image-unpacker/qc-image-unpacker_git.bb
+++ b/recipes-devtools/qc-image-unpacker/qc-image-unpacker_git.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://../LICENSE;md5=138532bb21858341808df2740a1d13bf"
 SRC_URI = " \
     git://github.com/anestisb/qc_image_unpacker;protocol=https;branch=master\
     file://0004-Fail-if-an-image-can-not-be-opened.patch;patchdir=.. \
+    file://0001-utils-fix-strrchr-conformance-to-C23.patch;patchdir=.. \
 "
 
 SRCREV = "28a783a9fc25dc87b7416b6d5b6f9ccd497d1c2e"


### PR DESCRIPTION
Building qc-image-unpacker using glibc 2.43 fails due to ISO C23 changes to strrchr(). Add a .patch to update code to use correct pointer types.