### PR TITLE
image_types_qcom: include soccp.bin and qsahara_device_programmer.xml

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -100,7 +100,9 @@ create_qcomflash_pkg() {
                 -name '*.fv' -o \
                 -name 'cdt_*.bin' -o \
                 -name 'logfs_*.bin' -o \
-                -name 'sec.dat'` ; do
+                -name 'qsahara_*.xml' -o \
+                -name 'sec.dat' -o \
+                -name 'soccp*.bin'` ; do
             install -m 0644 ${bfw} .
         done
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -21,6 +21,7 @@ do_deploy() {
     find "${S}" -maxdepth 1 -name '*.lzma' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    find "${S}" -maxdepth 1 -name 'qsahara_*.xml' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name '*.xz' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
 
     find "${UNPACKDIR}" -iname '*cdt*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;


### PR DESCRIPTION
Kaanapali uses qsahara_device_programmer.xml as device programmer while flashing, and soccp.bin file is flashed in soccp_a/b partiiton.
Including these files in the qcomflash directory.