### PR TITLE
workflows/build-yocto: skip summary and success jobs on forks

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -293,7 +293,7 @@ jobs:
 
   publish_summary:
     needs: compile
-    if: always()
+    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -306,6 +306,7 @@ jobs:
           pattern: build-url*
 
   build_successful:
+    if: github.repository_owner == 'qualcomm-linux'
     needs: compile
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Gate publish_summary and build_successful jobs to run only in the qualcomm-linux repository. This prevents forked repositories from executing summary-related jobs.