### PR TITLE
packagegroup-iq-9075-evk: add QCC2072 BT firmware support

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
@@ -10,7 +10,7 @@ PACKAGES = " \
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x linux-firmware-qca-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x linux-firmware-qca-wcn7850 linux-firmware-qca-qcc2072', '', d)} \
     camxfirmware-lemans \
     linux-firmware-qcom-sa8775p-audio \
     linux-firmware-qcom-sa8775p-compute \


### PR DESCRIPTION
The IQ‑9075‑EVK platform has a product requirement to support QCC2072. Add the required firmware to ensure proper initialization.

QCC2072 connectivity module requires:
– linux‑firmware‑qca‑qcc2072 (BT UART firmware)