### PR TITLE
qcom-armv8a: install sm8750-mtp firmware

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -91,4 +91,5 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb2-firmware \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb5-firmware \
+    packagegroup-sm8750-mtp-firmware \
 "


### PR DESCRIPTION
Add packagegroup-sm8750-mtp-firmware to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS so that the required firmware binaries for sm8750-mtp are available by default on qcom-armv8a builds.