### PR TITLE
Pin upstream layer commits for RC3 preparation

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -1,0 +1,24 @@
+header:
+    version: 14
+overrides:
+    repos:
+        oe-core:
+            commit: f235ffc43c7783a84e1ac0dce8489fcba8354e12
+        bitbake:
+            commit: 5d722b5d65e4eef7befe6376983385421e993f86
+        meta-arm:
+            commit: d987a5945802dcbbc06be91a0d34f00431ea840e
+        meta-qcom-distro:
+            commit: dc4051f119c08e081dfa932567ee6d88f32d1c54
+        meta-openembedded:
+            commit: 96a803a50d55a455b0584d8a81168351d0f8c697
+        meta-virtualization:
+            commit: 4e6c583591c1da7e898254dd33eca5cc04c739a9
+        meta-audioreach:
+            commit: 75402c8d1ea1203dcf3a63792161f7d5d93946bb
+        meta-selinux:
+            commit: 4904b87b12c51a68efc5b9cd45c7b519fdc48af1
+        meta-updater:
+            commit: bcea37a06cb8b17ddcd7f3209b4a3c5643fee4d5
+        meta-security:
+            commit: 8028c573db6923525c2918724f2bd36d4a420e0b

--- a/ci/meta-arm.yml
+++ b/ci/meta-arm.yml
@@ -4,6 +4,7 @@ header:
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
+    branch: master
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -12,6 +12,7 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    branch: master
     layers:
       meta-filesystems:
       meta-gnome:


### PR DESCRIPTION
In preparation for the Qualcomm Linux 2.0 RC3 release, add ci/base.lock.yml
file to stop tracking the moving tips of upstream meta layer repositories.

The lock file pins all external layers to fixed commit revisions
corresponding to the Yocto 6.0 (M3) release. This ensures reproducible
CI builds and mitigates unexpected breakages caused by upstream changes
during the release phase.