### PR TITLE
workflows/build-yocto: switch the yocto-check-layer/patchreview order

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -77,13 +77,13 @@ jobs:
           echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           chmod +x $KAS_CONTAINER
 
-      - name: Run yocto-check-layer
-        run: |
-          ci/kas-container-shell-helper.sh ci/yocto-check-layer.sh
-
       - name: Run Yocto patchreview
         run: |
           ci/kas-container-shell-helper.sh ci/yocto-patchreview.sh
+
+      - name: Run yocto-check-layer
+        run: |
+          ci/kas-container-shell-helper.sh ci/yocto-check-layer.sh
 
   compile_warm_up:
     needs: kas-setup


### PR DESCRIPTION
The yocto-check-layer takes a lot of time to run and in the other side the patchreview is pretty fast. So let's switch them and run the fastest one first.