### PR TITLE
workflows: collapse build summary table by default

### DIFF
--- a/.github/actions/print-build-output/action.yml
+++ b/.github/actions/print-build-output/action.yml
@@ -63,7 +63,9 @@ runs:
         summary_file_name = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary_file_name:
             with open(summary_file_name, "a") as summaryfile:
-                summaryfile.write("## Download URLs\n")
+                summaryfile.write("<summary>Download URLs</summary>\n")
+                summaryfile.write("<details>\n\n")
                 summaryfile.write(table_str)
+                summaryfile.write("</details>")
         print(table_str)
 


### PR DESCRIPTION
With a lot of builds and a lot of machines the build table is usually big. This patch collapses the table by default so more step summaries fit on the screen.