### PR TITLE
fastrpc: add udev rules for FastRPC device nodes

### DIFF
--- a/recipes-support/fastrpc/fastrpc/71-fastrpc.rules
+++ b/recipes-support/fastrpc/fastrpc/71-fastrpc.rules
@@ -1,0 +1,28 @@
+# udev rules for Qualcomm FastRPC devices
+# These rules set permissions and systemd tags for FastRPC device nodes
+
+# aDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd_audiopd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd_audiopd.service"
+
+# cDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsprpcd.service"
+
+# cDSP1 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp1", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsp1rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp1-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsp1rpcd.service"
+
+# gDSP0 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp0", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp0rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp0-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp0rpcd.service"
+
+# gDSP1 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp1", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp1rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp1-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp1rpcd.service"
+
+# sDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-sdsp", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sdsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-sdsp-secure", GROUP="render", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sdsprpcd.service"

--- a/recipes-support/fastrpc/fastrpc_1.0.4.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.4.bb
@@ -9,6 +9,7 @@ DEPENDS = "libbsd libyaml"
 SRCREV = "8572ae1c45d38a4dc8853b1b9b6738207ab1ce94"
 SRC_URI = "\
     git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
+    file://71-fastrpc.rules \
     file://run-ptest \
     file://0001-apps_mem-fallback-to-legacy-mmap-unmap-when-internal.patch \
 "
@@ -29,9 +30,13 @@ SYSTEMD_SERVICE:${PN} = " \
 
 do_install:append() {
     install -d ${D}${datadir}/qcom/
+    install -d ${D}${nonarch_base_libdir}/udev/rules.d/
 
     sed -i -e 's:/usr/bin/:${bindir}/:g' \
         ${D}${systemd_system_unitdir}/*.service
+
+    install -m 0644 ${UNPACKDIR}/71-fastrpc.rules \
+        ${D}${nonarch_base_libdir}/udev/rules.d/71-fastrpc.rules
 }
 
 FILES:${PN} += " \
@@ -43,6 +48,7 @@ FILES:${PN} += " \
     ${libdir}/libcdsprpc.so \
     ${libdir}/libsdsprpc.so \
     ${datadir}/qcom/ \
+    ${nonarch_base_libdir}/udev/rules.d \
 "
 
 FILES:${PN}-dev:remove = "${FILES_SOLIBSDEV}"


### PR DESCRIPTION
Add 71-fastrpc.rules to set permissions (0660, GROUP="render") and systemd service tags for all FastRPC misc device nodes (adsp, cdsp, cdsp1, gdsp0, gdsp1, sdsp) including their secure variants.

Update the recipe to install the rules file into
${nonarch_base_libdir}/udev/rules.d/ and include it in the package.