### PR TITLE
qcom-armv8a: ensure iq-615-evk firmware is included by default

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -84,6 +84,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-dragonboard410c-firmware \
     packagegroup-dragonboard820c-firmware \
     packagegroup-dragonboard845c-firmware \
+    packagegroup-iq-615-evk-firmware \
     packagegroup-iq-8275-evk-firmware \
     packagegroup-iq-9075-evk-firmware \
     packagegroup-rb1-firmware \


### PR DESCRIPTION
Add the iq-615 firmware packagegroup to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS so required firmware
is included by default in qcom-armv8a builds.