### PR TITLE
ci: temporarily disable boot-tests on db820c

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -102,13 +102,13 @@ runs:
               #cat dragonboard-410c.ini
               #lava-test-plans --dry-run --variables dragonboard-410c.ini --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-410c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-410c-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
 
-              cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-820c.ini
-              echo "BOOT_IMG_FILE=boot-apq8096-db820c-qcom-armv8a.img" >> dragonboard-820c.ini
-              echo "DEVICE_TYPE=dragonboard-820c" >> dragonboard-820c.ini
-              echo "BUILD_OS=${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}/" >> dragonboard-820c.ini
-              cat dragonboard-820c.ini
-              lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
-              echo "MACHINE=dragonboard" >> $GITHUB_ENV
+              #cp "${VARS_OUT_PATH}/gh-variables.ini" dragonboard-820c.ini
+              #echo "BOOT_IMG_FILE=boot-apq8096-db820c-qcom-armv8a.img" >> dragonboard-820c.ini
+              #echo "DEVICE_TYPE=dragonboard-820c" >> dragonboard-820c.ini
+              #echo "BUILD_OS=${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}/" >> dragonboard-820c.ini
+              #cat dragonboard-820c.ini
+              #lava-test-plans --dry-run --variables dragonboard-820c.ini --test-plan "${PROJECT_NAME}/${INPUTS_DISTRO_NAME}/${INPUTS_TESTPLAN}" --device-type "projects/${PROJECT_NAME}/devices/dragonboard-820c" --dry-run-path "${JOBS_OUT_PATH}/dragonboard-820c-${INPUTS_DISTRO_NAME}${INPUTS_KERNEL}-${INPUTS_TESTPLAN}" || true
+              #echo "MACHINE=dragonboard" >> $GITHUB_ENV
           else
               echo "DEVICE_TYPE=${INPUTS_MACHINE}" >> "${VARS_OUT_PATH}/gh-variables.ini"
 


### PR DESCRIPTION
Temporarily disable boot testing on dragonboard-820c until https://github.com/qualcomm-linux/kernel/issues/309 is fixed and available in linux-qcom-6.18.

This is needed as this failure is currently blocking wider testing on prs and merges.