### PR TITLE
ci: actions: fix input.prefix expression

### DIFF
--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -34,7 +34,7 @@ runs:
       id: listjobs
       shell: bash
       run: |
-        JOBFILES=$(find . -name "${{ input.prefix }}*.yaml")
+        JOBFILES=$(find . -name "${{ inputs.prefix }}*.yaml")
         RESULT_JSON=$(jq -n '{target: []}')
         for J in $JOBFILES
           do


### PR DESCRIPTION
Correct input variable is inputs.prefix.

Fix:
.github/actions/list-jobs/action.yml (Line: 36, Col: 12):
   Unrecognized named-value: 'input'. Located at position 1
   within expression: input.prefix