### PR TITLE
workflows: update lava-test-plans to 3544131

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -30,7 +30,7 @@ runs:
           persist-credentials: false
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: d5b19bcc4d038a40849fe3de0847d4277d5c1305
+          ref: 3544131df5c2df3ac1c7250393d28e60f72e41b0
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
here's the list of changes that comes with this ref update:
- fix: correct device path for EXCLUDED_TESTPLANS extraction
- workflows: upgrade actions/checkout to v6
- devices: re-enable AudioRecord test for iq-9075-evk
- refractor: remove test_name override capability
- testcases: Make camera postprocessing conditional on camera testplan
- devices: Support per-device testplan exclusion using Jinja2 template engine
- testcases: Pass LAVA_TESTCASE_ID to prevent result collisions
- projects: meta-qcom: fix flasher_device_type for qcs9100
- devices: Use extensible postprocess steps for iq-x7181-evk
- Add support for adding steps in postprocess.jinja2
- projects: meta-qcom: disable fastrpc_test for qcs615
- testcases: Add GStreamer video encode/decode test plan
- templates: Add iq-x7181-evk device support
- Add pre-merge-audio test for LAVA audio validation
- meta-qcom-distro: add more devices
- Fix "black" formatting warning
- meta-qcom: disable BT tests for qcs615-ride
- testcases: Add support for excluding all testcases in a set
- Enable jinja2 loopcontrols extension
- Add missing submit_to_lava function
- projects: add flasher_device_type to devices
- include: move flasher_device_type to internal variable

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>