### PR TITLE
minkipc: pack TA in its own package

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.4.bb
@@ -44,14 +44,6 @@ PACKAGE_BEFORE_PN += "${PN}-qteesupplicant"
 SYSTEMD_PACKAGES = "${PN}-qteesupplicant"
 SYSTEMD_SERVICE:${PN}-qteesupplicant = "qteesupplicant.service sfsconfig.service"
 
-FILES:${PN}-qteesupplicant = "${bindir}/qtee_supplicant \
-                              ${nonarch_libdir}/udev/rules.d/99-qcomtee-udev.rules \
-                              ${base_bindir}/sfs_config \
-"
-
-RDEPENDS:${PN}-qteesupplicant = "${PN}"
-RRECOMMENDS:${PN}-qteesupplicant = "mount-tee-partition"
-
 do_install:append() {
        mkdir -p ${D}${nonarch_base_libdir}/qtee-tas
        cp -R ${S}/ta/* ${D}${nonarch_base_libdir}/qtee-tas/
@@ -62,3 +54,9 @@ do_install:append() {
 
 FILES:${PN} += "${nonarch_base_libdir}/qtee-tas"
 
+FILES:${PN}-qteesupplicant = "${bindir}/qtee_supplicant \
+                              ${nonarch_libdir}/udev/rules.d/99-qcomtee-udev.rules \
+                              ${base_bindir}/sfs_config \
+"
+RDEPENDS:${PN}-qteesupplicant = "${PN}"
+RRECOMMENDS:${PN}-qteesupplicant = "mount-tee-partition"

--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.4.bb
@@ -41,6 +41,8 @@ EXTRA_OECMAKE = " \
 
 PACKAGE_BEFORE_PN += "${PN}-qteesupplicant"
 
+PACKAGES += "${PN}-ta"
+
 SYSTEMD_PACKAGES = "${PN}-qteesupplicant"
 SYSTEMD_SERVICE:${PN}-qteesupplicant = "qteesupplicant.service sfsconfig.service"
 
@@ -52,7 +54,9 @@ do_install:append() {
        rm ${D}${nonarch_base_libdir}/qtee-tas/NO.LOGIN.BINARY.LICENSE.QTI.pdf
 }
 
-FILES:${PN} += "${nonarch_base_libdir}/qtee-tas"
+FILES:${PN}-ta += "${nonarch_base_libdir}/qtee-tas"
+RDEPENDS:${PN} = "${PN}-ta"
+INSANE_SKIP:${PN}-ta += "arch"
 
 FILES:${PN}-qteesupplicant = "${bindir}/qtee_supplicant \
                               ${nonarch_libdir}/udev/rules.d/99-qcomtee-udev.rules \


### PR DESCRIPTION
Packing the TA are failing on armv7 as the prebuild arch did not match.
Adding a new package where the arch was skiped for testing solves the problem.

Fixes the following package QA Issue:
```
ERROR: minkipc-1.2.4-r0 do_package_qa: QA Issue: Architecture did not match (AArch64, expected ARM) in /usr/lib/qtee-tas/qcs8300/FD02C9DA-306C-48C7-A49C-BBD827AE86EE.mbn [arch]
ERROR: minkipc-1.2.4-r0 do_package_qa: QA Issue: Bit size did not match (64, expected 32) in /usr/lib/qtee-tas/qcs8300/FD02C9DA-306C-48C7-A49C-BBD827AE86EE.mbn [arch]
```