### PR TITLE
ci/ci: use the same package manager for all builds

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -10,3 +10,4 @@ local_conf_header:
     BB_SIGNATURE_HANDLER = "OEBasicHash"
     FIRMWARE_COMPRESSION:qcom-armv8a = "zst"
     INHERIT:remove = "rm_work"
+    PACKAGE_CLASSES = "package_rpm"


### PR DESCRIPTION
Currently we are using rpm in qcom-distro and ipk in nodistro.
This causes non-determinism between distributions and has implications in
build performance. Basically, we can't use packages in sstate-cache from
distro1 in distro2, and everything has to be recompiled.