### PR TITLE
android-tools-conf-configfs: add SoC serial to USB product string

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
@@ -1,5 +1,7 @@
 manufacturer=Qualcomm
 model=`hostname`
+[ -e /sys/devices/soc0/soc_id ] && model="${model}($(< /sys/devices/soc0/soc_id))"
+[ -e /sys/devices/soc0/serial_number ] && model="${model}_SN:$(printf '%x' "$(tr -d ' \n' < /sys/devices/soc0/serial_number)")"
 androidserial="$(sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline)"
 [ -z "$androidserial" ] && [ -e /sys/class/dmi/id/product_serial ] && androidserial=$(cat /sys/class/dmi/id/product_serial)
 [ -z "$androidserial" ] && [ -e /dev/sda ] && scsiserialline=$(udevadm info /dev/sda | grep ID_SCSI_SERIAL) && scsiserialvalue=$(echo "$scsiserialline" | awk -F= '{print $2}') && androidserial=$(echo -n "$scsiserialvalue" | crc32)

--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
@@ -1,5 +1,7 @@
 manufacturer=Qualcomm
 model=`hostname`
+# Append SoC serial number to USB Product string to uniquely identify the device in Axiom
+[ -e /sys/devices/soc0/serial_number ] && model="${model}_SN:$(printf '%x' "$(tr -d ' \n' < /sys/devices/soc0/serial_number)")"
 androidserial="$(sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline)"
 [ -z "$androidserial" ] && [ -e /sys/class/dmi/id/product_serial ] && androidserial=$(cat /sys/class/dmi/id/product_serial)
 [ -z "$androidserial" ] && [ -e /dev/sda ] && scsiserialline=$(udevadm info /dev/sda | grep ID_SCSI_SERIAL) && scsiserialvalue=$(echo "$scsiserialline" | awk -F= '{print $2}') && androidserial=$(echo -n "$scsiserialvalue" | crc32)


### PR DESCRIPTION
Axiom requires a stable and unique device identifier that is consistent across EDL, fastboot, and ADB modes. The ADB serial number cannot be used for this purpose, as it is not available in EDL or fastboot modes. However, the SoC serial number is accessible in all boot modes.

Including the SoC serial number in the USB gadget product string (strings/0x409/product), allows Axiom to reliably read and use it as a stable identifier for uniquely tracking devices.