### PR TITLE
ci/qcom-distro: Include meta-dpdk layer

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -294,6 +294,14 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: iq-9075-evk
+            distro:
+                name: qcom-distro-dpdk
+                yamlfile: ':ci/qcom-distro.yml:ci/dpdk.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: iq-8275-evk
             distro:
                 name: qcom-distro-kvm

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -20,3 +20,5 @@ overrides:
             commit: a8af24357121dc8614fd98f234b73d55005b0cc9
         meta-security:
             commit: 9265f142f3890df2d00d71d13b19e95a082707ed
+        meta-dpdk:
+            commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -20,3 +20,5 @@ overrides:
             commit: d713c99a9ddace090c0efc0ed57022185daa6fb2
         meta-security:
             commit: 596b966a0d047c2f48cb768821558e918ae0c477
+        meta-dpdk:
+            commit: 6a44b68cd579405534dac9d0ca4a281e9b239736

--- a/ci/dpdk.yml
+++ b/ci/dpdk.yml
@@ -1,0 +1,7 @@
+header:
+  version: 14
+
+repos:
+  meta-dpdk:
+    branch: master
+    url: https://git.yoctoproject.org/meta-dpdk

--- a/ci/dpdk.yml
+++ b/ci/dpdk.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+
+repos:
+  meta-dpdk:
+    branch: master
+    url: https://git.yoctoproject.org/meta-dpdk
+    layers:
+      .:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -51,3 +51,4 @@ target:
   - qcom-multimedia-image
   - qcom-multimedia-proprietary-image
   - qcom-container-orchestration-image
+  - qcom-networking-image

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -53,3 +53,4 @@ target:
   - qcom-multimedia-image
   - qcom-multimedia-proprietary-image
   - qcom-container-orchestration-image
+  - qcom-networking-image


### PR DESCRIPTION
Including the meta-dpdk layer in Qualcomm Distro.