### PR TITLE
Enable support for IQ-8275-AC STARTER EVK board

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -104,6 +104,7 @@ FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm] = \
     "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm-staging] = \
     "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0] = "monaco-ac-evk monaco-evk-camera-imx577"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
     "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-el2.dtbo \
                       qcom/monaco-camx-el2.dtbo \
+                      qcom/monaco-ac-evk.dtb \
                       qcom/monaco-evk-camx.dtbo \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
                       qcom/monaco-evk-staging.dtbo \


### PR DESCRIPTION
Add IQ-8275-AC STARTER EVK support to the machine IQ-8275 and add the corresponding FIT compatible mapping.

The IQ-8275-AC STARTER is a hardware variant of the IQ-8275 (monaco) platform
with a reduced PMIC configuration (2x PM8654AU), compared to the
IQ-8275 EVK which uses a 4-PMIC setup. The rest of the hardware
peripherals are largely identical and shared across both variants.

Since the IQ-8275-AC STARTER EVK belongs to the same platform family and reuses 
the same core hardware description, it is added under the existing IQ-8275 machine.

Changes:
- Add monaco-ac EVK DTB to LINUX_QCOM_KERNEL_DEVICETREE to the IQ-8275 machine 
   
- Add FIT DTB compatible string for monaco-ac-evk.dtb to ensure the
  correct DTB is selected during boot