### PR TITLE
Revert "Enabled hardening configs default to build. (#1223)"

### DIFF
--- a/recipes-kernel/linux/linux-qcom-6.18/configs/bsp-additions.cfg
+++ b/recipes-kernel/linux/linux-qcom-6.18/configs/bsp-additions.cfg
@@ -314,5 +314,3 @@ CONFIG_NFT_TPROXY=m
 CONFIG_NFT_TUNNEL=m
 CONFIG_PACKET_DIAG=y
 CONFIG_VETH=m
-# Disable stack erase plugin to avoid buildpath leakage in out-of-tree modules
-CONFIG_KSTACK_ERASE=n

--- a/recipes-kernel/linux/linux-qcom-next/configs/bsp-additions.cfg
+++ b/recipes-kernel/linux/linux-qcom-next/configs/bsp-additions.cfg
@@ -314,5 +314,3 @@ CONFIG_NFT_TPROXY=m
 CONFIG_NFT_TUNNEL=m
 CONFIG_PACKET_DIAG=y
 CONFIG_VETH=m
-# Disable stack erase plugin to avoid buildpath leakage in out-of-tree modules
-CONFIG_KSTACK_ERASE=n

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -36,7 +36,7 @@ S = "${UNPACKDIR}/${BP}"
 KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qcom-armv7a = "qcom_defconfig"
 
-KBUILD_CONFIG_EXTRA = "${S}/kernel/configs/hardening.config"
+KBUILD_CONFIG_EXTRA = "${@bb.utils.contains('DISTRO_FEATURES', 'hardened', '${S}/kernel/configs/hardening.config', '', d)}"
 KBUILD_CONFIG_EXTRA:append:aarch64 = " ${S}/arch/arm64/configs/prune.config"
 KBUILD_CONFIG_EXTRA:append:aarch64 = " ${S}/arch/arm64/configs/qcom.config"
 KBUILD_CONFIG_EXTRA:append = " ${@oe.utils.vartrue('DEBUG_BUILD', '${S}/kernel/configs/debug.config', '', d)}"

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -39,7 +39,7 @@ S = "${UNPACKDIR}/${BP}"
 KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qcom-armv7a = "qcom_defconfig"
 
-KBUILD_CONFIG_EXTRA = "${S}/kernel/configs/hardening.config"
+KBUILD_CONFIG_EXTRA = "${@bb.utils.contains('DISTRO_FEATURES', 'hardened', '${S}/kernel/configs/hardening.config', '', d)}"
 KBUILD_CONFIG_EXTRA:append:aarch64 = " ${S}/arch/arm64/configs/prune.config"
 KBUILD_CONFIG_EXTRA:append:aarch64 = " ${S}/arch/arm64/configs/qcom.config"
 KBUILD_CONFIG_EXTRA:append = " ${@oe.utils.vartrue('DEBUG_BUILD', '${S}/kernel/configs/debug.config', '', d)}"


### PR DESCRIPTION
This reverts commit de6bff83d8f885f6a5714f9eca14fa6210dcdbcc, reversing changes made to 22261fd965dcecb642d500ef57ea6dd3c9d1d6ce.

Reverting as this broke boot tests on qcs8300-ride-sx (from the cambridge lab).