### PR TITLE
RFC: base-files: make /var/tmp a persistent directory on Qualcomm machines

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,13 @@
+# Make /var/tmp a persistent real directory, compliant with FHS 3.0:
+# https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s15.html
+#
+# By default, OE-Core's base-files installs /var/tmp as a symlink to
+# /var/volatile/tmp, which is backed by a RAM-based tmpfs and does not
+# persist across reboots.  This violates FHS and breaks applications
+# (e.g. qtee_supplicant) that store reboot-persistent state under /var/tmp.
+#
+# Removing fs-perms-volatile-tmp.txt causes base-files to create /var/tmp
+# as a real directory with mode 1777 instead.  Systemd's 00-create-volatile.conf
+# still has "L /var/tmp -> /var/volatile/tmp", but the "L" type (without "+")
+# does not replace an existing non-symlink path, so no further override is needed.
+FILESYSTEM_PERMS_TABLES:remove:qcom = "files/fs-perms-volatile-tmp.txt"


### PR DESCRIPTION
This PR addresses the issue https://github.com/qualcomm-linux/meta-qcom/issues/1756

By default, OE-Core's FILESYSTEM_PERMS_TABLES includes files/fs-perms-volatile-tmp.txt, which causes the base-files recipe to install /var/tmp as a relative symlink pointing to volatile/tmp (i.e. /var/volatile/tmp).  The /var/volatile filesystem is typically a RAM-backed tmpfs, meaning its contents are ephemeral and do not survive reboots.  Furthermore, if the tmpfs is not yet mounted when early userspace code runs, the symlink target (/var/volatile/tmp) does not exist at all, causing operations like

  mkdir -p /var/tmp/qtee_supplicant

to fail with ENOENT even though /var/tmp itself appears to be present.

This also violates the Filesystem Hierarchy Standard (FHS 3.0, §5.15), which explicitly requires /var/tmp to preserve files across reboots:
  https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s15.html

Fix this for all Qualcomm machines by removing fs-perms-volatile-tmp.txt from FILESYSTEM_PERMS_TABLES.  The base-files do_install logic is conditional on this table:

  dirs1777 = "/tmp ${localstatedir}/${@bb.utils.contains(
      'FILESYSTEM_PERMS_TABLES', 'files/fs-perms-volatile-tmp.txt',
      'volatile/', '', d)}tmp"

  volatiles = "${@bb.utils.contains(
      'FILESYSTEM_PERMS_TABLES', 'files/fs-perms-volatile-tmp.txt',
      'tmp', '', d)}"

  for d in ${volatiles}; do
      ln -sf volatile/$d ${D}${localstatedir}/$d
  done

With the table removed: dirs1777 gains /var/tmp (created as a real directory, mode 1777), volatiles becomes empty for tmp, and the symlink is never installed.

Systemd's 00-create-volatile.conf still contains:

  L  /var/tmp  -  -  -  -  /var/volatile/tmp

The L type in systemd-tmpfiles (without the + modifier) creates a symlink only if the path does not already exist; it leaves existing non-symlink paths untouched.  Because /var/tmp is now a real directory in the rootfs, this entry becomes a no-op at runtime and no further override of 00-create-volatile.conf is required.