### PR TITLE
ci: update to actions/checkout@v6

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -34,7 +34,7 @@ jobs:
           wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
           chmod +x ${KAS_CONTAINER}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run kas lock
         run: |
@@ -57,7 +57,7 @@ jobs:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
@@ -116,7 +116,7 @@ jobs:
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run kas build
         uses: ./.github/actions/compile
@@ -246,7 +246,7 @@ jobs:
                 yamlfile: ""
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run kas build
         uses: ./.github/actions/compile

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           - machine: qcom-armv7a
             kernel: _linux-qcom-6.18
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
     outputs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -165,7 +165,7 @@ jobs:
         run: |
           echo "${RESULT}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -186,7 +186,7 @@ jobs:
     outputs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -240,7 +240,7 @@ jobs:
       summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The following warning has been around for quite some time:

 Node.js 20 actions are deprecated. The following actions are running
 on Node.js 20 and may not work as expected:
 actions/checkout@v4. Actions will be forced to run with Node.js 24 by
 default starting June 2nd, 2026. Please check if updated versions of
 these actions are available that support Node.js 24

Github actions/checkout@v6 has been released for quite some time, it's time to upgrade here.