### PR TITLE
Add SM8750 MTP initramfs firmware image

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-sm8750-mtp-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-sm8750-mtp-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with SM8750 MTP firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-sm8750-mtp-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Introduce initramfs firmware image recipe for SM8750 MTP board to include required
firmware files via packagegroup-sm8750-mtp-firmware for kernel validation workflows.