### PR TITLE
Enable Audio over HDMI and Displayport for Kodiak and Lemans

### DIFF
--- a/recipes-kernel/linux/linux-qcom-6.18/v1-0001-arm64-dts-qcom-Enable-secondary-mi2s.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/v1-0001-arm64-dts-qcom-Enable-secondary-mi2s.patch
@@ -1,0 +1,106 @@
+From 67453e9e586436865e3e0b85c73dfb880d5e73ed Mon Sep 17 00:00:00 2001
+From: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+Date: Sun, 12 Apr 2026 23:59:28 -0700
+Subject: [PATCH v1 1/4] arm64: dts: qcom: Enable secondary mi2s
+
+Enable secondary mi2s to support HDMI audio.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260413091937.134469-2-kumar.singh@oss.qualcomm.com/]
+
+Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/kodiak.dtsi         |  5 +++
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 43 ++++++++++++++++++++
+ 2 files changed, 48 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/kodiak.dtsi b/arch/arm64/boot/dts/qcom/kodiak.dtsi
+index 6079e67ea829..d1009debc12b 100644
+--- a/arch/arm64/boot/dts/qcom/kodiak.dtsi
++++ b/arch/arm64/boot/dts/qcom/kodiak.dtsi
+@@ -5827,6 +5827,11 @@ mi2s1_ws: mi2s1-ws-state {
+ 				function = "mi2s1_ws";
+ 			};
+ 
++			mi2s1_mclk: mi2s1-mclk-state {
++				pins = "gpio105";
++				function = "sec_mi2s";
++			};
++
+ 			pcie0_clkreq_n: pcie0-clkreq-n-state {
+ 				pins = "gpio88";
+ 				function = "pcie0_clkreqn";
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index e3d2f01881ae..2e4062052828 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -672,6 +672,7 @@ &i2c0 {
+ 	lt9611_codec: hdmi-bridge@2b {
+ 		compatible = "lontium,lt9611uxc";
+ 		reg = <0x2b>;
++		#sound-dai-cells = <1>;
+ 
+ 		interrupts-extended = <&tlmm 24 IRQ_TYPE_EDGE_FALLING>;
+ 		reset-gpios = <&pm7250b_gpios 2 GPIO_ACTIVE_HIGH>;
+@@ -1110,6 +1111,9 @@ &sound {
+ 	compatible = "qcom,qcs6490-rb3gen2-sndcard";
+ 	model = "QCS6490-RB3Gen2";
+ 
++	pinctrl-0 = <&mi2s1_data0>, <&mi2s1_mclk>, <&mi2s1_sclk>, <&mi2s1_ws>;
++	pinctrl-names = "default";
++
+ 	audio-routing = "SpkrLeft IN", "WSA_SPK1 OUT",
+ 			"SpkrRight IN", "WSA_SPK2 OUT",
+ 			"VA DMIC0", "vdd-micb",
+@@ -1149,6 +1153,22 @@ platform {
+ 			sound-dai = <&q6apm>;
+ 		};
+ 	};
++
++	mi2s1-playback-dai-link {
++		link-name = "Secondary MI2S Playback";
++
++		codec {
++			sound-dai = <&lt9611_codec 0>;
++		};
++
++		cpu {
++			sound-dai = <&q6apmbedai SECONDARY_MI2S_RX>;
++		};
++
++		platform {
++			sound-dai = <&q6apm>;
++		};
++	};
+ };
+ 
+ &swr2 {
+@@ -1437,3 +1457,26 @@ &lpass_audiocc {
+ 	compatible = "qcom,qcm6490-lpassaudiocc";
+ 	/delete-property/ power-domains;
+ };
++
++&mi2s1_data0 {
++	drive-strength = <8>;
++	bias-disable;
++};
++
++&mi2s1_mclk {
++	drive-strength = <8>;
++	bias-disable;
++	output-high;
++};
++
++&mi2s1_sclk {
++	drive-strength = <8>;
++	bias-disable;
++	output-high;
++};
++
++&mi2s1_ws {
++	drive-strength = <8>;
++	bias-disable;
++	output-high;
++};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-6.18/v1-0001-arm64-dts-qcom-lemans-Enable-DISPLAY-PORT.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/v1-0001-arm64-dts-qcom-lemans-Enable-DISPLAY-PORT.patch
@@ -1,0 +1,45 @@
+From 02743e98b6e54fea6687760b6149d506f4c474cb Mon Sep 17 00:00:00 2001
+From: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+Date: Sun, 12 Apr 2026 21:21:14 -0700
+Subject: [PATCH v1] arm64: dts: qcom: lemans: Enable DISPLAY-PORT
+
+Add dailinks for DISPLAY-PORT to enable audio functionality
+on edp0.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260413043713.1659-1-kumar.singh@oss.qualcomm.com/]
+
+Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/lemans-evk.dts | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/lemans-evk.dts b/arch/arm64/boot/dts/qcom/lemans-evk.dts
+index 90fce947ca7e..daed18b1e6f5 100644
+--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
++++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
+@@ -130,6 +130,22 @@ platform {
+ 				sound-dai = <&q6apm>;
+ 			};
+ 		};
++
++		dp0-dai-link {
++			link-name = "DisplayPort0 Playback";
++
++			cpu {
++				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
++			};
++
++			codec {
++				sound-dai = <&mdss0_dp0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
+ 	};
+ 
+ 	vbus_supply_regulator_0: regulator-vbus-supply-0 {
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-6.18/v1-0002-arm64-dts-qcom-qcs6490-Enable-DP-audio.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/v1-0002-arm64-dts-qcom-qcs6490-Enable-DP-audio.patch
@@ -1,0 +1,44 @@
+From 6c71a9db523200c4cf5e84ad3d0e61aab8bef4c1 Mon Sep 17 00:00:00 2001
+From: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 00:03:16 -0700
+Subject: [PATCH v1 2/4] arm64: dts: qcom: qcs6490: Enable DP audio
+
+Add new dai link to enable DP audio.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260413091937.134469-3-kumar.singh@oss.qualcomm.com/]
+
+Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 2e4062052828..90fd8822dabd 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -1169,6 +1169,22 @@ platform {
+ 			sound-dai = <&q6apm>;
+ 		};
+ 	};
++
++	dp-dai-link {
++		link-name = "DisplayPort0 Playback";
++
++		codec {
++			sound-dai = <&mdss_dp>;
++		};
++
++		cpu {
++			sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
++		};
++
++		platform {
++			sound-dai = <&q6apm>;
++		};
++	};
+ };
+ 
+ &swr2 {
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-6.18/v1-0003-ASoC-qcom-q6dsp-Update-bit-format-support-for-sec.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/v1-0003-ASoC-qcom-q6dsp-Update-bit-format-support-for-sec.patch
@@ -1,0 +1,43 @@
+From 9a0f015752ed079818d4d9e345d17073c0f7497b Mon Sep 17 00:00:00 2001
+From: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 00:04:25 -0700
+Subject: [PATCH v1 3/4] ASoC: qcom: q6dsp: Update bit format support for
+ secondary i2s
+
+Add 32bit for playback and capture over secondary mi2s.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260413091937.134469-4-kumar.singh@oss.qualcomm.com/]
+
+Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+---
+ sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c b/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
+index 4eed54b071a5..0664f18d7a44 100644
+--- a/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
++++ b/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
+@@ -380,7 +380,9 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.stream_name = "Secondary MI2S Playback",
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+-			.formats = SNDRV_PCM_FMTBIT_S16_LE,
++			.formats = SNDRV_PCM_FMTBIT_S16_LE |
++				   SNDRV_PCM_FMTBIT_S24_LE |
++				   SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+@@ -394,7 +396,8 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+ 			.formats = SNDRV_PCM_FMTBIT_S16_LE |
+-				   SNDRV_PCM_FMTBIT_S24_LE,
++				   SNDRV_PCM_FMTBIT_S24_LE |
++				   SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-6.18/v1-0004-ASoC-qcom-sc8280xp-don-t-force-S16_LE-in-hw_param.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/v1-0004-ASoC-qcom-sc8280xp-don-t-force-S16_LE-in-hw_param.patch
@@ -1,0 +1,36 @@
+From e68e0c1f9e9899109e1e31fdc34b10a866421fb2 Mon Sep 17 00:00:00 2001
+From: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 00:08:12 -0700
+Subject: [PATCH v1 4/4] ASoC: qcom: sc8280xp: don't force S16_LE in hw_params
+ fixup
+
+The machine driver was unconditionally forcing S16_LE in
+sc8280xp_be_hw_params_fixup(), which prevents links (e.g. HDMI bridges)
+that require 32-bit formats from working. Drop the format override and
+keep only the fixed rate/channels constraints.
+
+Upstream-Status: Submitted [https://lore.kernel.org/all/20260413091937.134469-5-kumar.singh@oss.qualcomm.com/]
+
+Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>
+---
+ sound/soc/qcom/sc8280xp.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/sound/soc/qcom/sc8280xp.c b/sound/soc/qcom/sc8280xp.c
+index 7925aa3f63ba..c00eabf200b7 100644
+--- a/sound/soc/qcom/sc8280xp.c
++++ b/sound/soc/qcom/sc8280xp.c
+@@ -75,10 +75,8 @@ static int sc8280xp_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+ 					SNDRV_PCM_HW_PARAM_RATE);
+ 	struct snd_interval *channels = hw_param_interval(params,
+ 					SNDRV_PCM_HW_PARAM_CHANNELS);
+-	struct snd_mask *fmt = hw_param_mask(params, SNDRV_PCM_HW_PARAM_FORMAT);
+ 
+ 	rate->min = rate->max = 48000;
+-	snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S16_LE);
+ 	channels->min = 2;
+ 	channels->max = 2;
+ 	switch (cpu_dai->id) {
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -23,6 +23,10 @@ SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"
 SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
 SRC_URI += "file://0001-tools-use-basename-to-identify-file-in-gen-mach-type.patch"
 SRC_URI += "file://v1-0001-arm64-dts-qcom-lemans-Enable-DISPLAY-PORT.patch"
+SRC_URI += "file://v1-0001-arm64-dts-qcom-Enable-secondary-mi2s.patch"
+SRC_URI += "file://v1-0002-arm64-dts-qcom-qcs6490-Enable-DP-audio.patch"
+SRC_URI += "file://v1-0003-ASoC-qcom-q6dsp-Update-bit-format-support-for-sec.patch"
+SRC_URI += "file://v1-0004-ASoC-qcom-sc8280xp-don-t-force-S16_LE-in-hw_param.patch"
 
 # Additional kernel configs.
 SRC_URI += " \

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -22,6 +22,7 @@ SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"
 
 SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
 SRC_URI += "file://0001-tools-use-basename-to-identify-file-in-gen-mach-type.patch"
+SRC_URI += "file://v1-0001-arm64-dts-qcom-lemans-Enable-DISPLAY-PORT.patch"
 
 # Additional kernel configs.
 SRC_URI += " \


### PR DESCRIPTION
linux-qcom: Enable Audio over HDMI and Displayport for Kodiak and Lemans

Kodiak link : 
https://lore.kernel.org/all/20260413091937.134469-1-kumar.singh@oss.qualcomm.com/

Lemans link : 
https://lore.kernel.org/all/20260413043713.1659-1-kumar.singh@oss.qualcomm.com/