### PR TITLE
iq-x7181-evk: Set RT CPU/IRQ/RCU variables for RT kernel

### DIFF
--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -24,3 +24,10 @@ QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
+
+# Isolate rt cpu
+QCOM_RT_CPU        = "11"
+QCOM_IRQAFF        = "0-10"
+QCOM_RCU_NOCBS     = "11"
+QCOM_RCU_EXPEDITED = "1"
+QCOM_CPUIDLE_OFF   = "1"


### PR DESCRIPTION
Isolate single dedicated cpu for RT tasks. 
Set QCOM_RT_CPU=11, QCOM_IRQAFF=0-10, QCOM_RCU_NOCBS=11, 
meanwhile enable expedited RCU and cpuidle.off for RT builds.