### PR TITLE
workflows/build-yocto: pass value of cache_dir correctly

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -134,7 +134,7 @@ jobs:
           distro_name: ${{matrix.distro.name}}
           kernel_yaml: ${{matrix.kernel.yamlfile}}
           kernel_dirname: ${{matrix.kernel.dirname}}
-          cache_dir: ${CACHE_DIR}
+          cache_dir: ${{env.CACHE_DIR}}
           sdk: ${{inputs.sdk}}
 
   compile:
@@ -269,7 +269,7 @@ jobs:
           distro_name: ${{matrix.distro.name}}
           kernel_yaml: ${{matrix.kernel.yamlfile}}
           kernel_dirname: ${{matrix.kernel.dirname}}
-          cache_dir: ${CACHE_DIR}
+          cache_dir: ${{env.CACHE_DIR}}
           sdk: ${{inputs.sdk}}
 
   publish_summary:


### PR DESCRIPTION
Make sure that we actually pass the value of CACHE_DIR from env context to compile action.

Suggested-by: Naveen Kumar <kumarn@qti.qualcomm.com>