### PR TITLE
iris-video-dlkm: update iris driver to v1.0.4

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.4.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.4.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "7461781d270fe3d7a0fbfd909cc3ed6db653e111"
+SRCREV  = "02248f4021f7690e675c408b4fd0208ad559a1d5"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.4 brings below updates for Qcom Iris

- Add iommu-map based IOMMU configuration support for Lemans and Hamoa
- Enable support for up to 32 instances on Lemans