### PR TITLE
Extend EL2 DTBO support and FIT DTB compatibility across Ride and EVK platforms

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -24,7 +24,7 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2] = " \
     qcom,qcs9075-iot-el2kvm \
     qcom,qcs9075-socv2.0-iot-el2kvm \
 "
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2] = " \
+FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2+lemans-camx-el2] = " \
     qcom,qcs9075-iot-camx-el2kvm \
     qcom,qcs9075-socv2.0-iot-camx-el2kvm \
 "

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -77,7 +77,9 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
     qcom,qcs6490-iot-subtype2-camx \
 "
 FIT_DTB_COMPATIBLE[qcs8300-ride] = "qcom,qcs8300-adp"
+FIT_DTB_COMPATIBLE[qcs8300-ride+monaco-el2] = "qcom,qcs8300-adp-el2kvm"
 FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx] = "qcom,qcs8300-adp-camx"
+FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx+monaco-el2+monaco-camx-el2] = "qcom,qcs8300-adp-camx-el2kvm"
 FIT_DTB_COMPATIBLE[qcs9100-ride] = " \
     qcom,qcs9100-qam \
     qcom,qcs9100-socv2.0-qam \

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -107,18 +107,34 @@ FIT_DTB_COMPATIBLE[sa8775p-ride] = " \
     qcom,sa8775p-qam \
     qcom,sa8775p-socv2.0-qam \
 "
+FIT_DTB_COMPATIBLE[sa8775p-ride+lemans-el2] = " \
+    qcom,sa8775p-qam-el2kvm \
+    qcom,sa8775p-socv2.0-qam-el2kvm \
+"
 FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx] = " \
     qcom,sa8775p-qam-camx \
     qcom,sa8775p-socv2.0-qam-camx \
+"
+FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx+lemans-el2+lemans-camx-el2] = " \
+    qcom,sa8775p-qam-camx-el2kvm \
+    qcom,sa8775p-socv2.0-qam-camx-el2kvm \
 "
 FIT_DTB_COMPATIBLE[sa8775p-ride-camx] = "qcom,sa8775p-qam-camx"
 FIT_DTB_COMPATIBLE[sa8775p-ride-r3] = " \
     qcom,sa8775p-qam-r2.0 \
     qcom,sa8775p-socv2.0-qam-r2.0 \
 "
+FIT_DTB_COMPATIBLE[sa8775p-ride-r3+lemans-el2] = " \
+    qcom,sa8775p-qam-r2.0-el2kvm \
+    qcom,sa8775p-socv2.0-qam-r2.0-el2kvm \
+"
 FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx] = " \
     qcom,sa8775p-qam-r2.0-camx \
     qcom,sa8775p-socv2.0-qam-r2.0-camx \
+"
+FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx+lemans-el2+lemans-camx-el2] = " \
+    qcom,sa8775p-qam-r2.0-camx-el2kvm \
+    qcom,sa8775p-socv2.0-qam-r2.0-camx-el2kvm \
 "
 FIT_DTB_COMPATIBLE[sdm845-db845c] = "qcom,sdm845"
 FIT_DTB_COMPATIBLE[sm8450-hdk] = "qcom,sm8450-hdk"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -36,8 +36,10 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-evk-staging] = " \
     qcom,qcs9075-iot-subtype1-staging \
     qcom,qcs9075v2-iot-subtype1-staging \
 "
+FIT_DTB_COMPATIBLE[monaco-evk+monaco-el2] = "qcom,qcs8275-iot-el2kvm"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
+FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx+monaco-el2+monaco-camx-el2] = "qcom,qcs8275-iot-camx-el2kvm"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subtype3"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine+monaco-evk-staging] = "qcom,qcs8275-iot-subtype3-staging"
 FIT_DTB_COMPATIBLE[purwa-iot-evk] = "qcom,purwa-evk"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -13,6 +13,8 @@ KERNEL_DEVICETREE ?= " \
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+                      qcom/monaco-el2.dtbo \
+                      qcom/monaco-camx-el2.dtbo \
                       qcom/monaco-evk-camx.dtbo \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
                       qcom/monaco-evk-staging.dtbo \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-el2.dtbo \
                       qcom/lemans-evk-camx.dtbo \
+                      qcom/lemans-camx-el2.dtbo \
                       qcom/lemans-evk-ifp-mezzanine.dtbo \
                       qcom/lemans-evk-staging.dtbo \
                       "

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -14,6 +14,8 @@ KERNEL_DEVICETREE ?= " \
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+                      qcom/monaco-el2.dtbo \
+                      qcom/monaco-camx-el2.dtbo \
                       qcom/qcs8300-ride-camx.dtbo \
                       "
 

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -18,6 +18,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-el2.dtbo \
+                      qcom/lemans-camx-el2.dtbo \
                       qcom/sa8775p-ride-camx.dtbo \
                       "
 

--- a/recipes-kernel/linux/qcom-dtb-metadata_0.5.bb
+++ b/recipes-kernel/linux/qcom-dtb-metadata_0.5.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-dtb-metadata.git;branch=main;protocol=https;tag=v${PV}"
 
-SRCREV = "0c3dbe81151caa7f797c5cf34d6f7581ad416aa6"
+SRCREV = "bf60e31a7eebbf5f54b5af55d182f869716966c0"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
## Summary

This PR extends **EL2 DTBO enablement** across multiple Qualcomm **Ride** and **EVK**
platforms by updating kernel device tree lists, adding more **FIT DTB compatible
mappings**, and updating **qcom-dtb-metadata** version.

These changes ensure that **EL2/KVM-enabled DTBOs** are consistently built,
packaged, and correctly selected during FIT image boot across supported SoCs
and platform variants.

## Changes Included

- Added **EL2-enabled DTBOs** to kernel device tree lists for:
  - `iq-8275-evk`
  - `iq-9075-evk`
  - `qcs8300-ride-sx`
  - `qcs9100-ride-sx`

- Extended `FIT_DTB_COMPATIBLE` mappings to support EL2/KVM configurations across:
  - Monaco EVK variants
  - QCS8300 Ride platforms
  - SA8775P Ride platforms (including camx and R3 variants)
  - QCS9100 Ride platforms (including R3 and multiple SoC revisions)

- Normalized **FIT DTB compatible keys** to align with existing platform and DTBO
  naming conventions

- Updated **qcom-dtb-metadata** to version vo.5 to pick up corresponding
  EL2/KVM compatibility additions

## Related Work

- qcom-dtb-metadata EL2/KVM compatibility updates:
  - https://github.com/qualcomm-linux/qcom-dtb-metadata/pull/58
  - https://github.com/qualcomm-linux/qcom-dtb-metadata/pull/59