### PR TITLE
add phone capability via MACHINE_FEATURE for Industrial kits.

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs8300.inc
 
-MACHINE_FEATURES += "efi pci tpm2"
+MACHINE_FEATURES += "efi pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk.dtb \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi pci tpm2"
+MACHINE_FEATURES += "efi pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/lemans-evk.dtb \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/qcom-qcs6490.inc
 
 # NOTE: TPM hardware is only present on rb3gen2-industrial kit
-MACHINE_FEATURES += "efi pci tpm2"
+MACHINE_FEATURES += "efi pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \


### PR DESCRIPTION
This change adds the 'phone' capability to MACHINE_FEATURES for the
Rb3gen2-core-kit, iq-9075-evk and iq-8275-evk machines having external M.2 attach modems.

The intent is to advertise telephony support at the machine level,
allowing higher layers to conditionally enable cellular-related components based on MACHINE_FEATURES.