### PR TITLE
ci: fix template injection warnings

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -45,39 +45,54 @@ runs:
       shell: bash
       run: |
         # use a monthly sstate cache folder
-        echo "DL_DIR=${{inputs.cache_dir}}/downloads" >> $GITHUB_ENV
-        echo "SSTATE_DIR=${{inputs.cache_dir}}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
+        echo "DL_DIR=${INPUTS_CACHE_DIR}/downloads" >> $GITHUB_ENV
+        echo "SSTATE_DIR=${INPUTS_CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
         echo "KAS_WORK_DIR=$PWD/../kas" >> $GITHUB_ENV
+      env:
+        INPUTS_CACHE_DIR: ${{inputs.cache_dir}}
 
     - name: Dump kas-build yaml
       shell: bash
       run: |
         mkdir $KAS_WORK_DIR
         $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs \
-          ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }} > kas-build.yml
+          ci/mirror.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML} > kas-build.yml
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
 
     - name: Kas qcom world build
       shell: bash
       run: |
-        $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}:ci/world.yml
+        $KAS_CONTAINER build ci/mirror.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}:ci/world.yml
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg buildchart-world.svg
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
 
     - name: Kas build images
       shell: bash
       run: |
-        $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}
+        $KAS_CONTAINER build ci/mirror.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg .
 
-        if [ "${{ inputs.machine }}" = "qcom-armv8a" ]; then
-          $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}:ci/initramfs-test.yml
+        if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
+          $KAS_CONTAINER build ci/mirror.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}:ci/initramfs-test.yml
 
           # SDK only with the default kernel
-          if [ "${{ inputs.sdk }}" = "1" ] && [ "${{ inputs.kernel_yaml }}" = "" ] ; then
-            $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }} --task populate_sdk
+          if [ "${INPUTS_SDK}" = "1" ] && [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
+            $KAS_CONTAINER build ci/mirror.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML} --task populate_sdk
           fi
         fi
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
+        INPUTS_SDK: ${{ inputs.sdk }}
 
     - uses: actions/upload-artifact@v6
       with:
@@ -97,8 +112,8 @@ runs:
         # The upload-private-artifact-action runs from a container that
         # expects file to be relative to our PWD. deploy_dir is outside
         # that, so we move things around:
-        deploy_dir=../kas/build/tmp/deploy/images/${{inputs.machine}}
-        uploads_dir=./uploads/${{ inputs.distro_name }}${{ inputs.kernel_dirname }}/${{ inputs.machine }}
+        deploy_dir=../kas/build/tmp/deploy/images/${INPUTS_MACHINE}
+        uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
         mkdir -p $uploads_dir
         # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
         find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
@@ -109,6 +124,10 @@ runs:
         if [ -d $deploy_dir/../../sdk ]; then
           cp $deploy_dir/../../sdk/* $uploads_dir/
         fi
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+        INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
 
     - name: Upload artifacts to S3 bucket
       uses: qualcomm-linux/upload-private-artifact-action@aws-v4
@@ -122,11 +141,15 @@ runs:
       shell: bash
       id: print-output
       run: |
-        KERNEL_DIRNAME="${{ inputs.kernel_dirname }}"
-        BUILDNAME="${{ inputs.machine }}_${{ inputs.distro_name }}${KERNEL_DIRNAME}"
+        KERNEL_DIRNAME="${INPUTS_KERNEL_DIRNAME}"
+        BUILDNAME="${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${KERNEL_DIRNAME}"
         FILENAME="build-url_${BUILDNAME}"
         echo "${{ steps.upload_s3_artifacts.outputs.url }}" > "${FILENAME}"
         echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
     - name: Upload build URL
       uses: actions/upload-artifact@v6
       with:

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -56,8 +56,8 @@ runs:
           mkdir -p "${VARS_OUT_PATH}"
           mkdir -p "${JOBS_OUT_PATH}"
           PROJECT_NAME="${GITHUB_REPOSITORY#*/}"
-          if [ -n "${{ inputs.project }}" ]; then
-            PROJECT_NAME="${{ inputs.project }}"
+          if [ -n "${INPUTS_PROJECT}" ]; then
+            PROJECT_NAME="${INPUTS_PROJECT}"
           fi
           echo "PROJECT_NAME=${PROJECT_NAME}" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "PROJECT=projects/${PROJECT_NAME}/" >> "${VARS_OUT_PATH}/gh-variables.ini"
@@ -71,14 +71,14 @@ runs:
           echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "FLASHER_DEVICE_TYPE=qcs" >> "${VARS_OUT_PATH}/gh-variables.ini"
           IMAGE_TYPE="core-image-base"
-          if [ "${{ inputs.distro_name }}" = "qcom-distro" ]; then
+          if [ "${INPUTS_DISTRO_NAME}" = "qcom-distro" ]; then
               IMAGE_TYPE="qcom-multimedia-image"
               echo "AUTO_LOGIN_PASSWORD_PROMPT=Password" >> "${VARS_OUT_PATH}/gh-variables.ini"
               echo "AUTO_LOGIN_PASSWORD=oelinux123" >> "${VARS_OUT_PATH}/gh-variables.ini"
           fi
