### PR TITLE
iq-x7181-evk: remove setting QCOM_DTB_DEFAULT

### DIFF
--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-hamoa.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "hamoa-iot-evk"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \
                       "


### PR DESCRIPTION
Remove explicit setting of `QCOM_DTB_DEFAULT` to enable multi-DTB support on IQ-X7181 IoT EVK.

Log snippet of booting with multi-DTB: 
```
ProcessQcomMetaDtbOemNode: Board Param: OEM Id = 0
ProcessQcomMetaDtbSocNode:Board Param:
 ChipVersion: 0x20001
ChipId: 0x2C5
 ProcessQcomMetaDtbSocNode: Node hamoav2.1
FromDtbChipIdentifier = 2C5
FromDtbChipRevision = 20001
 ProcessQcomMetaDtbBoardNode: Board Param: BoardId = 0x2F
 ProcessQcomMetaDtbBoardNode: Node evk BoardId = 0x2F
PackageId: 0x0
ProcessQcomMetaDtbSocSkuNode: Board Param:
FoundryId: 0x1
PackageId: 0x0
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Board Param:
BoardSubTypeId = 0x0
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Node subtype0 From fdt BoardSubTypeId = 0
Failed to get boot device type, Not Found
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Board Param:
BootDeviceType = 0x1
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Node emmc From fdt StorageTypeId = 1
 ProcessQcomMetaDtbBoardMemorySizeNode:Board Param:
Ddr Size = 0
 ProcessQcomMetaDtbBoardMemorySizeNode: Node 4GB+ From fdt DdrSizeId = 0
 ProcessQcomMetaDtbSoftSkuNode: Board Param: Board SoftSkuId = 0
 ProcessQcomMetaDtbSoftSkuNode: Node softsku0 SoftSkuId = 0
 ParseFitDt: Configuration From BoardParam
qcom, hamoav2.1, evk, subtype0, emmc, 4GB+, softsku0,
 FindConfigToBoot: SubNode 500 And Node Name conf-1 Len = 6
FindConfigToBoot: Invalid Configuration ConfigFdt "qcom,hamoa-evk"
 FindConfigToBoot: CompatibleMatchFlag = 0 CurrSubStringCnt = 1
 FindConfigToBoot: SubNode 604 And Node Name conf-2 Len = 6
 FindConfigToBoot: CompatibleMatchFlag = 1 CurrSubStringCnt = 2
FindConfigToBoot:Booting with = qcom,hamoav2.1-evk
 FindConfigToBoot: i = 0 fdt fdt-hamoa-iot-evk.dtb str len = 21
ParseFitDt::
Config fdt-hamoa-iot-evk.dtb & Type 0
FitLoadDtbFromFdt: Config fdt-hamoa-iot-evk.dtb & Type 0
Reading of OsConfigTableSelection failed,checking DT settings
 Bad main_symbols in ufdt_overlay_do_fixups
Failed to apply devie tree
HypDtFixupEventNotifyFunc: Dtb apply overlay skipped
```