### PR TITLE
layer.conf: update to be compatible with wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PRIORITY_qcom = "6"
 
 LAYERDEPENDS_qcom = "core"
 LAYERRECOMMENDS_qcom = "openembedded-layer meta-arm"
-LAYERSERIES_COMPAT_qcom = "whinlatter"
+LAYERSERIES_COMPAT_qcom = "wrynose"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
OE-core has switched to using wrynose release name. Adjust LAYERSERIES_COMPAT accordingly.