### PR TITLE
iris-video-dlkm: update iris driver to v1.0.2

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.2.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.2.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "224c671c84c082e96e3afa9a4844b31ad2703761"
+SRCREV  = "9635b0dae12758fb3b8ffd7e388890923dd4177b"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.2 brings below update for Qcom Iris

This release fixes an mmap issue when a client calls reqbuf -> mmap without export_buf. Separate helpers are introduced for direct mmap and export -> mmap paths to correctly handle both use cases.