### PR TITLE
systemd: prevent boot hang when EFI partition is not ready

### DIFF
--- a/recipes-core/systemd/systemd/systemd-boot-random-seed.service.d/override.conf
+++ b/recipes-core/systemd/systemd/systemd-boot-random-seed.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+Requires=efi.mount
+After=efi.mount
+BindsTo=efi.mount
+
+[Service]
+TimeoutStartSec=30s

--- a/recipes-core/systemd/systemd/systemd-boot-update.service.d/override.conf
+++ b/recipes-core/systemd/systemd/systemd-boot-update.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+Requires=efi.mount
+After=efi.mount
+BindsTo=efi.mount
+
+[Service]
+TimeoutStartSec=30s

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,6 +1,10 @@
 FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}:"
 
-SRC_URI:append:qcom = " file://99-dma-heap.rules"
+SRC_URI:append:qcom = " \
+    file://99-dma-heap.rules \
+    file://systemd-boot-update.service.d/override.conf \
+    file://systemd-boot-random-seed.service.d/override.conf \
+"
 
 # Create a group dmaheap and add this group to /dev/dma_heap/system through
 # dma-heap rules.
@@ -10,6 +14,19 @@ do_install:append:qcom() {
     install -d ${D}${nonarch_libdir}/udev/rules.d
     install -m 0644 ${UNPACKDIR}/99-dma-heap.rules \
         ${D}${nonarch_libdir}/udev/rules.d/
+
+    install -d ${D}${systemd_system_unitdir}/systemd-boot-update.service.d
+    install -m 0644 ${UNPACKDIR}/systemd-boot-update.service.d/override.conf \
+        ${D}${systemd_system_unitdir}/systemd-boot-update.service.d/override.conf
+
+    install -d ${D}${systemd_system_unitdir}/systemd-boot-random-seed.service.d
+    install -m 0644 ${UNPACKDIR}/systemd-boot-random-seed.service.d/override.conf \
+        ${D}${systemd_system_unitdir}/systemd-boot-random-seed.service.d/override.conf
 }
+
+FILES:${PN}:append:qcom = " \
+    ${systemd_system_unitdir}/systemd-boot-update.service.d/override.conf \
+    ${systemd_system_unitdir}/systemd-boot-random-seed.service.d/override.conf \
+"
 
 FILES:${PN}-udev-rules:append:qcom = " ${nonarch_libdir}/udev/rules.d/99-dma-heap.rules"


### PR DESCRIPTION
System occasionally hangs during early boot
because systemd-boot-update.service and systemd-boot-random-seed.service can block indefinitely when /efi is not mountable.

Add drop-in overrides to bind these services to efi.mount with a 30s timeout, preventing indefinite hangs while preserving normal behavior when EFI is healthy.

Fixes: https://github.com/qualcomm-linux/meta-qcom/issues/1709