### PR TITLE
conf: machine: qcs615-ride: remove setting QCOM_DTB_DEFAULT

### DIFF
--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-qcs615.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "qcs615-ride"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs615-ride.dtb \
                       "


### PR DESCRIPTION
Remove explicit setting of `QCOM_DTB_DEFAULT` to enable multi-DTB support on QCS615 ADP Air EVK by default.

Log snippet of booting with multi-DTB:
```
ProcessQcomMetaDtbOemNode: Board Param: OEM Id = 0
ProcessQcomMetaDtbSocNode:Board Param:
 ChipVersion: 0x10001
ChipId: 0x2A8
 ProcessQcomMetaDtbSocNode: Node qcs615v1.1
FromDtbChipIdentifier = 2A8
FromDtbChipRevision = 10001
 ProcessQcomMetaDtbBoardNode: Board Param: BoardId = 0x19
 ProcessQcomMetaDtbBoardNode: Node adp BoardId = 0x19
PackageId: 0x0
ProcessQcomMetaDtbSocSkuNode: Board Param:
FoundryId: 0x3
PackageId: 0x0
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Board Param:
BoardSubTypeId = 0x3
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Node subtype3 From fdt BoardSubTypeId = 3
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Board Param:
BootDeviceType = 0x1
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Node emmc From fdt StorageTypeId = 1
 ProcessQcomMetaDtbBoardMemorySizeNode:Board Param:
Ddr Size = 0
 ProcessQcomMetaDtbBoardMemorySizeNode: Node 4GB+ From fdt DdrSizeId = 0
 ProcessQcomMetaDtbSoftSkuNode: Board Param: Board SoftSkuId = 0
 ProcessQcomMetaDtbSoftSkuNode: Node softsku0 SoftSkuId = 0
GetVariable failed to get size: Not Found, skipping RT Overlay
 ParseFitDt: Configuration From BoardParam
qcom, qcs615v1.1, adp, sku0, subtype3, emmc, 4GB+, softsku0,
 FindConfigToBoot: SubNode 504 And Node Name conf-1 Len = 6
FindConfigToBoot: Invalid Configuration ConfigFdt "qcom,qcs615-adp"
 FindConfigToBoot: CompatibleMatchFlag = 0 CurrSubStringCnt = 1
 FindConfigToBoot: SubNode 604 And Node Name conf-2 Len = 6
 FindConfigToBoot: CompatibleMatchFlag = 1 CurrSubStringCnt = 2
FindConfigToBoot:Booting with = qcom,qcs615v1.1-adp
 FindConfigToBoot: i = 0 fdt fdt-qcs615-ride.dtb str len = 19
ParseFitDt::
Config fdt-qcs615-ride.dtb & Type 0
FitLoadDtbFromFdt: Config fdt-qcs615-ride.dtb & Type 0
Reading of OsConfigTableSelection failed,checking DT settings
 CryptoDxeFixupEventNotifyFunc: mmc node=/soc@0/crypto@7c8000 not found in device tree
HypDtFixupEventNotifyFunc: Dtb apply overlay skipped
```