### PR TITLE
qcom-ptool: update revision

### DIFF
--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "386018c76d9b4f63141ad33905506e231cdc6f38"
+SRCREV = "c738ecf712be514bdb1074311028a7ac201b4740"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

tests: check-missing-files: add files used by KAANAPALI-MTP
platforms: add machine specific partitions.conf for kaanapali-mtp board
platforms: add emmc version of iq-9075-evk files
platforms/contents.xml.in: add missing component for glymur-crd
gen_partition.py: fix integer division in partition_size_in_kb()
gen_partition.py: fix phys_part type inconsistency in partition_options()
ptool.py: fix MBR disk signature written in wrong byte order
ptool, msp: extract duplicated helpers into shared utils.py
ptool, msp, gen_partition, gen_contents: sort imports with isort
ptool, msp, gen_partition, gen_contents: fix all ruff-reported issues
ptool, msp, utils, gen_partition, gen_contents: apply black formatting