### PR TITLE
workflows: don't fail-fast the build step

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -136,7 +136,7 @@ jobs:
     outputs:
       url: ${{ steps.compile_kas.outputs.url }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         machine:
           - glymur-crd


### PR DESCRIPTION
It's not infrequent when one of the jobs hits the infrastructure timeout, fails and then GH cancels other build jobs, even if they didn't hit such an infrastructure issue (and could continue to be executed, finishing the build). Change fail-fast for the non-warm-up build step to false to let other jobs to finish (or to fail miserably).