### PR TITLE
firmware-qcom-boot-iq-x7181: Update artifactory URL and boot firmware tag for IQ-X7181 to 00008.0

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
@@ -4,8 +4,8 @@ LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27
 
 include firmware-qcom-boot-common.inc
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/ubuntu_qualcomm_iot-spf-1-0/ubuntu-qualcomm-iot-spf-1-0_test_device_public"
-FW_BUILD_ID = "r1.0.r1_${PV}/hamoa_iot-ubun-1-0-r1"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Ubuntu_Qualcomm_IoT.SPF.1.0/ubuntu_qualcomm_iot.spf.1.0-test-device-public"
+FW_BUILD_ID = "r1.0.r1_${PV}/HAMOA_IOT.UBUN.1.0.R1"
 FW_BIN_PATH = "common/build/bin"
 BOOTBINARIES = "HAMOA_bootbinaries"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00006.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00006.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "00213d5f0c6325aaa25dbb67834285ccdeee9e15c4f76e12c66cf37cf26aaafa"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00008.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00008.0.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "6da4295c827eb14f5a2734b0f38033639e5f3f141668eba69a0923fc3adaf39e"


### PR DESCRIPTION
Update boot firmware artifactory URL and update firmware tag to 00008.0.

Known update:
- Add support for the IQ-X5121(Purwa) IoT EVK.