### PR TITLE
workflows: update lava-test-plans to 2092477

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -30,7 +30,7 @@ runs:
           persist-credentials: false
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: d5b19bcc4d038a40849fe3de0847d4277d5c1305
+          ref: 2092477fcdc856332ee140eb517e326382a014d7
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
This update adds device template support for iq-x7181-evk. These additions enable automated testing workflows for these devices through the LAVA test infrastructure.

Fix for the issue: [Issues#1740](https://github.com/qualcomm-linux/meta-qcom/issues/1740)

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>