### PR TITLE
sensors: upgrade 1.1.0 -> 1.2.0

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.2.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.2.0.bb
@@ -5,9 +5,9 @@ validate sensor services functionality through the Sensinghub Interface."
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom-2;md5=f33ba334514c4dfabc6ab7377babb377"
 
-PBT_BUILD_DATE = "260402"
+PBT_BUILD_DATE = "260407"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "12acdab39fe79bfc9c00697f5d7d3a766d9f6192f0fc74cfab3242528d40e967"
+SRC_URI[sha256sum] = "8d3b87e74895a569af835d4071b497934ab613e0e3d35cf41367df249d0a57d0"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Upgrade sensors binaries to version 1.2.0 using the latest codebase. Added target-specific runtime registry files for rb1corekit to enable sensor features on the device.