### PR TITLE
Enable the QPS615 Ethernet driver on supported boards (for the LTS kernel)

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -22,6 +22,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-8275-evk-hexagon-dsp-binaries \
     qairt-sdk-hexagon-v75 \
     qcom-fastcv-binaries-qcs8300-ride-dsp \
+    qps615-dlkm \
 "
 
 QCOM_CDT_FILE = "cdt_qcs8275_iq_8275_evk_pro_sku"

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -23,6 +23,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-9075-evk-hexagon-dsp-binaries \
     qairt-sdk-hexagon-v73 \
     qcom-fastcv-binaries-sa8775p-ride-dsp \
+    qps615-dlkm \
 "
 
 QCOM_CDT_FILE = "cdt_rb8_core_kit"

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -93,4 +93,5 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \
     packagegroup-rb5-firmware \
     packagegroup-sm8750-mtp-firmware \
+    qps615-dlkm \
 "

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -24,6 +24,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-industrial-mezzanine-firmware \
     qairt-sdk-hexagon-v68 \
     qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
+    qps615-dlkm \
 "
 
 QCOM_CDT_FILE = "cdt_core_kit"

--- a/recipes-kernel/qps615-module/qps615-dlkm_6.0.1.bb
+++ b/recipes-kernel/qps615-module/qps615-dlkm_6.0.1.bb
@@ -31,3 +31,4 @@ B = "${S}/drivers/net/ethernet/toshiba/tc956x"
 # Therefore, pf=1 needs to be set while compiling for non-SRIOV VF config.
 EXTRA_OEMAKE += "KCFLAGS='-DTC956X -DCONFIG_TC956X_PLATFORM_SUPPORT -DTC956X_SRIOV_PF' pf=1"
 
+RDEPENDS:${PN} += "qps615-firmware"


### PR DESCRIPTION
Thank you for the comments on the meta-qcom-distro PR. This is again an RFC of sorts.

There's a product requirement to enable the QPS615 ethernet driver for QLI 2.0. The official Toshiba driver only supports kernel 6.6 and had to be patched to compile on the 6.18 kernel. The recipe + patches were recently merged on meta-qcom (the PRs have also been submitted to the upstream repo).

This change adds kernel-module-tc956x-pcie-eth to the SOC packagegroups for the boards that have the QPS615 chip connected over PCIe:
  - IQ-9 EVK IFP Mezz (qcs9100)
  - IQ-8 EVK IFP Mezz (qcs8300)
  - Rb3Gen2 Core Kit / Industrial Kit (qcs6490)

Additionally, it adds RDEPENDS for qps615-firmware in the qps615-dlkm recipe so that the QPS615 firmware is automatically installed alongside the driver.

**Exception details:** Until the QPS615 driver is upstreamed to the kernel (third party ETA: end of 2026), an exception has been approved to include the driver as an out of tree DLKM (QLIJIRA-99) for QLI 2.0.