### PR TITLE
trusted-firmware-a-qcom/optee-os-qcom: switch to nobranch and use tags

### DIFF
--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
@@ -2,7 +2,8 @@ require recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
 
 PV = "2.14.0-qcom+git"
 
-SRC_URI = "git://github.com/qualcomm-linux/trusted-firmware-a.git;protocol=https;name=tfa;branch=qcom-next"
+SRC_TAG = "tag=qcom-next-2.14-20260220"
+SRC_URI = "git://github.com/qualcomm-linux/trusted-firmware-a.git;protocol=https;name=tfa;nobranch=1;${SRC_TAG}"
 SRCREV_tfa = "78d883ea408d58786287102bc704a5bfce2cbd90"
 
 require trusted-firmware-a-qcom.inc

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
@@ -2,7 +2,8 @@ require recipes-security/optee/optee-os.inc
 
 PV = "4.9.0-qcom+git"
 
-SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;branch=qcom-next"
+SRC_TAG = "tag=4.9.0"
+SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;nobranch=1;${SRC_TAG}"
 SRCREV_optee = "c2b0684fcd89929976a8726e6e3af922b48dd2c7"
 
 require optee-qcom.inc


### PR DESCRIPTION
The qcom-next branch was rebased and therefore we cannot use it on the SRC_URI.
When the rebase was done, a tag is created to store the previous head.
This tag this will always be available and will not change the git revision.
To fix the problem, stop using the branch and start using the tag mentioned.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1932