### PR TITLE
ci: add post-compile success job

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -286,3 +286,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: build-url*
 
+  build_successful:
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build completed successfully
+        run: echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"


### PR DESCRIPTION
The publish-summary checkrun was used by various automations to trigger
subsequent CI jobs on build success. This step was updated to always run
regardless of build compilation failures making it an unreliable trigger.
(https://github.com/qualcomm-linux/meta-qcom/commit/e9542ed9c8be673d3df3c118bdd4a1eebbc7622d)

This change adds a success-only job after all compile matrix builds pass.
The resulting check can be reused by downstream workflows.

Fixes: #1796 