### PR TITLE
ci: add testimage

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -193,6 +193,31 @@ jobs:
       kernel_dirname: ''
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
 
+  testimage-runs:
+    needs: [testimage, github-cache-check, compile-env]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        machine:
+          - testimage-run
+        distro:
+          - name: nodistro
+            yamlfile: ""
+    uses: ./.github/workflows/compile.yml
+    with:
+      run_on: arm64-metal
+      name: ${{ matrix.machine }}/${{ matrix.distro.name }}
+      world: false
+      machine: ${{matrix.machine}}
+      distro_yaml: ${{matrix.distro.yamlfile}}
+      distro_name: ${{matrix.distro.name}}
+      kernel_yaml: ''
+      kernel_dirname: ''
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+
   compile_warm_up:
     needs: [kas-setup, github-cache-check, compile-env]
     if: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -210,6 +210,7 @@ jobs:
     with:
       run_on: arm64-metal
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}
+      bblock: true
       world: false
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -169,6 +169,30 @@ jobs:
         run: |
           echo "CACHE_DIR=${{env.CACHE_DIR}}" >> $GITHUB_OUTPUT
 
+  testimage:
+    needs: [kas-setup, github-cache-check, compile-env]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        machine:
+          - testimage
+        distro:
+          - name: nodistro
+            yamlfile: ""
+    uses: ./.github/workflows/compile.yml
+    with:
+      name: ${{ matrix.machine }}/${{ matrix.distro.name }}
+      world: false
+      machine: ${{matrix.machine}}
+      distro_yaml: ${{matrix.distro.yamlfile}}
+      distro_name: ${{matrix.distro.name}}
+      kernel_yaml: ''
+      kernel_dirname: ''
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+
   compile_warm_up:
     needs: [kas-setup, github-cache-check, compile-env]
     if: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
+  KAS_IMAGE_VERSION: "latest"
 
 jobs:
   kas-setup:
@@ -38,8 +39,7 @@ jobs:
         run: |
           KAS_CONTAINER=$RUNNER_TEMP/kas-container
           echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
-          LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
-          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
+          wget -qO ${KAS_CONTAINER} https://github.com/siemens/kas/raw/refs/heads/master/kas-container
           chmod +x ${KAS_CONTAINER}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -41,6 +41,7 @@ on:
 
 env:
   KAS_CLONE_DEPTH: 1
+  KAS_IMAGE_VERSION: "latest"
 
 jobs:
   reusable_compile_job:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -68,8 +68,11 @@ jobs:
         shell: bash
         run: |
           KAS_CONTAINER=$RUNNER_TEMP/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           chmod +x $KAS_CONTAINER
+          if [ -c /dev/kvm ]; then
+            KAS_CONTAINER="$KAS_CONTAINER --kvm"
+          fi
+          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
 
       - name: Setup build variables
         shell: bash

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -9,6 +9,10 @@ on:
         required: false
         type: boolean
         default: false
+      bblock:
+        required: false
+        type: boolean
+        default: false
       target:
         required: false
         type: boolean
@@ -129,6 +133,12 @@ jobs:
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
           mv $KAS_WORK_DIR/build/buildstats* .
+
+      - name: Kas bblock
+        if: inputs.bblock
+        shell: bash
+        run: |
+          $KAS_CONTAINER shell ${KAS_YAMLS} --command "bblock qemu-system-native"
 
       - name: Kas build images
         if:  inputs.target

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: boolean
         default: true
+      run_on:
+        required: false
+        type: string
+        default: amd64
       name:
         required: true
         type: string
@@ -46,7 +50,7 @@ env:
 jobs:
   reusable_compile_job:
     if: inputs.enabled
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: [self-hosted, qcom-u2404, "${{ inputs.run_on }}"]
     name: ${{ inputs.name }}
     steps:
       - uses: actions/checkout@v6

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -24,3 +24,5 @@ overrides:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
             commit: 60e38e2015f19058b467febd044f49bf70c4528f
+        meta-yocto:
+            commit: 366fa2f21bfb0d9c4de492e0204a0dd38ce241ab

--- a/ci/genericarm64.yml
+++ b/ci/genericarm64.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+local_conf_header:
+  cmdline: |
+  qcomflash: |
+  qemu: |
+    # runqemu snapshot slirp nographic
+    EXTRA_IMAGEDEPENDS = "u-boot"
+
+repos:
+  meta-yocto:
+    url: https://github.com/yoctoproject/meta-yocto
+    branch: master
+    layers:
+      meta-yocto-bsp:
+
+machine: genericarm64

