### PR TITLE
linux-qcom-next: update to tag qcom-next-7.0-rc6-20260409

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.19+7.0-rc5"
+LINUX_VERSION ?= "6.19+7.0-rc6"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.0-rc5-20260331
-SRCREV ?= "162b8025fc21754337158dd046058b06995fbbaa"
+# tag: qcom-next-7.0-rc6-20260409
+SRCREV ?= "9097b3fed74955e3a247770312184c05e64926e2"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.0-rc6-20260409, which corresponds to kernel version v7.0-rc6

Fastrpc failure on RB3GEN2 Overlay corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1807
Display and GFX failure on Overlay Build corresponds to Github issue https://github.com/qualcomm-linux/meta-qcom/issues/1824
Display and GFX is validated with tip of meta-qcom on RB8 and is working with 7.0-rc6