### PR TITLE
weston-init: add repaint-window=10 to [core] config

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -10,6 +10,7 @@ SRC_URI:append:qcom = " \
 do_compile:append:qcom() {
     sed -i -e 's:@bindir@:${bindir}:g' ${UNPACKDIR}/additional-devices.conf
     sed -i -e 's:@bindir@:${bindir}:g' ${UNPACKDIR}/weston-start.sh
+    sed -i -e "/^\[core\]/a repaint-window=10" ${UNPACKDIR}/weston.ini
 }
 
 do_install:append:qcom() {


### PR DESCRIPTION
Weston's default repaint-window is 7ms. At 60 fps the vsync interval is ~16ms. Under load (multi-surface composition or 4K fullscreen weston-simple-egl), the compositor cannot complete repaints within this window, causing up to 50% FPS drops.

Changing repaint-window to 10ms gives the compositor sufficient time to complete repaints before vblank while retaining a 6ms buffer acquisition window, improving frame delivery consistency without introducing additional frame latency.