### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -36,14 +36,14 @@ runs:
 
     - name: Setting up kas-container
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env]
         KAS_CONTAINER=$RUNNER_TEMP/kas-container
         echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
         chmod +x $KAS_CONTAINER
 
     - name: Setup build variables and sstate-cache
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env]
         # use a monthly sstate cache folder
         echo "DL_DIR=${INPUTS_CACHE_DIR}/downloads" >> $GITHUB_ENV
         echo "SSTATE_DIR=${INPUTS_CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -45,7 +45,7 @@ runs:
 
       - name: Run lava-test-plans
         shell: bash
-        run: |
+        run: | # zizmor: ignore[github-env]
           set -euo pipefail
           cd lava-test-plans && pip install .
           lava-test-plans --version

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: [ master ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6 # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        foundriesio/*: ref-pin
+        qualcomm-linux/*: ref-pin


### PR DESCRIPTION
Scan all GitHub workflows in the repository using zizmor action [1].

Set advanced-security to false to use annotations instead of letting zizmor write security events. And, ignore all unpinned-uses warnings for actions hosted under trusted orgs.

[1] https://github.com/zizmorcore/zizmor-action