### PR TITLE
Enable Talos Ride Platform EL2/KVM DTBO compilation and FIT DTB support

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -47,6 +47,10 @@ FIT_DTB_COMPATIBLE[qcs615-ride] = " \
     qcom,qcs615-adp \
     qcom,qcs615-socv1.1-adp \
 "
+FIT_DTB_COMPATIBLE[qcs615-ride+talos-el2] = " \
+    qcom,qcs615-adp-el2kvm \
+    qcom,qcs615-socv1.1-adp-el2kvm \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
     qcom,qcs5430-iot \
     qcom,qcs6490-iot \

--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -12,6 +12,11 @@ KERNEL_DEVICETREE ?= " \
                       qcom/qcs615-ride.dtb \
                       "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+                      qcom/talos-el2.dtbo \
+                      "
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcs615-ride-firmware \
     packagegroup-qcs615-ride-hexagon-dsp-binaries \


### PR DESCRIPTION
KVM support on Talos Ride platform requires the EL2 DTBO. So updated `fit-dtb-compatible.inc` with these entries and update machine conf to build EL2 DTBOs.

Relate-PRs: #1631 #1851 