### PR TITLE
recipes-support/fastrpc: add legacy mmap/unmap fallback for apps_mem

### DIFF
--- a/recipes-support/fastrpc/fastrpc/0001-apps_mem-fallback-to-legacy-mmap-unmap-when-internal.patch
+++ b/recipes-support/fastrpc/fastrpc/0001-apps_mem-fallback-to-legacy-mmap-unmap-when-internal.patch
@@ -1,0 +1,61 @@
+From b66a7f98c1256af7628cff70544680892a8c8ad4 Mon Sep 17 00:00:00 2001
+From: Jianping Li <jianping.li@oss.qualcomm.com>
+Date: Tue, 24 Mar 2026 14:12:28 +0800
+Subject: [PATCH] apps_mem: fallback to legacy mmap/unmap when internal API
+ fails (Talos)
+
+On Talos, fastrpc_mmap_internal/munmap_internal can fail or be unsupported.
+Fallback to fastrpc_mmap and then remote_mmap64_internal,
+and use remote_munmap64 when internal munmap fails.
+
+Signed-off-by: Jianping Li <jianping.li@oss.qualcomm.com>
+Upstream-Status: Submitted [https://github.com/qualcomm/fastrpc/pull/319/changes/b66a7f98c1256af7628cff70544680892a8c8ad4]
+---
+ src/apps_mem_imp.c | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/src/apps_mem_imp.c b/src/apps_mem_imp.c
+index 7813bb3..c236047 100644
+--- a/src/apps_mem_imp.c
++++ b/src/apps_mem_imp.c
+@@ -167,13 +167,19 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
+             AEE_ENORPCMEMORY);
+     fd = rpcmem_to_fd_internal(buf);
+     VERIFYC(fd > 0, AEE_EBADPARM);
+-    VERIFY(AEE_SUCCESS ==
+-           (nErr = fastrpc_mmap_internal(domain, fd, buf, 0, len,
+-                                         rflags, vadsp)));
+-    pbuf = (uint64_t)buf;
+-    *vapps = pbuf;
+-    minfo->vapps = *vapps;
++    nErr = fastrpc_mmap_internal(domain, fd, buf, 0, len,
++                                          rflags, vadsp);   
++    if (nErr != AEE_SUCCESS) {
++      rpcmem_free_internal(buf);
++      buf = NULL;
++      fd = -1;
++      VERIFY(AEE_SUCCESS == (nErr = remote_mmap64_internal(fd, rflags, 
++                              (uint64_t)buf, len, (uint64_t *)vadsp)));
++    }
+   }
++  pbuf = (uint64_t)buf;
++  *vapps = pbuf;
++  minfo->vapps = *vapps;
+   minfo->vadsp = *vadsp;
+   minfo->size = len;
+   minfo->mapped = 0;
+@@ -257,7 +263,10 @@ __QAIC_IMPL(apps_mem_request_unmap64)(uint64_t vadsp,
+        * For other cases, use fastrpc_munmap_internal as they were mapped with fastrpc_mmap_internal.
+        */
+       if (mfree) {
+-         VERIFY(AEE_SUCCESS == (nErr = fastrpc_munmap_internal(domain, (uint64_t)vadsp, len)));
++         nErr = fastrpc_munmap_internal(domain, (uint64_t)vadsp, len);
++         if (nErr != AEE_SUCCESS) {
++            VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
++         }
+       } else {
+          VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
+       }
+-- 
+2.34.1
+

--- a/recipes-support/fastrpc/fastrpc_1.0.4.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.4.bb
@@ -10,6 +10,7 @@ SRCREV = "8572ae1c45d38a4dc8853b1b9b6738207ab1ce94"
 SRC_URI = "\
     git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
     file://run-ptest \
+    file://0001-apps_mem-fallback-to-legacy-mmap-unmap-when-internal.patch \
 "
 
 inherit autotools systemd ptest pkgconfig


### PR DESCRIPTION
Currently, the unsigned PD test is failing on Talos.
Because fastrpc_mmap_internal/munmap_internal can fail or be unsupported. Fallback to fastrpc_mmap and then remote_mmap64_internal, and use remote_munmap64 when internal munmap fails.

Address part of the Talos issue:
https://github.com/qualcomm-linux/meta-qcom/issues/1767