### PR TITLE
workflows: revert list-jobs action variable fix

### DIFF
--- a/.github/actions/list-jobs/action.yml
+++ b/.github/actions/list-jobs/action.yml
@@ -34,7 +34,9 @@ runs:
       id: listjobs
       shell: bash
       run: |
-        JOBFILES=$(find . -name "${{ inputs.prefix }}*.yaml")
+        # This is intentionally left not using inputs.prefix.
+        # Full refactoring is on the way. Please leave it like this for now.
+        JOBFILES=$(find . -name "*.yaml")
         RESULT_JSON=$(jq -n '{target: []}')
         for J in $JOBFILES
           do


### PR DESCRIPTION
When "input" is changed to "inputs" fixing a typo, the action breaks. Full refactoring is on the way. Leaving the action with a typo as it works.