### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260408

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260403
-SRCREV ?= "7ea01f6a3cff61f8e0535e6b018695d54d38202a"
+# tag:qcom-6.18.y-20260408
+SRCREV ?= "085c63ce16cc2faedcd4f6400a64d3161df4f74c"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260408

Changelog:
QCLINUX: arm64: dts: qcom: Add Hamoa camx overlay dts
FROMLIST: ASoC: qcom: qdsp6: q6prm: add the missing LPASS MCLK clock IDs
FROMLIST: arm64: dts: qcom: lemans-evk-ifp-mezzanine: Enable mdss1 display Port
QCLINUX: drm/msm: Fix MODULE_PARM_DESC compilation build error
QCLINUX: defconfig: Enable Qualcomm BCL driver
FROMLIST: arm64: dts: qcom: pm8350c: Enable Qualcomm BCL device
FROMLIST: arm64: dts: qcom: pm7250b: Enable Qualcomm BCL device
FROMLIST: hwmon: Add Qualcomm PMIC BCL hardware monitor driver
FROMLIST: dt-bindings: hwmon: Add qcom,bcl-hwmon yaml bindings
FROMLIST: arm64: dts: qcom: lemans-ride: Enable mdss1 display Port
FROMLIST: arm64: dts: qcom: lemans: add mdss1 display device nodes
FROMLIST: Revert "pinctrl: qcom: x1e80100: Bypass PDC wakeup parent for now"
FROMLIST: arm64: dts: qcom: x1e80100: Add deepest idle state
FROMLIST: arm64: dts: qcom: x1e80100: Remove interconnect from SCM device
FROMLIST: irqchip/qcom-pdc: Configure PDC to pass through mode
FROMLIST: dt-bindings: interrupt-controller: qcom,pdc: Document reg and QMP
FROMLIST: arm64: dts: qcom: purwa: Drop the Hamoa workaround for PDC
FROMLIST: dt-bindings: interrupt-controller: qcom,pdc: Document x1p42100 PDC
QCLINUX: drm/msm: auto-detect separate GPU KMS mode based on HW topology
FROMLIST: media: iris: add FPS calculation and VPP FW overhead in frequency formula
FROMGIT: arm64: defconfig: Enable Qualcomm WCD937x headphone codec as module
PENDING: media: iris: update MDT PAS load call for new API
FROMGIT: arm64: dts: qcom: purwa-iot-evk: Enable UFS
FROMLIST: media: qcom: venus: relax encoder frame/blur step size on v6
FROMLIST: media: qcom: venus: relax encoder frame/blur dimension steps on v4
FROMLIST: media: qcom: venus: drop extra padding in NV12 raw size calculation
BACKPORT: media: venus: assign unique bus_info strings for encoder and decoder
BACKPORT: media: venus: drop unused module aliases
BACKPORT: media: venus: drop bogus probe deferrals
BACKPORT: media: iris: Introduce vpu ops for vpu4 with necessary hooks
BACKPORT: media: iris: Move vpu35 specific api to common to use for vpu4
BACKPORT: media: iris: Move vpu register defines to common header file
BACKPORT: media: iris: Introduce buffer size calculations for vpu4
BACKPORT: media: iris: Add support for multiple TZ content protection(CP) configs
BACKPORT: media: iris: Add support for multiple clock sources
BACKPORT: media: qcom: iris: Add intra refresh support for encoder
BACKPORT: media: qcom: iris: Add flip support for encoder
BACKPORT: media: qcom: iris: Add rotation support for encoder
BACKPORT: media: qcom: iris: Add scale support for encoder
BACKPORT: media: qcom: iris: Improve format alignment for encoder
BACKPORT: media: qcom: iris: Improve crop_offset handling for encoder
BACKPORT: media: iris: Change psc properties message to debug level
BACKPORT: media: iris: Document difference in size during allocation
BACKPORT: media: iris: Cast iris_hfi_gen2_get_instance() allocation type
BACKPORT: media: Use of_reserved_mem_region_to_resource() for "memory-region"
FROMLIST: media: qcom: venus: flip the venus/iris switch
FROMLIST: media: qcom: iris: increase H265D_MAX_SLICE to fix H.265 decoding on SC7280
FROMLIST: arm64: dts: qcom: sm8750: Enable TSENS and thermal zones
FROMLIST:dt-bindings: thermal: qcom-tsens: Document the SM8750 Temperature Sensor
FROMLIST: drm/bridge: display-connector: trigger initial HPD event for DP
FROMLIST: clk: qcom: camcc-x1e80100: Add support for camera QDSS debug clocks
FROMLIST: dt-bindings: clock: qcom: Add X1P42100 camera clock controller
FROMLIST: drm/bridge: display-connector: don't autoenable HPD IRQ