### PR TITLE
workflows: build-yocto: skip lock update when lock is already available

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -43,6 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Run kas lock
+        if: ${{ hashFiles('ci/base.lock.yml') == '' }}
         run: |
           ${KAS_CONTAINER} lock --update ci/base.yml:ci/qcom-distro.yml
 


### PR DESCRIPTION
Avoid running `kas lock --update` when `ci/base.lock.yml` is already available as part of the repository, to avoid unexpected lock updates during the build.