### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260317

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag: qcom-6.18.y-20260309
-SRCREV ?= "06f8ab99cf04dd7ce71861f57f7b516004a9b5e2"
+# tag:qcom-6.18.y-20260317
+SRCREV ?= "c60e1a1fe181cede961d8f4ceaf5792f47cb8950"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260317

Changelog:
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: support Bluetooth over both USB and UART
UPSTREAM: mhi: host: Add support for loading dual ELF image format
UPSTREAM: wifi: ath12k: Fix wrong P2P device link id issue
UPSTREAM: wifi: ath12k: enable QCC2072 support
UPSTREAM: wifi: ath12k: fix PCIE_LOCAL_REG_QRTR_NODE_ID definition for QCC2072
UPSTREAM: wifi: ath12k: send peer meta data version to firmware
UPSTREAM: wifi: ath12k: limit number of channels per WMI command
UPSTREAM: wifi: ath12k: handle REO status ring for QCC2072
UPSTREAM: wifi: ath12k: handle REO CMD ring for QCC2072
UPSTREAM: wifi: ath12k: add hardware ops support for QCC2072
UPSTREAM: wifi: ath12k: add HAL descriptor and ops for QCC2072
UPSTREAM: wifi: ath12k: support downloading auxiliary ucode image for QCC2072
UPSTREAM: wifi: ath12k: support LPASS_SHARED target memory type
UPSTREAM: wifi: ath12k: add hardware parameters for QCC2072
UPSTREAM: wifi: ath12k: add hardware registers for QCC2072
UPSTREAM: wifi: ath12k: fix mac phy capability parsing
UPSTREAM: wifi: ath12k: refactor 320 MHz bandwidth support parsing
UPSTREAM: wifi: ath12k: fix preferred hardware mode calculation
UPSTREAM: wifi: ath12k: refactor REO status ring handling
UPSTREAM: wifi: ath12k: refactor REO CMD ring handling
UPSTREAM: wifi: ath12k: refactor PCI window register access
UPSTREAM: wifi: ath12k: do WoW offloads only on primary link
UPSTREAM: wifi: ath12k: clean up on error in ath12k_dp_setup()
UPSTREAM: wifi: ath12k: remove redundant pci_set_drvdata() call
UPSTREAM: Merge branch 'ath12k-ng' into ath-next
UPSTREAM: wifi: ath12k: Skip DP peer creation for scan vdev
UPSTREAM: wifi: ath12k: move firmware stats request outside of atomic context
UPSTREAM: wifi: ath12k: add the missing RCU lock in ath12k_dp_tx_free_txbuf()
UPSTREAM: wifi: ath12k: Remove Wi-Fi 7 header dependencies from common ath12k module
UPSTREAM: wifi: ath12k: Move MSDU END TLV processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move MU user processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move remaining SIG TLV parsing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move EHT SIG processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move HE SIG processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move HT/VHT SIG processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move TX monitor functionality to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move RX status TLV parsing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move MPDU pop functionality to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move monitor status processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Move monitor ring processing to Wi-Fi 7 module
UPSTREAM: wifi: ath12k: Replace lock/unlock with guard()
UPSTREAM: wifi: ath12k: Use dp objects in performance critical paths
UPSTREAM: wifi: ath12k: Build all the files in wifi7 directory into ath12k_wifi7.ko
UPSTREAM: wifi: ath12k: Remove arch-specific HAL dependencies from common DP
UPSTREAM: wifi: ath12k: Move ath12k_dp_rx_get_peer_id API to Wi-Fi 7
UPSTREAM: wifi: ath12k: Move ath12k_dp_rx_frags_cleanup API to Wi-Fi 7
UPSTREAM: wifi: ath12k: Remove the wifi7 header inclusions in common code
UPSTREAM: wifi: ath12k: Move ieee80211_ops callback to the arch specific module
UPSTREAM: wifi: ath12k: Add helper to free DP link peer
UPSTREAM: wifi: ath12k: Move DP specific link stats to DP link peer
UPSTREAM: wifi: ath12k: Move DP device stats to ath12k_dp
UPSTREAM: wifi: ath12k: Add callbacks in arch_ops for rx APIs
UPSTREAM: wifi: ath12k: Add lockdep warn for RCU
UPSTREAM: wifi: ath12k: Use ath12k_dp_peer in per packet Tx & Rx paths
UPSTREAM: wifi: ath12k: Attach and detach ath12k_dp_link_peer to ath12k_dp_peer
UPSTREAM: wifi: ath12k: Define ath12k_dp_peer structure & APIs for create & delete
UPSTREAM: wifi: ath12k: Add hash table for ath12k_dp_link_peer
UPSTREAM: wifi: ath12k: Move ath12k_dp_link_peer list from ath12k_base to ath12k_dp
UPSTREAM: wifi: ath12k: Add hash table for ath12k_link_sta in ath12k_base
UPSTREAM: wifi: ath12k: Rename ath12k_peer to ath12k_dp_link_peer
UPSTREAM: wifi: ath12k: Move DP related functions from peer.c to dp_peer.c file
UPSTREAM: wifi: ath12k: Drop hal_ prefix from hardware register names
UPSTREAM: wifi: ath12k: Rename hal_ops to ops
UPSTREAM: wifi: ath12k: Remove the unused ring inits in wcn
UPSTREAM: wifi: ath12k: Segregate the common and wifi7 specific structures
UPSTREAM: wifi: ath12k: Move HAL Cookie Conversion and RBM related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL REO and Rx buf related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL Tx, REO and link idle setup related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL CE status and set link desc addr APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL CE desc related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL SRNG shadow config and get ring id APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL CE setup and SRNG related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Use hal handle instead of ab handle
UPSTREAM: wifi: ath12k: Add direct HAL pointer in ath12k_dp
UPSTREAM: wifi: ath12k: Move hal_params and regs to hal from hw
UPSTREAM: wifi: ath12k: Move wbm_rbm_map to hw specific hal files
UPSTREAM: wifi: ath12k: Initialize hal_ops through hal_init
UPSTREAM: wifi: ath12k: Initialize desc_size through hal_init
UPSTREAM: wifi: ath12k: Move srng config and hal_ops to hw specific hal files
UPSTREAM: wifi: ath12k: Rearrange PPDU radio stats
UPSTREAM: wifi: ath12k: Refactor data path pdev struct
UPSTREAM: wifi: ath12k: Refactor ath12k_vif structure
UPSTREAM: wifi: ath12k: Add framework for hardware specific DP interrupt handler
UPSTREAM: wifi: ath12k: Add framework for hardware specific ieee80211_ops registration
UPSTREAM: wifi: ath12k: Rearrange DP fields in ath12k_hw_group struct
UPSTREAM: wifi: ath12k: Support arch-specific DP device allocation
UPSTREAM: wifi: ath12k: Convert ath12k_dp member in ath12k_base to pointer
UPSTREAM: wifi: ath12k: Change the API prefixes to ath12k_wifi7 in tx/rx
UPSTREAM: wifi: ath12k: Remove hal_rx_ops and merge into hal_ops
UPSTREAM: wifi: ath12k: Add new infra for the rx path
UPSTREAM: wifi: ath12k: Move hal_rx_ops callbacks to hal_ops
UPSTREAM: wifi: ath12k: Replace ops with direct calls for rxdma ring mask
UPSTREAM: wifi: ath12k: unify HAL ops naming across chips
UPSTREAM: wifi: ath12k: Move the hal APIs to hardware specific files
UPSTREAM: wifi: ath12k: Remove non-compact TLV support from QCN
UPSTREAM: wifi: ath12k: Move HTT specific code from dp.c to newly introduced files
UPSTREAM: wifi: ath12k: Move HTT Tx specific code to newly introduced files
UPSTREAM: wifi: ath12k: Move HTT Rx specific code to newly introduced files
UPSTREAM: wifi: ath12k: Move HTT code in dp.h to newly introduced files
UPSTREAM: wifi: ath12k: Move ath12k_dp_tx and related APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move arch specific tx APIs to wifi7 directory
UPSTREAM: wifi: ath12k: Move arch specific rx tid and related functions to wifi7 directory
UPSTREAM: wifi: ath12k: Move arch specific REO functions to wifi7 directory
UPSTREAM: wifi: ath12k: Separate arch specific part of RX APIs
UPSTREAM: wifi: ath12k: Move srng processing to wifi7 directory
UPSTREAM: wifi: ath12k: Move regular msdu processing functions to wifi7 directory
UPSTREAM: wifi: ath12k: Move rx error and defrag functions to wifi7 directory
UPSTREAM: wifi: ath12k: Move rxdma ring config functions to wifi7 directory
UPSTREAM: wifi: ath12k: Move rx_desc.h file to wifi7 directory
UPSTREAM: wifi: ath12k: Move hal_desc.h file to wifi7 directory
UPSTREAM: wifi: ath12k: Move Rx error related functions to wifi7 directory
UPSTREAM: wifi: ath12k: Move HAL Rx wrapper APIs to dp_rx.h
UPSTREAM: wifi: ath12k: Move hal_rx.h file to wifi7 directory
UPSTREAM: wifi: ath12k: Move hal_tx.h file to wifi7 directory
UPSTREAM: wifi: ath12k: Move hal_tx and hal_rx to wifi7 directory
UPSTREAM: wifi: ath12k: Remove HAL define dependencies from shared AHB code
UPSTREAM: wifi: ath12k: Remove HAL defines from shared PCI code
UPSTREAM: wifi: ath12k: Rename ath12k_* symbols to ath12k_wifi7_* for clarity
UPSTREAM: wifi: ath12k: Modularize driver into common and Wi-Fi 7 specific components
UPSTREAM: wifi: ath12k: Move hw_init invocation to target-specific probe
UPSTREAM: wifi: ath12k: Move Wi-Fi 7 specific init routines to dedicated file
UPSTREAM: wifi: ath12k: Restructure ahb.c into common and Wi-Fi 7 specific modules
UPSTREAM: wifi: ath12k: Rename ahb_hif_ops to reflect generic usage
UPSTREAM: wifi: ath12k: Rename hw.c to Wi-Fi 7 specific implementation file
UPSTREAM: wifi: ath12k: Move Wi-Fi 7 MHI configuration to dedicated file
UPSTREAM: wifi: ath12k: Move Wi-Fi 7 WMI configuration to dedicated file
UPSTREAM: wifi: ath12k: Move Copy Engine configuration to Wi-Fi 7 specific file
UPSTREAM: wifi: ath12k: Restructure PCI code to common and Wi-Fi 7 specific logic
UPSTREAM: wifi: ath12k: Set EHT fixed rates for associated STAs
UPSTREAM: wifi: ath12k: add EHT rates to ath12k_mac_op_set_bitrate_mask()
UPSTREAM: wifi: ath12k: Add EHT fixed GI/LTF
UPSTREAM: wifi: ath12k: Add EHT MCS/NSS rates to Peer Assoc
UPSTREAM: wifi: ath12k: add EHT rate handling to existing set rate functions
UPSTREAM: wifi: ath12k: generalize GI and LTF fixed rate functions
UPSTREAM: wifi: ath12k: Assert base_lock is held before allocating REO update element
UPSTREAM: wifi: ath12k: add support for BSS color change
UPSTREAM: wifi: ath12k: Add MODULE_FIRMWARE() entries
UPSTREAM: wifi: ath12k: Fix NSS value update in ext_rx_stats
UPSTREAM: wifi: ath12k: Defer vdev bring-up until CSA finalize to avoid stale beacon
UPSTREAM: wifi: ath12k: track dropped MSDU buffer type packets in REO exception ring
UPSTREAM: wifi: ath12k: Remove struct wmi_bcn_send_from_host_cmd
Revert "FROMLIST: mhi: host: Add standard elf image download functionality"
FROMLIST: arm64: dts: qcom: x1e80100: Extend the gcc input clock list
FROMLIST: clk: qcom: gcc-x1e80100: Add missing USB4 clocks/resets
FROMLIST: dt-bindings: clock: qcom,x1e80100-gcc: Add missing USB4 clocks/resets
QCLINUX: qcom.config: Enable FTRACE option for performance profiling
FROMLIST: arm64: dts: qcom: hamoa: Add PSCI SYSTEM_RESET2 types

