### PR TITLE
gst-plugins-imsdk: add mosquitto runtime dependency for MQTT adaptor

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bb
@@ -49,3 +49,7 @@ RDEPENDS:${PN}-qtimltflite += "tensorflow-lite"
 
 # The Smart Video Encoder plugin loads the libVideoCtrl library at runtime using dlopen(). To ensure runtime availability, added runtime dependency on 'smart-venc-ctrl-algo'.
 RDEPENDS:${PN}-qtismartvencbin += "smart-venc-ctrl-algo"
+
+# The MQTT adaptor loads the mosquitto library at runtime using dlopen(). MQTT server also needed to exercise the use-case.
+# To ensure runtime availability, added runtime dependency on 'mosquitto'.
+RDEPENDS:libgstqtimqttadaptor += "mosquitto"


### PR DESCRIPTION
The MQTT adaptor uses libmosquitto and loads it at runtime via dlopen(). In addition, the mosquitto broker service is required to execute the supported MQTT use cases.

Since the mosquitto package provides the broker service and has an RDEPENDS on libmosquitto, add a runtime dependency on mosquitto to ensure both the library and service are available at runtime.