### PR TITLE
ci: make PR origin available for forked pull request workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  actions: read
 
 jobs:
   event-file:
@@ -23,6 +24,15 @@ jobs:
       with:
         name: Event File
         path: ${{ github.event_path }}
+        
+  pr-to-workflow-dependency:
+    name: "PR To Workflow Dependency"
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qswat-reusable-pr-to-workflow-dependency.yml@qswat-release-v1
+    with:
+      workflow_id: ${{ github.run_id }}
+      run_attempt: ${{ github.run_attempt }}
+      pr_number: ${{ github.event.pull_request.number }}
+      
   build-pr:
     uses: ./.github/workflows/build-yocto.yml
     with:


### PR DESCRIPTION
Problem: Downstream automation needs to determine which pull request
triggered a CI workflow run so that validation results can be associated
with the correct submission and used to drive subsequent CR state
transitions. This requires access to the source PR, including repository
and branch information. Without this data, workflow runs cannot be
reliably linked to the pull request that caused them, preventing correct
CR state updates.

For pull requests originating from forks, workflow completion events do
not consistently expose enough information to establish this association.

Approaches considered: Several fields provided by the GitHub workflow run
API appear suitable but cannot be relied on as a stable solution.

The .pull_requests[] field is not consistently populated for workflows
triggered from forked repositories.

The referenced_workflows[].ref field is optional and depends on workflow
topology. It only resolves to PR-style references when reusable workflows
are present and reside in the same repository. If reusable workflows are
moved to a shared repository, or if multiple reusable workflows are involved,
the reference resolves to a branch or becomes ambiguous.

As a result, none of the available metadata fields provide a reliable way to
determine the originating pull request for forked workflows across different
CI configurations.

Solution: To ensure reliable PR identification, the required PR context is
made available explicitly at workflow runtime. This provides a stable and
predictable source of PR origin information, independent of repository
layout, reusable workflow structure, or future CI refactoring.