### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260325

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.12"
+LINUX_VERSION ?= "6.18.18"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260317
-SRCREV ?= "c60e1a1fe181cede961d8f4ceaf5792f47cb8950"
+# tag:qcom-6.18.y-20260325
+SRCREV ?= "064f7053ecc0cf4c28d8f58e3a703ca74518edfc"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260325

Changelog:
Merge tag 'v6.18.18' into qcom-6.18.y
WORKAROUND: remoteproc: qcom: Fix RB8 device hung issue
QCLINUX: arm64: configs: Added Docker/Kubernetes support in qcom.config
FROMLIST: drm/msm/dsi/phy: fix rounding error in recalc_rate
FROMLIST: media: qcom: camss: Add missing clocks for VFE lite on sa8775p
FROMLIST: media: qcom: camss: Fix csid clock configuration for sa8775p
FROMLIST: media: qcom: camss: Fix csid IRQ offset for sa8775p
QCLINUX: debug: Enable ATH11K CFR
FROMGIT: wifi: ath11k: Register handler for CFR capture event
FROMGIT: wifi: ath11k: Register DBR event handler for CFR data
FROMGIT: wifi: ath11k: Register relayfs entries for CFR dump
FROMGIT: wifi: ath11k: Add support unassociated client CFR
FROMGIT: wifi: ath11k: Register debugfs for CFR configuration
FROMGIT: wifi: ath11k: Add initialization and deinitialization sequence for CFR module
QCLINUX: arm64: dts: qcom: lemans: Fix comment typo in camx EL2 dtso.
FROMLIST: crypto: qce - Add runtime PM and interconnect bandwidth scaling support
BACKPORT: bluetooth: btqca: Add WCN6855 firmware priority selection feature
BACKPORT: bluetooth: btqca: move WCN7850 workaround to the caller
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: Update TSENS thermal zone configuration
FROMLIST: arm64: dts: qcom: x1e80100: Add '#cooling-cells' for CPU nodes
FROMLIST: arm64: dts: qcom: hamoa-iot-evk-camera-imx577: Add DT overlay
FROMLIST: arm64: dts: qcom: hamoa-iot-som: Add pm8010 L4M regulator
FROMLIST: arm64: dts: qcom: x1e80100-lenovo-yoga-slim7x: Add pm8010 camera PMIC with voltage levels for IR and RGB camera
FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add on ov02c10 RGB sensor on CSIPHY4
FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add pm8010 camera PMIC with voltage levels for IR and RGB camera
FROMLIST: arm64: dts: qcom: x1e80100-crd: Add ov08x40 RGB sensor on CSIPHY4
FROMLIST: arm64: dts: qcom: x1e80100-crd: Add pm8010 CRD pmic,id=m regulators
FROMLIST: arm64: dts: qcom: x1e80100: Add CAMSS block definition
FROMLIST: arm64: dts: qcom: x1e80100: Add MIPI CSI PHY nodes
FROMLIST: arm64: dts: qcom: x1e80100: Add CCI definitions
FROMLIST: arm64: dts: qcom: x1e80100: Add CAMCC block definition
FROMLIST: media: qcom: camss: Drop legacy PHY descriptions from x1e
FROMLIST: media: qcom: camss: Add support for PHY API devices
FROMLIST: media: qcom: camss: Add legacy_phy flag to SoC definition structures
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Allow CSIPHY supplies to be optional
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add iommus minItems: 5
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add support for combo-mode endpoints
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add optional PHY handle definitions
FROMLIST: phy: qcom-mipi-csi2: Add a CSI2 MIPI DPHY driver
FROMLIST: dt-bindings: phy: qcom: Add CSI2 C-PHY/DPHY schema

PR Test Results :

| Test Case | [qcs615](https://lava.infra.foundries.io/results/165815) | [qcs615_prop](https://lava.infra.foundries.io/results/165755) | [qcs8300](https://lava.infra.foundries.io/results/165752) | [qcs8300_prop](https://lava.infra.foundries.io/results/165756) | [rb3gen2](https://lava.infra.foundries.io/results/165749) | [rb3gen2_prop](https://lava.infra.foundries.io/results/165882) | [rb8](https://lava.infra.foundries.io/results/165750) | [rb8_prop](https://lava.infra.foundries.io/results/165754) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| adsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| AudioRecord | ✅ Pass | ❌ Fail | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| BT_ON_OFF | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| cdsp_remoteproc | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| CPUFreq_Validation | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| DSP_AudioPD | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Ethernet | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ⚠️ Skip | ⚠️ Skip | ⚠️ Skip | ✅ Pass |
| fastrpc_test | ❌ Fail | ❌ Fail | ✅ Pass | ✅ Pass | ✅ Pass | ❌ Fail | ✅ Pass | ✅ Pass |
| hotplug | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| Interrupts | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| irq | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| OpenCV | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_Firmware_Driver | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |
| WiFi_OnOff | ⚠️ Skip | ⚠️ Skip | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass | ✅ Pass |

Fastrpc failure on Talos corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1767
Fastrpc failure on RB3GEN2 Overlay corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1807

Base Build :
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass |  
Audio Record | Pass | Pass | Pass | NA |  
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encoder H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Pass | Pass | Pass | Pass | 
Graphics | Pass | Pass | Pass | Pass | 
DSP | Pass | Pass | Pass | Pass |  
Open CV | Pass | Pass | Pass | Pass |  

Overlay Build
Test Case | RB3 | RB8 | RB4 | Talos | Comments
-- | -- | -- | -- | -- | --
QC BT driver | Pass | Pass | Pass | Pass |  
Ethernet | Pass | Pass | Pass | Pass |  
Wlan enable | Pass | Pass | Pass | Pass |  
Audio Record | Pass | Pass | Pass | NA |  
Audio Playback | Pass | Pass | Pass | NA |  
V4L2 – HFI 1.0 (Encode H264) | Pass | Pass | Pass | Pass |  
V4L2 – HFI 1.0 (Decode H264) | Pass | Pass | Pass | Pass |  
Display | Fail | Fail | Fail | Fail |   https://github.com/qualcomm-linux/meta-qcom/issues/1824
Graphics | Fail | Fail | Fail | Fail |  https://github.com/qualcomm-linux/meta-qcom/issues/1824
DSP | Pass | Pass | Pass | Pass |  
FastCV | Pass | Pass | Pass | Fail |  https://github.com/qualcomm-linux/meta-qcom/issues/1767