PR Test Report : 

| Test Case | [qcs615](https://lava.infra.foundries.io/results/162705) | [qcs615_prop](https://lava.infra.foundries.io/results/162739) | [qcs8300](https://lava.infra.foundries.io/results/162706) | [qcs8300_prop](https://lava.infra.foundries.io/results/162740) | [rb3gen2](https://lava.infra.foundries.io/results/162736) | [rb3gen2_prop](https://lava.infra.foundries.io/results/162812) | [rb8](https://lava.infra.foundries.io/results/162702) | [rb8_prop](https://lava.infra.foundries.io/results/162738) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| adsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| AudioRecord | ✅ Pass | ❌ Fail | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| BT_ON_OFF | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| cdsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| CPUFreq_Validation | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| DSP_AudioPD | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Ethernet | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ⚠️ Skip |
| hotplug | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Interrupts | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| irq | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| OpenCV | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_Firmware_Driver | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_OnOff | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass |

AudioRecord failure corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1664

Kernel Test Team Report:

Base Build :
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass |
Audio Record | Pass | Pass | Pass | NA |  
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encoder H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Fail | Fail | Fail | Fail |  https://github.com/qualcomm-linux/meta-qcom/issues/1746
Graphics | Fail | Fail | Fail | Fail |  https://github.com/qualcomm-linux/meta-qcom/issues/1746
DSP | Pass | Pass | Pass | Pass |  
Open CV | Pass | Pass | Pass | Pass |  

Overlay build : 
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass | 
Audio Record | Pass | Pass | Pass | NA |  During audio Tests , restarting  PipeWire sometimes takes more time
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encode H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Pass | Pass | Pass | Pass |  
Graphics | Pass | Pass | Pass | Pass |  
DSP | Pass | Pass | Pass | Pass |  
FastCV | Pass | Pass | Pass | Fail | https://github.com/qualcomm-linux/meta-qcom/issues/1767  