### PR TITLE
adreno: Update to 1.855.3

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.855.3.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.855.3.bb
@@ -6,15 +6,15 @@ DESCRIPTION = "Collection of prebuilt User Mode libraries to support OpenGL ES, 
 
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=4ceffe94cb40cdce6d2f4fb93cc063d1 \
-                    file://NOTICE;md5=18837ae43f290ad72cdcccead4d7700a "
+                    file://NOTICE;md5=8a8bfc3e11e68334dc7e9d2daf1e93e3 "
 
 # no top-level dir in the archive, unpack to subdir to prevent UNPACKDIR pollution
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/gfx-adreno.le.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8a.tar.gz;subdir=${BP}"
-PBT_BUILD_DATE = "260304"
-SRC_URI[sha256sum] = "8e0b463519321613fa96f057c7cd7f67fd72b22dd0feb3129ffaab1400f17065"
+PBT_BUILD_DATE = "260318"
+SRC_URI[sha256sum] = "f211be698ebbcefa2e4afcdfc7a1529e6a9bc628d47bcab9234fe29aceb4008e"
 
 # These are listed here in order to identify RDEPENDS
-DEPENDS += " glib-2.0 libdmabufheap libdrm virtual/libgbm msm-gbm-backend \
+DEPENDS += " glib-2.0 libdrm virtual/libgbm msm-gbm-backend \
              ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', '', d)} \
              ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
              ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxcb libx11 xcb-util-image', '', d)}"


### PR DESCRIPTION
Update qcom-adreno version from 1.855.2 to 1.855.3

CHANGES for 1.855.3:
* Remove dependency on libdmabufheap and update NOTICE file.
* Add Vulkan 1.3 support for Kodiak, Lemans, Monaco and Talos.
* Enable Vulkan extensions - VK_KHR_dynamic_rendering, VK_KHR_maintenance4 and VK_KHR_format_feature_flags2.
* Improve Linux buffer sharing and memory handling to strengthen graphics interoperability.
* Enhance Wayland dma‑buf protocol integration (ZWP) with better buffer lifecycle management.
* Reduce presentation stalls and improved stability on X11/DRI3 based systems.
* Add configuration controls to improve robustness and fallback behavior on diverse platforms.
* Refactor Wayland buffer handling to improve reliability and maintainability.
* Fix GPU memory address programming issues to improve correctness and stability.
* Improve handling of display connection termination scenarios.
* Expand support for YUY2, UYVY, YVYU, formats in OpenGL ES rendering paths.
* Improve OpenCL driver error logging.
* Refactor function pointer typedefs in cl_ext_qcom.h.