### PR TITLE
Add devicetree overlays to support QPS615 on Rb3Gen2, IQ-8275 IFP Mezz and IQ-9075 IFP Mezz

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -39,6 +39,7 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-evk-staging] = " \
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subtype3"
+FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine+monaco-evk-staging] = "qcom,qcs8275-iot-subtype3-staging"
 FIT_DTB_COMPATIBLE[purwa-iot-evk] = "qcom,purwa-evk"
 FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"
 FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo] = "qcom,apq8064"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -56,6 +56,10 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
     qcom,qcs5430-iot \
     qcom,qcs6490-iot \
 "
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-staging] = " \
+    qcom,qcs5430-iot-staging \
+    qcom,qcs6490-iot-staging \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
     qcom,qcs5430-iot-subtype9 \
     qcom,qcs6490-iot-subtype9 \

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -32,6 +32,10 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine] = " \
     qcom,qcs9075-iot-subtype1 \
     qcom,qcs9075v2-iot-subtype1 \
 "
+FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-evk-staging] = " \
+    qcom,qcs9075-iot-subtype1-staging \
+    qcom,qcs9075v2-iot-subtype1-staging \
+"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subtype3"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk-camx.dtbo \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
+                      qcom/monaco-evk-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -16,6 +16,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-el2.dtbo \
                       qcom/lemans-evk-camx.dtbo \
                       qcom/lemans-evk-ifp-mezzanine.dtbo \
+                      qcom/lemans-evk-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -16,6 +16,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-vision-mezzanine-camx.dtbo \
+                      qcom/qcs6490-rb3gen2-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
This series adds Device Tree overlay (DTBO) support for the QPS615 PCIe Ethernet switch across three Qualcomm platforms. The QPS615 is a PCIe switch with dual Ethernet ports, present on the IFP Mezzanine board (IQ-9075 EVK and IQ-8275 EVK) and integrated on the RB3Gen2 Core Kit. Its Ethernet functionality is enabled by an out-of-tree kernel driver (qps615-dlkm) that requires platform-specific devicetree properties to access hardware resources.

These are "staging" DTBOs due to their downstream nature, they live in the LINUX_QCOM_KERNEL_DEVICETREE list and are referenced via FIT_DTB_COMPATIBLE overlay combinations in the FIT image.

The changes are 3 pairs - one pair each for Rb3Gen2, IQ-9075 EVK IFP Mezz and IQ-8275 EVK Mezz. For each pair, one commit updates `fit-dtb-compatible.inc` to register the staging overlay combination, and the second adds the DTBO to the machine configuration:

**Exception details:** Until the QPS615 driver is upstreamed to the kernel (third party ETA: end of 2026), an exception has been approved to include the driver + DT overlay (QLIJIRA-99).