### PR TITLE
ci: nightly: temporarily disable building SDK

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,7 +17,7 @@ jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml
     with:
-      sdk: "1"
+      sdk: "0" # temporarily until we can split IMSDK correctly
   test-nightly:
     uses: ./.github/workflows/test.yml
     needs: build-nightly


### PR DESCRIPTION
As discussed at
https://github.com/qualcomm-linux/meta-qcom-distro/pull/237, IMSDK requires proper package (or recipe) split between OSS and proprietary dependencies as the main -dev package (used by the SDK) depends on both, causing qcom-multimedia-image to bring proprietary components.

This revert is temporarily needed to unlock nighly CI runs, until the SDK can be generated for both qcom-multimedia-image and qcom-multimedia-proprietary-image.