### PR TITLE
camx-dlkm: Update camx driver to v1.0.0 

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.0.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.0.bb
@@ -3,10 +3,11 @@ HOMEPAGE = "https://github.com/qualcomm-linux/camera-driver"
 LICENSE = "GPL-2.0-with-Linux-syscall-note"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0"
+SRC_URI = " \
+    git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
+"
 
-PV = "0.0+git"
-SRCREV = "c62c54bb9c04efe5afb91576be55797aadf635f8"
+SRCREV = "3dac889d25682686d5d6990b0a62e4cd699c8cd9"
 
 inherit module
 


### PR DESCRIPTION
This tag brings the following updates:

- Fix incorrect request pointer in flush logic.
- Fix KMD buffer handle in IFE prepare.
- Fix memory leak and invalid handle access.
- Fix OOB write and array access issues.
- Fixes prevent issues during sched req.
- Fix OOB access while processing output buffer.
- Protect shared WM common data.
- Adapt to qcom_mdt_pas_load() API changes.
- Add cpas support for v695_100.
- Add ife csid support for v695.
- Add camera support for x1e80100.