### PR TITLE
linux-qcom-next: update to tag qcom-next-7.0-rc3-20260324

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.19+7.0-rc2"
+LINUX_VERSION ?= "6.19+7.0-rc3"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.0-rc2-20260317
-SRCREV ?= "e1d0aefa8b8339ad0fd939c3d5b1f67e93b1ca94"
+# tag: qcom-next-7.0-rc3-20260324
+SRCREV ?= "6b346ee225a1747218759fc4846aacf203e1eb35"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.0-rc3-20260324, which corresponds to kernel version v7.0-rc3

PR Test Results :
| Test Case | [qcs615](https://lava.infra.foundries.io/results/163969) | [qcs615_prop](https://lava.infra.foundries.io/results/163973) | [qcs8300](https://lava.infra.foundries.io/results/163970) | [qcs8300_prop](https://lava.infra.foundries.io/results/163974) | [qcs9100](https://lava.infra.foundries.io/results/164143) | [qcs9100_prop](https://lava.infra.foundries.io/results/164144) | [rb1](https://lava.infra.foundries.io/results/164224) | [rb3gen2](https://lava.infra.foundries.io/results/163967) | [rb3gen2_prop](https://lava.infra.foundries.io/results/163971) | [rb8](https://lava.infra.foundries.io/results/163968) | [rb8_prop](https://lava.infra.foundries.io/results/163972) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| adsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| AudioRecord | ✅ Pass | ❌ Fail | ✅ Pass | ❌ Fail | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| BT_ON_OFF | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ⚠️ Skip |
| cdsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| CPUFreq_Validation | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| DSP_AudioPD | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| fastrpc_test | ❌ Fail | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ❌ Fail | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass |
| hotplug | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Interrupts | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| irq | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| OpenCV | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_Firmware_Driver | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_OnOff | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ⚠️ Skip |

AudioRecord failure corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1664
Fastrpc failure on Talos corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1767
Fastrpc failure on RB3GEN2 Overlay corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1807
Fastrpc failure on RB1 corresponds to Github issue https://github.com/qualcomm-linux/kernel/issues/359

Kernel Test Team Report:

Base Build :

Test Case | RB3 | RB8 | RB4 | Lemans Ride | Monaco Ride | Talos | Comments
-- | -- | -- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass | Pass | Pass |  
Audio Record | Pass | Pass | Pass | No Soundcards | No Soundcards | NA |  
Audio Playback | Pass | Pass | Pass | No Soundcards | No Soundcards | NA |  
V4L2 – HFI 1.0 (Encoder H264) | Pass | Pass | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass | Pass | Pass |  
Display | Fail | Fail | Fail | Fail | Fail | Fail | [#1746](https://github.com/qualcomm-linux/meta-qcom/issues/1746)
Graphics | Fail | Fail | Fail | Fail | Fail | Fail | [#1746](https://github.com/qualcomm-linux/meta-qcom/issues/1746)
DSP | Pass | Pass | Pass | Pass | Pass | Pass |  
Open CV | Pass | Pass | Pass | Pass | Pass | Pass |  

Overlay Build

Test Case | RB3 | RB8 | RB4 | Lemans Ride | Monaco Ride | Talos | Comments
-- | -- | -- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass | Pass | Pass |  
Audio Record | Pass | Pass | Pass | No Soundcards | No Soundcards | NA |  
Audio Playback | Pass | Pass | Pass | No Soundcards | No Soundcards | NA |  
V4L2 – HFI 1.0 (Encode H264) | Pass | Pass | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass | Pass | Pass |  
Display | Pass | Pass | Pass | Pass | Pass | Pass |  
Graphics | Pass | Pass | Pass | Pass | Pass | Pass |  
DSP | Pass | Pass | Pass | Pass | Pass | Pass |  
FastCV | Pass | Pass | Pass | Pass | Pass | Fail |  https://github.com/qualcomm-linux/meta-qcom/issues/1767
