### PR TITLE
weston-init: set require-outputs=none to allow startup without connected display

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -8,6 +8,8 @@ SRC_URI:append:qcom = " \
 "
 
 do_install:append:qcom() {
+    sed -i -e "/^\[core\]/a require-outputs=none" ${D}${sysconfdir}/xdg/weston/weston.ini
+
     install -d ${D}${systemd_system_unitdir}/weston.service.d
     install -m 0644 ${UNPACKDIR}/additional-devices.conf \
         ${D}${systemd_system_unitdir}/weston.service.d/additional-devices.conf


### PR DESCRIPTION
By default, Weston exits at startup if no output connector is reported as connected by the DRM subsystem. On platforms where displays are connected after boot via HPD (Hot Plug Detect), this causes the Weston service to be killed during early boot and remain down until manually restarted.

Setting require-outputs=none in the [core] section instructs Weston to start and remain running even when no connector is active at boot time. When a display is subsequently hot plugged and HPD is asserted, Weston automatically picks up the new connector and brings up the output without requiring a service restart.