### PR TITLE
Stop generating empty -dbg and -dev packages in QCOM firmware recipes

### DIFF
--- a/recipes-bsp/firmware/camxfirmware-kodiak_1.0.7.bb
+++ b/recipes-bsp/firmware/camxfirmware-kodiak_1.0.7.bb
@@ -9,37 +9,16 @@ SRC_URI[sha256sum] = "e346b7b5b20e8f28e2dc5cf36edc52f25eb3aeab315f77999c55c6dc1b
 
 S = "${UNPACKDIR}"
 
-inherit allarch
+FW_QCOM_NAME = "qcm6490"
+require recipes-bsp/firmware/firmware-qcom.inc
 
 # Disable configure and compile steps since this recipe uses prebuilt binaries.
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
-# Possible values are "xz" and "zst".
-FIRMWARE_COMPRESSION ?= ""
-
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/qcm6490
+    install -d ${D}${FW_QCOM_PATH}
+    install -m 0644 ${S}/usr/lib/firmware/qcom/qcm6490/CAMERA_ICP_170.elf ${D}${FW_QCOM_PATH}
     install -d ${D}${datadir}/doc/${BPN}
-
-    cp -r ${S}/usr/lib/firmware/qcom/qcm6490/CAMERA_ICP_170.elf ${D}${nonarch_base_libdir}/firmware/qcom/qcm6490/
-
-    case "${FIRMWARE_COMPRESSION}" in
-        zst | zstd)
-            zstd --compress --rm ${D}${nonarch_base_libdir}/firmware/qcom/qcm6490/CAMERA_ICP_170.elf
-            ;;
-        xz)
-            xz --compress --check=crc32 ${D}${nonarch_base_libdir}/firmware/qcom/qcm6490/CAMERA_ICP_170.elf
-            ;;
-    esac
-
     install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/${BPN}
 }
-
-FILES:${PN} = "${nonarch_base_libdir}/firmware/qcom/qcm6490"
-
-# Firmware file are pre-compiled, pre-stripped, and not target architecture executables.
-# Skipping QA checks: 'already-stripped', 'arch' because:
-# - Firmware is not AArch64 ELF (arch check fails)
-# - file is Pre-stripped  (already-stripped)
-INSANE_SKIP:${PN} += "already-stripped arch"

--- a/recipes-bsp/firmware/camxfirmware-lemans_1.0.7.bb
+++ b/recipes-bsp/firmware/camxfirmware-lemans_1.0.7.bb
@@ -9,42 +9,33 @@ SRC_URI[sha256sum] = "62dd76046c1ae0e34f843285524be02e9fe96093ff68096cb998e9844f
 
 S = "${UNPACKDIR}"
 
-inherit allarch
+FW_QCOM_NAME = "sa8775p"
+require recipes-bsp/firmware/firmware-qcom.inc
 
 # Disable configure and compile steps since this recipe uses prebuilt binaries.
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
-# Possible values are "xz" and "zst".
-FIRMWARE_COMPRESSION ?= ""
+def fw_compr_file_suffix(d):
+    compr = d.getVar('FIRMWARE_COMPRESSION')
+    if compr == '':
+        return ''
+    if compr == 'zstd':
+        compr = 'zst'
+    return '.' + compr
 
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/sa8775p
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/qcs8300
+    install -d ${D}${FW_QCOM_PATH}
+    install -m 0644 ${S}/usr/lib/firmware/qcom/sa8775p/CAMERA_ICP.mbn ${D}${FW_QCOM_PATH}
     install -d ${D}${datadir}/doc/${BPN}
-
-    cp -r ${S}/usr/lib/firmware/qcom/sa8775p/CAMERA_ICP.mbn ${D}${nonarch_base_libdir}/firmware/qcom/sa8775p/
-
-    case "${FIRMWARE_COMPRESSION}" in
-        zst | zstd)
-            zstd --compress --rm ${D}${nonarch_base_libdir}/firmware/qcom/sa8775p/CAMERA_ICP.mbn
-            ;;
-        xz)
-            xz --compress --check=crc32 ${D}${nonarch_base_libdir}/firmware/qcom/sa8775p/CAMERA_ICP.mbn
-            ;;
-    esac
-
     install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/${BPN}
 
-    ln -srf ${D}${nonarch_base_libdir}/firmware/qcom/sa8775p/CAMERA_ICP.mbn* ${D}${nonarch_base_libdir}/firmware/qcom/qcs8300/
+    # Monaco and Lemans platforms use same CAMX firmware.
+    # Create symlinks under qcs8300 to satisfy platform-specific
+    # lookup paths and avoid binary duplication for Monaco.
+    install -d ${D}${FW_QCOM_BASE_PATH}/qcs8300
+    ln -sf ../${FW_QCOM_NAME}/CAMERA_ICP.mbn${@fw_compr_file_suffix(d)} ${D}${FW_QCOM_BASE_PATH}/qcs8300/
 }
 
