### PR TITLE
modemmanager: enable QRTR/MHI-based external modem support on RBx platforms

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/files/0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch
@@ -1,0 +1,95 @@
+From a611705c361361594b04bf3a708552cd56453886 Mon Sep 17 00:00:00 2001
+From: Mrigank Dembla <mdembla@qti.qualcomm.com>
+Date: Thu, 9 Apr 2026 18:05:30 +0530
+Subject: [PATCH] qcom-soc: add QRTR/MHI-based modem support
+
+Enable proper support for Qualcomm PCIe/MHI-based modems that expose
+control and data interfaces via QRTR and the WWAN subsystem instead of
+USB.
+
+The changes include:
+- Restore opt-in handling for WWAN devices and explicitly enable only
+  valid WWAN control ports (QMI, MBIM, QCDM, AT) to avoid incorrect
+modem
+  grouping.
+- Recognize mhi_net as a valid Qualcomm data interface in the qcom-soc
+  plugin and udev rules.
+- Allow QMI bearers to operate correctly over mhi_net data ports.
+- Enable QMI data endpoint selection for MHI-backed net devices.
+
+This allows ModemManager to correctly detect, group, and operate
+QRTR + MHI based external PCIe modems, matching how USB-based Qualcomm
+modems are already supported.
+
+Tested on Qualcomm PCIe/MHI modem platforms SDX35 using QRTR transport.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1443]
+
+Signed-off-by: Mrigank Dembla <mdembla@qti.qualcomm.com>
+---
+ src/80-mm-candidate.rules                              | 9 ++++++++-
+ src/mm-bearer-qmi.c                                    | 2 ++
+ src/plugins/qcom-soc/77-mm-qcom-soc.rules              | 1 +
+ src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c | 2 +-
+ 4 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/80-mm-candidate.rules b/src/80-mm-candidate.rules
+index a9c5a6ea..5e4467f3 100644
+--- a/src/80-mm-candidate.rules
++++ b/src/80-mm-candidate.rules
+@@ -28,6 +28,13 @@ KERNEL=="cdc-wdm*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
+ #    the "wwan_dev" device type (full device, not just one port)
+ SUBSYSTEMS=="usb", GOTO="mm_candidate_end"
+ SUBSYSTEM=="wwan", ENV{DEVTYPE}=="wwan_dev", GOTO="mm_candidate_end"
+-SUBSYSTEM=="wwan", ENV{ID_MM_CANDIDATE}="1"
++SUBSYSTEM=="wwan", ENV{ID_MM_CANDIDATE}="0", GOTO="mm_candidate_end"
++
++SUBSYSTEM=="wwan", ATTR{type}=="AT", ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
++SUBSYSTEM=="wwan", ATTR{type}=="MBIM", ENV{ID_MM_PORT_TYPE_MBIM}="1"
++SUBSYSTEM=="wwan", ATTR{type}=="QMI", ENV{ID_MM_PORT_TYPE_QMI}="1"
++SUBSYSTEM=="wwan", ATTR{type}=="QCDM", ENV{ID_MM_PORT_TYPE_QCDM}="1"
++SUBSYSTEM=="wwan", ATTR{type}=="FIREHOSE", ENV{ID_MM_PORT_IGNORE}="1"
++
+ 
+ LABEL="mm_candidate_end"
+diff --git a/src/mm-bearer-qmi.c b/src/mm-bearer-qmi.c
+index 64d983eb..301c0a6b 100644
+--- a/src/mm-bearer-qmi.c
++++ b/src/mm-bearer-qmi.c
+@@ -2445,6 +2445,8 @@ load_settings_from_bearer (MMBearerQmi         *self,
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUESTED;
+         else if (!g_strcmp0 (data_port_driver, "ipa"))
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUIRED;
++	else if (!g_strcmp0 (data_port_driver, "mhi_net"))
++	    ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_REQUESTED;	
+         else
+             ctx->multiplex = MM_BEARER_MULTIPLEX_SUPPORT_NONE;
+     }
+diff --git a/src/plugins/qcom-soc/77-mm-qcom-soc.rules b/src/plugins/qcom-soc/77-mm-qcom-soc.rules
+index 9719f96f..d4e50be8 100644
+--- a/src/plugins/qcom-soc/77-mm-qcom-soc.rules
++++ b/src/plugins/qcom-soc/77-mm-qcom-soc.rules
+@@ -5,6 +5,7 @@ ACTION!="add|change|move|bind", GOTO="mm_qcom_soc_end"
+ # Process only known wwan, net and rpmsg ports
+ SUBSYSTEM=="net",   DRIVERS=="bam-dmux",      GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="net",   DRIVERS=="ipa",           GOTO="mm_qcom_soc_process"
++SUBSYSTEM=="net",   DRIVERS=="mhi_net",       GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="wwan",  DRIVERS=="qcom-q6v5-mss", GOTO="mm_qcom_soc_process"
+ SUBSYSTEM=="rpmsg", DRIVERS=="qcom-q6v5-mss", GOTO="mm_qcom_soc_process"
+ GOTO="mm_qcom_soc_end"
+diff --git a/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c b/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
+index fa19bd4d..bd388e0f 100644
+--- a/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
++++ b/src/plugins/qcom-soc/mm-broadband-modem-qmi-qcom-soc.c
+@@ -125,7 +125,7 @@ peek_port_qmi_for_data (MMBroadbandModemQmi  *self,
+     net_port = mm_port_peek_kernel_device (data);
+     net_port_driver = mm_kernel_device_get_driver (net_port);
+ 
+-    if (g_strcmp0 (net_port_driver, "ipa") == 0)
++    if (g_strcmp0 (net_port_driver, "ipa") == 0 || g_strcmp0 (net_port_driver, "mhi_net") == 0)
+         return peek_port_qmi_for_data_ipa (self, data, out_endpoint, error);
+ 
+     if (g_strcmp0 (net_port_driver, "bam-dmux") == 0)
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -15,5 +15,5 @@ SRC_URI:append:qcom = " \
     file://0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch \
     file://0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch \
     file://0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch \
-    file://0011-enable-modemmanager-mhi-support.patch \
+    file://0001-qcom-soc-add-QRTR-MHI-based-modem-support.patch \
 "

--- a/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -15,4 +15,5 @@ SRC_URI:append:qcom = " \
     file://0008-whitespace-fixes-and-adjust-some-sms-storage-functio.patch \
     file://0009-sms-storage-do-hex-binary-conversion-in-sms-storage.patch \
     file://0010-sms-storage-Add-slot-info-for-TA-SMS-in-DB.patch \
+    file://0011-enable-modemmanager-mhi-support.patch \
 "


### PR DESCRIPTION
This PR supersedes #1728.

PR #1728 was auto‑closed when the source branch temporarily matched
meta‑qcom master during a refresh. This PR continues the same work,
rebased onto current master, with additional updates.

Enable ModemManager support for Qualcomm RB3Gen2 (industrial kit), RB4,
and RB8 (core kit + mezzanine) platforms using externally attached M.2
modems exposed via PCIe/MHI and QRTR.

This change extends the qcom‑soc ModemManager integration to recognize
`mhi_net`‑based data interfaces alongside existing `ipa` support,
allowing external SDX modems (e.g. SDX35) to be detected and used for
data calls via ModemManager.

The current implementation intentionally targets single external modem
configurations, which are sufficient to enable cellular data
functionality on the above platforms for this release. A more generic
solution covering multiple concurrently attached SDX modems requires
additional kernel and ModemManager changes and broader hardware
validation, and is being worked on separately.

Without this enablement, ModemManager cannot detect MHI‑attached
external modems on these platforms, preventing cellular data bring‑up
on otherwise supported hardware configurations.

This change provides minimal, platform‑scoped support for the current
meta‑qcom release, without precluding future refinement as multi‑modem
support is stabilized.