### PR TITLE
ci: print-build-action: skip table generation if no artifact

### DIFF
--- a/.github/actions/print-build-output/action.yml
+++ b/.github/actions/print-build-output/action.yml
@@ -3,7 +3,7 @@ inputs:
   pattern:
     description: File pattern to download
     required: true
-  gh_token:
+  github-token:
     description: "Github token. It's required to download artifacts from the workflow"
     required: true
 
@@ -13,7 +13,7 @@ runs:
     - name: 'Download build URLs'
       uses: actions/download-artifact@v7
       with:
-        github-token: ${{ inputs.gh_token }}
+        github-token: ${{ inputs.github-token }}
         pattern: ${{ inputs.pattern }}
         path: urlfiles
         merge-multiple: true


### PR DESCRIPTION
Since e9542ed9c8be, the job publish_summary is always executed, even if some builds have failed. However it might be the case that all builds have failed, and that there is no artifacts at all. Such as in https://github.com/qualcomm-linux/meta-qcom/actions/runs/23239927263/job/67553697251. In such a case the print-output step will fail to build the summary table. Instead of making the python snippet more complicated, let's check if artifacts are available, or skip the step completely.