-PACKAGES += "camxfirmware-monaco"
-FILES:camxfirmware-monaco = "${nonarch_base_libdir}/firmware/qcom/qcs8300"
-FILES:${PN} = "${nonarch_base_libdir}/firmware/qcom/sa8775p"
-
-# Firmware file are pre-compiled, pre-stripped, and not target architecture executables.
-# Skipping QA checks: 'already-stripped', 'arch' because:
-# - Firmware is not AArch64 ELF (arch check fails)
-# - file is Pre-stripped  (already-stripped)
-INSANE_SKIP:${PN} += "already-stripped arch"
+PACKAGE_BEFORE_PN += "camxfirmware-monaco"
+FILES:camxfirmware-monaco = "${FW_QCOM_BASE_PATH}/qcs8300"

--- a/recipes-bsp/firmware/camxfirmware-talos_1.0.1.bb
+++ b/recipes-bsp/firmware/camxfirmware-talos_1.0.1.bb
@@ -9,37 +9,16 @@ SRC_URI[sha256sum] = "b9f9e36ab2a81cc4b5583110776b45a281f63acb9974a09bee19735b6d
 
 S = "${UNPACKDIR}"
 
-inherit allarch
+FW_QCOM_NAME = "qcs615"
+require recipes-bsp/firmware/firmware-qcom.inc
 
 # Disable configure and compile steps since this recipe uses prebuilt binaries.
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
-# Possible values are "xz" and "zst".
-FIRMWARE_COMPRESSION ?= ""
-
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/qcs615
+    install -d ${D}${FW_QCOM_PATH}
+    install -m 0644 ${S}/usr/lib/firmware/qcom/qcs615/CAMERA_ICP.elf ${D}${FW_QCOM_PATH}
     install -d ${D}${datadir}/doc/${BPN}
-
-    cp -r ${S}/usr/lib/firmware/qcom/qcs615/CAMERA_ICP.elf ${D}${nonarch_base_libdir}/firmware/qcom/qcs615/
-
-    case "${FIRMWARE_COMPRESSION}" in
-        zst | zstd)
-            zstd --compress --rm ${D}${nonarch_base_libdir}/firmware/qcom/qcs615/CAMERA_ICP.elf
-            ;;
-        xz)
-            xz --compress --check=crc32 ${D}${nonarch_base_libdir}/firmware/qcom/qcs615/CAMERA_ICP.elf
-            ;;
-    esac
-
     install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/${BPN}
 }
-
-FILES:${PN} = "${nonarch_base_libdir}/firmware/qcom/qcs615"
-
-# Firmware file are pre-compiled, pre-stripped, and not target architecture executables.
-# Skipping QA checks: 'already-stripped', 'arch' because:
-# - Firmware is not AArch64 ELF (arch check fails)
-# - file is Pre-stripped  (already-stripped)
-INSANE_SKIP:${PN} += "already-stripped arch"

--- a/recipes-bsp/firmware/firmware-qcom.inc
+++ b/recipes-bsp/firmware/firmware-qcom.inc
@@ -2,6 +2,10 @@ inherit allarch
 
 FILES:${PN} += "${nonarch_base_libdir}/firmware/"
 
+# Firmware files are pre-compiled, pre-stripped, and not target architecture executables.
+# Skipping QA checks: 'already-stripped', 'arch' because:
+# - Firmware is not AArch64 ELF (arch check fails)
+# - file is Pre-stripped  (already-stripped)
 INSANE_SKIP:${PN} += "arch already-stripped"
 
 # Default settings

--- a/recipes-bsp/firmware/firmware-qcom.inc
+++ b/recipes-bsp/firmware/firmware-qcom.inc
@@ -71,3 +71,9 @@ do_install:append() {
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_DEFAULT_DEPS = "1"
+
+# These pkgs are empty and when present will be pulled into SDK
+# by default and cause license conflits, so don't generate them.
+PACKAGES:remove = "${PN}-dbg"
+PACKAGES:remove = "${PN}-dev"
+PACKAGES:remove = "${PN}-staticdev"


### PR DESCRIPTION
The QCOM firmware recipes installs only firmware files and does not produce debug symbols
or development headers. Restrict these recipes to generate only the main package to avoid
producing empty -dbg and -dev packages and reduce unnecessary packaging noise.