-          echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${INPUTS_MACHINE}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
           export BUILD_URL=""
-          export BUILD_URL_FILE="$GITHUB_WORKSPACE/build-url_${{ inputs.machine }}_${{ inputs.distro_name }}${{ inputs.kernel }}"
+          export BUILD_URL_FILE="$GITHUB_WORKSPACE/build-url_${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}"
           echo "${BUILD_URL_FILE}"
           if [ -f "$BUILD_URL_FILE" ]; then
               export BUILD_URL=$(cat "${BUILD_URL_FILE}")
@@ -90,32 +90,38 @@ runs:
           fi
           echo "BUILD_DOWNLOAD_URL=${BUILD_URL}/" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
-          echo "ROOTFS_URL=${BUILD_URL}/${{ inputs.distro_name }}${{ inputs.kernel }}/${{ inputs.machine }}/${IMAGE_TYPE}-${{ inputs.machine }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "ROOTFS_URL=${BUILD_URL}/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}/${INPUTS_MACHINE}/${IMAGE_TYPE}-${INPUTS_MACHINE}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
-          if [ "${{ inputs.machine }}" = "qcom-armv8a" ]; then
+          if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
               echo "ROOTFS_IMG_FILE=${IMAGE_TYPE}-qcom-armv8a.rootfs.ext4" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
               #cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-410c.ini
               #echo "DEVICE_TYPE=dragonboard-410c" >> dragonboard-410c.ini
               #echo "BOOT_IMG_FILE=boot-apq8016-sbc-qcom-armv8a.img" >> dragonboard-410c.ini
-              #echo "BUILD_OS=${{ inputs.distro_name }}${{ inputs.kernel }}/" >> dragonboard-410c.ini
+              #echo "BUILD_OS=${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}/" >> dragonboard-410c.ini
               #cat dragonboard-410c.ini
-              #lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${PROJECT_NAME}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
+              #lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
 
               cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-820c.ini
               echo "BOOT_IMG_FILE=boot-apq8096-db820c-qcom-armv8a.img" >> dragonboard-820c.ini
               echo "DEVICE_TYPE=dragonboard-820c" >> dragonboard-820c.ini
-              echo "BUILD_OS=${{ inputs.distro_name }}${{ inputs.kernel }}/" >> dragonboard-820c.ini
+              echo "BUILD_OS=${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}/" >> dragonboard-820c.ini
               cat dragonboard-820c.ini
-              lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${PROJECT_NAME}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
+              lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
               echo "MACHINE=dragonboard" >> $GITHUB_ENV
           else
-              echo "DEVICE_TYPE=${{ inputs.machine }}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+              echo "DEVICE_TYPE=${INPUTS_MACHINE}" >> "${VARS_OUT_PATH}/gh-variables.ini"
 
               cat "${VARS_OUT_PATH}/gh-variables.ini"
-              lava-test-plans --dry-run --variables "${VARS_OUT_PATH}/gh-variables.ini" --test-plan "${PROJECT_NAME}/${{ inputs.distro_name }}/${{ inputs.testplan }}" --device-type "projects/${PROJECT_NAME}/devices/${{ inputs.machine }}" --dry-run-path "${JOBS_OUT_PATH}/${{ inputs.machine }}-${{ inputs.distro_name }}${{ inputs.kernel }}-${{ inputs.testplan }}" || true
-              echo "MACHINE=${{ inputs.machine }}" >> $GITHUB_ENV
+              lava-test-plans --dry-run --variables "${VARS_OUT_PATH}/gh-variables.ini" --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/${INPUTS_MACHINE}" --dry-run-path "${JOBS_OUT_PATH}/${INPUTS_MACHINE}-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
+              echo "MACHINE=${INPUTS_MACHINE}" >> $GITHUB_ENV
           fi
+        env:
+          INPUTS_PROJECT: ${{ inputs.project }}
+          INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+          INPUTS_MACHINE: ${{ inputs.machine }}
+          INPUTS_KERNEL: ${{ inputs.kernel }}
+          INPUTS_TESTPLAN: ${{ inputs.testplan }}
 
       - name: "List files"
         shell: bash

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -36,7 +36,7 @@ runs:
       - name: Publish Test Job Details
         shell: bash
         run: |