--- a/ci/testimage-run.yml
+++ b/ci/testimage-run.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/testimage.yml
+
+local_conf_header:
+  test: |
+    # running tests automatically
+    TESTIMAGE_AUTO = "1"
+    # change qemu defaults
+    TEST_QEMUBOOT_TIMEOUT = "180"
+    TEST_RUNQEMUPARAMS = "snapshot slirp nographic"
+    # ptests are expected to fail
+    PTEST_EXPECT_FAILURE = '1'
+    # RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectfail: EXPECTEDFAIL (9633.62s)
+    #TEST_SUITES:remove = "ptest"
+    # RESULTS - systemd.SystemdBasicTests.test_systemd_failed: FAILED (3.17s)
+    #TEST_SUITES:remove = "systemd"
+    # minimal test suite
+    #TEST_SUITES = "ping ssh parselogs"
+
+# NOTE: to run specific PKG ptest
+#target:
+#  - core-image-ptest-[PKG]

--- a/ci/testimage.yml
+++ b/ci/testimage.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/genericarm64.yml
+
+local_conf_header:
+  ptest: |
+    # install ptest pkgs
+    EXTRA_IMAGE_FEATURES += "ptest-pkgs"
+  testimage: |
+    # enable testimage for the target image excluding initramfs
+    IMAGE_CLASSES += "testimage"
+    IMAGE_CLASSES:remove:pn-core-image-initramfs-boot = "testimage"
+    # test requirements: ssh scp
+    #CORE_IMAGE_EXTRA_INSTALL += "dropbear"
+    CORE_IMAGE_EXTRA_INSTALL += "openssh-sshd"
+    # test requirements: parselogs
+    CORE_IMAGE_EXTRA_INSTALL += "openssh-sftp-server"


### PR DESCRIPTION
The build system has the ability to run a series of automated tests for qemu images.
All the tests are actually commands run on the target system over ssh.
The tests themselves are written in Python, making use of the unittest module.
The class that enables this is testimage.bbclass (which handles loading the tests and starting the qemu image)

For now it runs the default tests definded upstream in oe-core, The "SKIPPED" tests are due to missing packages in the image. I would prefer to start with the default definition and then adapt it to our needs.

