### PR TITLE
image_types_qcom.bbclass: include xbl_config_devprg.elf for Kaanapali-MTP

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -102,7 +102,8 @@ create_qcomflash_pkg() {
                 -name 'logfs_*.bin' -o \
                 -name 'qsahara_*.xml' -o \
                 -name 'sec.dat' -o \
-                -name 'soccp*.bin'` ; do
+                -name 'soccp*.bin' -o \
+                -name 'xbl_config_devprg.elf'` ; do
             install -m 0644 ${bfw} .
         done
 


### PR DESCRIPTION
[PR#1191](https://github.com/qualcomm-linux/meta-qcom/pull/1191) adds KVM support which excludes **xbl_config\*.elf** files and installs xbl_config.elf or xbl_config_kvm.elf based on the kvm DISTRO_FEATURE.

xbl_config_devprg.elf is required by Kaanapali-MTP while flashing, so including it in the qcomflash directory.