### PR TITLE
actions/compile: run and show the oe-core buildstats-summary

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -71,6 +71,8 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
+        $KAS_CONTAINER shell ${KAS_YAMLS}:ci/world.yml \
+          -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg buildchart-world.svg
 
@@ -78,17 +80,23 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER build ${KAS_YAMLS}
+        $KAS_CONTAINER shell ${KAS_YAMLS} \
+          -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg .
 
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
           $KAS_CONTAINER build ${KAS_YAMLS}:ci/initramfs-test.yml
+          $KAS_CONTAINER shell ${KAS_YAMLS}:ci/initramfs-test.yml \
+            -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
           ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
           mv $KAS_WORK_DIR/build/buildchart.svg buildchart-initramfs-test.svg
 
           # SDK only with the default kernel
           if [ "${INPUTS_SDK}" = "1" ] && [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
             $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk
+            $KAS_CONTAINER shell ${KAS_YAMLS} \
+              -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
             ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
             mv $KAS_WORK_DIR/build/buildchart.svg buildchart-sdk.svg
           fi


### PR DESCRIPTION
This OE-core helper script will post process the buildstats and will print out
the task ordered by 'duration' excluding those with a time less than 'shortest'.

```
| $ buildstats-summary --sort duration --highlight 0 --shortest 900"
| 0:16:02    clang:do_compile
| 0:16:11    gcc:do_package  
| 0:16:28    opencv:do_compile
| 0:19:49    clang-native:do_compile
| 0:20:47    llvm:do_compile
| 0:34:41    rust-native:do_install
```

This will help us better understand which tasks are consuming most of the time.
The list above shows the usual suspects.