```
INFO     - RESULTS:
INFO     - RESULTS - date.DateTest.test_date: PASSED (4.00s)
INFO     - RESULTS - df.DfTest.test_df: PASSED (0.59s)
INFO     - RESULTS - oe_syslog.SyslogTest.test_syslog_running: PASSED (0.60s)
INFO     - RESULTS - oe_syslog.SyslogTestConfig.test_syslog_logger: PASSED (1.95s)
INFO     - RESULTS - oe_syslog.SyslogTestConfig.test_syslog_restart: PASSED (0.97s)
INFO     - RESULTS - pam.PamBasicTest.test_pam: PASSED (2.26s)
INFO     - RESULTS - parselogs.ParseLogsTest.test_get_context: PASSED (0.00s)
INFO     - RESULTS - parselogs.ParseLogsTest.test_parselogs: PASSED (2.77s)
INFO     - RESULTS - perl.PerlTest.test_perl_works: PASSED (0.57s)
INFO     - RESULTS - ping.PingTest.test_ping: PASSED (0.00s)
INFO     - RESULTS - python.PythonTest.test_python3: PASSED (0.60s)
INFO     - RESULTS - scp.ScpTest.test_scp_file: PASSED (1.12s)
INFO     - RESULTS - ssh.SSHTest.test_ssh: PASSED (0.56s)
INFO     - RESULTS - systemd.SystemdBasicTests.test_systemd_basic: PASSED (0.55s)
INFO     - RESULTS - systemd.SystemdBasicTests.test_systemd_failed: PASSED (1.12s)
INFO     - RESULTS - systemd.SystemdBasicTests.test_systemd_list: PASSED (1.24s)
INFO     - RESULTS - systemd.SystemdJournalTests.test_systemd_boot_time: PASSED (0.57s)
INFO     - RESULTS - systemd.SystemdJournalTests.test_systemd_journal: PASSED (0.56s)
INFO     - RESULTS - systemd.SystemdServiceTests.test_systemd_disable_enable: PASSED (2.99s)
INFO     - RESULTS - systemd.SystemdServiceTests.test_systemd_status: PASSED (0.57s)
INFO     - RESULTS - systemd.SystemdServiceTests.test_systemd_stop_start: PASSED (2.20s)
INFO     - RESULTS - apt.AptRepoTest.test_apt_install_from_repo: SKIPPED (0.00s)
INFO     - RESULTS - buildcpio.BuildCpioTest.test_cpio: SKIPPED (0.00s)
INFO     - RESULTS - buildgalculator.GalculatorTest.test_galculator: SKIPPED (0.00s)
INFO     - RESULTS - buildlzip.BuildLzipTest.test_lzip: SKIPPED (0.00s)
INFO     - RESULTS - connman.ConnmanTest.test_connmand_help: SKIPPED (0.00s)
INFO     - RESULTS - connman.ConnmanTest.test_connmand_running: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfBasicTest.test_dnf_help: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfBasicTest.test_dnf_history: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfBasicTest.test_dnf_info: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfBasicTest.test_dnf_search: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfBasicTest.test_dnf_version: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_exclude: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_install: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_install_dependency: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_install_from_disk: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_install_from_http: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_installroot: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_installroot_usrmerge: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_makecache: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_reinstall: SKIPPED (0.00s)
INFO     - RESULTS - dnf.DnfRepoTest.test_dnf_repoinfo: SKIPPED (0.00s)
INFO     - RESULTS - gcc.GccCompileTest.test_gcc_compile: SKIPPED (0.00s)
INFO     - RESULTS - gcc.GccCompileTest.test_gpp2_compile: SKIPPED (0.00s)
INFO     - RESULTS - gcc.GccCompileTest.test_gpp_compile: SKIPPED (0.00s)
INFO     - RESULTS - gcc.GccCompileTest.test_make: SKIPPED (0.00s)
INFO     - RESULTS - gi.GObjectIntrospectionTest.test_python: SKIPPED (0.00s)
INFO     - RESULTS - go.CgoHelloworldTest.test_cgohelloworld: SKIPPED (0.00s)
INFO     - RESULTS - go.GoCompileTest.test_go_compile: SKIPPED (0.00s)
INFO     - RESULTS - go.GoCompileTest.test_go_module: SKIPPED (0.00s)
INFO     - RESULTS - go.GoHelloworldTest.test_gohelloworld: SKIPPED (0.00s)
INFO     - RESULTS - kernelmodule.KernelModuleTest.test_kernel_module: SKIPPED (0.00s)
INFO     - RESULTS - ldd.LddTest.test_ldd: SKIPPED (0.00s)
INFO     - RESULTS - logrotate.LogrotateTest.test_logrotate_newlog: SKIPPED (0.00s)
INFO     - RESULTS - logrotate.LogrotateTest.test_logrotate_wtmp: SKIPPED (0.00s)
INFO     - RESULTS - oe_syslog.SyslogTestConfig.test_syslog_startup_config: SKIPPED (0.00s)
INFO     - RESULTS - opkg.OpkgRepoTest.test_opkg_install_from_repo: SKIPPED (0.00s)
INFO     - RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectsuccess: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmBasicTest.test_rpm_help: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmBasicTest.test_rpm_query: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmBasicTest.test_rpm_query_nonroot: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmInstallRemoveTest.test_check_rpm_install_removal_log_file_size: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmInstallRemoveTest.test_rpm_install: SKIPPED (0.00s)
INFO     - RESULTS - rpm.RpmInstallRemoveTest.test_rpm_remove: SKIPPED (0.00s)
INFO     - RESULTS - rust.RustCLibExampleTest.test_rust_c_lib_example: SKIPPED (0.00s)
INFO     - RESULTS - rust.RustCompileTest.test_cargo_compile: SKIPPED (0.00s)
INFO     - RESULTS - rust.RustCompileTest.test_rust_compile: SKIPPED (0.00s)
INFO     - RESULTS - stap.StapTest.test_stap: SKIPPED (0.00s)
INFO     - RESULTS - systemd.SystemdServiceTests.test_systemd_coredump_minidebuginfo: SKIPPED (0.00s)
INFO     - RESULTS - systemd.SystemdServiceTests.test_systemd_disable_enable_ro: SKIPPED (0.00s)
INFO     - RESULTS - weston.WestonTest.test_wayland_info: SKIPPED (0.00s)
INFO     - RESULTS - weston.WestonTest.test_weston_can_initialize_new_wayland_compositor: SKIPPED (0.00s)
INFO     - RESULTS - weston.WestonTest.test_weston_running: SKIPPED (0.00s)
INFO     - RESULTS - weston.WestonTest.test_weston_supports_xwayland: SKIPPED (0.00s)
INFO     - RESULTS - xorg.XorgTest.test_xorg_running: SKIPPED (0.00s)
INFO     - RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectfail: EXPECTEDFAIL (2254.14s)
INFO     - SUMMARY:
INFO     - core-image-base () - Ran 76 tests in 2280.013s
INFO     - core-image-base - OK - All required tests passed (successes=21, skipped=54, failures=0, errors=0)
```

Depends on https://github.com/qualcomm-linux/meta-qcom/pull/2688