### PR TITLE
mount-tee-partition: fix early-boot format/mount ordering cycle

### DIFF
--- a/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
+++ b/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
@@ -4,11 +4,11 @@
 
 [Unit]
 Description=Create ext4 filesystem on persist partition if missing
+DefaultDependencies=no
 Requires=dev-disk-by\x2dpartlabel-persist.device
 After=dev-disk-by\x2dpartlabel-persist.device
 ConditionPathExists=/dev/disk/by-partlabel/persist
 Before=var-lib-tee.mount
-Wants=var-lib-tee.mount
 ConditionPathIsMountPoint=!/var/lib/tee
 
 [Service]

--- a/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
+++ b/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
@@ -5,8 +5,6 @@
 [Unit]
 Description=Mount persist partition at /var/lib/tee
 Before=local-fs.target sfsconfig.service
-Requires=format-tee-partition.service
-After=format-tee-partition.service
 
 [Mount]
 DirectoryMode=0755


### PR DESCRIPTION
Remove mutual Wants/Requires dependencies between
format-tee-partition.service and var-lib-tee.mount and rely on ordering-only logic to enforce format before mount.

Also disable DefaultDependencies for format-tee-partition, as units started from local-fs-pre.target should not implicitly depend on basic.target. The default dependency added an ordering loop involving basic.target, local-fs.target, and var-lib-tee.mount, causing early-boot services to be skipped.

With this change, format is guaranteed to run before the persist partition is mounted, without creating systemd ordering cycles during boot.