### PR TITLE
Remove efivar dependency by defaulting CamX DTBO in Config2

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -40,23 +40,19 @@ FIT_DTB_COMPATIBLE[qcs615-ride] = " \
     qcom,qcs615-adp \
     qcom,qcs615v1.1-adp \
 "
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
     qcom,qcs5430-iot \
     qcom,qcs6490-iot \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
-    qcom,qcs5430-iot-subtype9 \
-    qcom,qcs6490-iot-subtype9 \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
     qcom,qcs5430-iot-subtype2 \
     qcom,qcs6490-iot-subtype2 \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
     qcom,qcs5430-iot-camx \
     qcom,qcs5430-iot-subtype2-camx \
     qcom,qcs6490-iot-camx \
     qcom,qcs6490-iot-subtype2-camx \
+"
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
+    qcom,qcs5430-iot-subtype9 \
+    qcom,qcs6490-iot-subtype9 \
 "
 FIT_DTB_COMPATIBLE[qcs8300-ride] = "qcom,qcs8300-adp"
 FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx] = "qcom,qcs8300-adp-camx"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -103,6 +103,8 @@ FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx] = " \
 FIT_DTB_COMPATIBLE[sdm845-db845c] = "qcom,sdm845"
 FIT_DTB_COMPATIBLE[sm8450-hdk] = "qcom,sm8450-hdk"
 FIT_DTB_COMPATIBLE[sm8750-mtp] = "qcom,sm8750-mtp"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577] = "qcom,qcs615v1.1-iot"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx] = "qcom,qcs615v1.1-iot-camx"
+FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx] = " \
+    qcom,qcs615v1.1-iot \
+    qcom,qcs615v1.1-iot-camx \
+"
 FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01] = "qcom,talos-evk-lvds-auo,g133han01"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -11,11 +11,9 @@ FIT_DTB_COMPATIBLE[hamoa-iot-evk] = " \
     qcom,hamoav2.1-evk \
 "
 FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577] = " \
+FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx] = " \
     qcom,qcs9075-iot \
     qcom,qcs9075v2-iot \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx] = " \
     qcom,qcs9075-iot-camx \
     qcom,qcs9075v2-iot-camx \
 "

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -25,8 +25,10 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2] = " \
     qcom,qcs9075-iot-camx-el2kvm \
     qcom,qcs9075v2-iot-camx-el2kvm \
 "
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
+FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = " \
+    qcom,qcs8275-iot \
+    qcom,qcs8275-iot-camx \
+"
 FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"
 FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo] = "qcom,apq8064"
 FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410] = "qcom,apq8064-ifc6410"


### PR DESCRIPTION
We updated the default boot configuration to use CamX (downstream camera DTBO). This change is applicable to the multimedia‑prop‑image with Config2 and removes the need to pass the camx string via efivar. The change has been implemented and validated on KLMT.