-          INPUT=$(for TESTJOB in $(find ${{ github.workspace }} -name "${{ inputs.prefix }}.json")
+          INPUT=$(for TESTJOB in $(find ${{ github.workspace }} -name "${INPUTS_PREFIX}.json")
           do
               JOB_ID=$(cat "${TESTJOB}" | jq ".id")
               JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"
@@ -78,27 +78,27 @@ runs:
 
           # Print header row
           printf "| %s |" "Test"
-          printf "| %s |" "Test" >> ${{inputs.summary_file_name}}
+          printf "| %s |" "Test" >> ${INPUTS_SUMMARY_FILE_NAME}
           for D in $DEVICES; do
             printf " %s |" "$D"
-            printf " %s |" "$D" >> ${{inputs.summary_file_name}}
+            printf " %s |" "$D" >> ${INPUTS_SUMMARY_FILE_NAME}
           done
           echo
-          echo >> ${{inputs.summary_file_name}}
+          echo >> ${INPUTS_SUMMARY_FILE_NAME}
 
           ## Print separator
           printf "| ---- |"
-          printf "| ---- |" >> ${{inputs.summary_file_name}}
+          printf "| ---- |" >> ${INPUTS_SUMMARY_FILE_NAME}
           for _ in $DEVICES; do
             printf " ---- |"
-            printf " ---- |" >> ${{inputs.summary_file_name}}
+            printf " ---- |" >> ${INPUTS_SUMMARY_FILE_NAME}
           done
           echo
-          echo >> ${{inputs.summary_file_name}}
+          echo >> ${INPUTS_SUMMARY_FILE_NAME}
 
           for R in $RESULTS; do
             printf "| %s |" "$R"
-            printf "| %s |" "$R" >> ${{inputs.summary_file_name}}
+            printf "| %s |" "$R" >> ${INPUTS_SUMMARY_FILE_NAME}
 
             for D in $DEVICES; do
               VALUE=$(echo "$INPUT" | jq -r --arg d "$D" --arg r "$R" '.[$d][$r].result // ""')
@@ -108,15 +108,15 @@ runs:
               if [ "${VALUE}" = "skip" ]; then CHECKMARK=":warning:"; fi
               if [ -z "${VALUE}" ]; then CHECKMARK=":no_entry_sign:"; fi
               printf " %s [%s](%s) |" "$CHECKMARK" "$VALUE" "$URL"
-              printf " %s [%s](%s) |" "$CHECKMARK" "$VALUE" "$URL" >> ${{inputs.summary_file_name}}
+              printf " %s [%s](%s) |" "$CHECKMARK" "$VALUE" "$URL" >> ${INPUTS_SUMMARY_FILE_NAME}
             done
-            echo >> ${{inputs.summary_file_name}}
+            echo >> ${INPUTS_SUMMARY_FILE_NAME}
           done
-          echo "### All jobs summary" >> ${{inputs.summary_file_name}}
-          echo "" >> ${{inputs.summary_file_name}}
-          echo "| Job ID | Device | State | Health |" >> ${{inputs.summary_file_name}}
-          echo "| ---- | ---- | ---- | ---- |" >> ${{inputs.summary_file_name}}
-          for TESTJOB in $(find ${{ github.workspace }} -name "${{ inputs.prefix }}.json")
+          echo "### All jobs summary" >> ${INPUTS_SUMMARY_FILE_NAME}
+          echo "" >> ${INPUTS_SUMMARY_FILE_NAME}
+          echo "| Job ID | Device | State | Health |" >> ${INPUTS_SUMMARY_FILE_NAME}
+          echo "| ---- | ---- | ---- | ---- |" >> ${INPUTS_SUMMARY_FILE_NAME}
+          for TESTJOB in $(find ${{ github.workspace }} -name "${INPUTS_PREFIX}.json")
           do
               JOB_ID=$(cat "${TESTJOB}" | jq ".id")
               JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"
@@ -124,8 +124,11 @@ runs:
               JOB_HEALTH=$(echo "$JOB_DETAILS" | jq -r ".health")
               JOB_STATE=$(echo "$JOB_DETAILS" | jq -r ".state")
               JOB_DEVICE_TYPE=$(echo "$JOB_DETAILS" | jq -r ".requested_device_type")
-              echo "| [$JOB_ID]($JOB_URL) | $JOB_DEVICE_TYPE | $JOB_STATE | $JOB_HEALTH |" >> ${{inputs.summary_file_name}}
+              echo "| [$JOB_ID]($JOB_URL) | $JOB_DEVICE_TYPE | $JOB_STATE | $JOB_HEALTH |" >> ${INPUTS_SUMMARY_FILE_NAME}
           done
+        env:
+          INPUTS_PREFIX: ${{ inputs.prefix }}
+          INPUTS_SUMMARY_FILE_NAME: ${{inputs.summary_file_name}}
       - name: Upload summary
         id: upload-summary
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -51,11 +51,13 @@ jobs:
         id: pr_comment_prep
         run: |
           echo "## Test run [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" > pr-comment.txt
-          echo "## Test jobs for commit ${{ github.event.workflow_run.head_sha }}" >> pr-comment.txt
+          echo "## Test jobs for commit ${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" >> pr-comment.txt
           PR_NUMBER=$(cat "artifacts/Event File/event.json" | jq -r ".number")
           RESULT_FILE_NAME=$(find ./results_summary/ -type f)
           cat "${RESULT_FILE_NAME}" >> pr-comment.txt
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3


### PR DESCRIPTION
The template in delimiters ${{ ... }} is expanded before workflow execution and can, in case of some events, lead to code injection by the user that triggered the event [1][2].

Use an intermediate environment variable that is set to these values to remediate for all instances flagged by zizmor.

[1] https://securitylab.github.com/resources/github-actions-untrusted-input/
[2] https://docs.zizmor.sh/audits/#template-injection