### PR TITLE
mount-tee-partition: make persist handling event driven

### DIFF
--- a/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
+++ b/recipes-bsp/partition/mount-tee-partition/format-tee-partition.service
@@ -5,8 +5,6 @@
 [Unit]
 Description=Create ext4 filesystem on persist partition if missing
 DefaultDependencies=no
-Requires=dev-disk-by\x2dpartlabel-persist.device
-After=dev-disk-by\x2dpartlabel-persist.device
 ConditionPathExists=/dev/disk/by-partlabel/persist
 Before=var-lib-tee.mount
 ConditionPathIsMountPoint=!/var/lib/tee
@@ -15,6 +13,3 @@ ConditionPathIsMountPoint=!/var/lib/tee
 Type=oneshot
 ExecStart=@sbindir@/check-tee-partition-fs.sh
 RemainAfterExit=yes
-
-[Install]
-WantedBy=local-fs-pre.target

--- a/recipes-bsp/partition/mount-tee-partition/persist.rules
+++ b/recipes-bsp/partition/mount-tee-partition/persist.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="block", ENV{DEVTYPE}=="partition", ENV{PARTNAME}=="persist", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}+="var-lib-tee.mount"

--- a/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
+++ b/recipes-bsp/partition/mount-tee-partition/var-lib-tee.mount
@@ -5,12 +5,12 @@
 [Unit]
 Description=Mount persist partition at /var/lib/tee
 Before=local-fs.target sfsconfig.service
+ConditionPathExists=/dev/disk/by-partlabel/persist
+After=format-tee-partition.service
+Requires=format-tee-partition.service
 
 [Mount]
 DirectoryMode=0755
 What=/dev/disk/by-partlabel/persist
 Where=/var/lib/tee
 Type=ext4
-
-[Install]
-WantedBy=local-fs.target

--- a/recipes-bsp/partition/mount-tee-partition_1.0.bb
+++ b/recipes-bsp/partition/mount-tee-partition_1.0.bb
@@ -8,6 +8,7 @@ SRC_URI = " \
     file://var-lib-tee.mount \
     file://check-tee-partition-fs.sh \
     file://format-tee-partition.service \
+    file://persist.rules \
 "
 
 inherit features_check systemd
@@ -28,6 +29,8 @@ do_install() {
             ${D}${systemd_system_unitdir}/format-tee-partition.service
     sed -i -e "s,@sbindir@,${sbindir},g" \
             ${D}${systemd_system_unitdir}/format-tee-partition.service
+    install -Dm 0644 ${UNPACKDIR}/persist.rules \
+            ${D}${nonarch_base_libdir}/udev/rules.d/99-persist.rules
 }
 
 PACKAGES = "${PN}"


### PR DESCRIPTION
On platforms without a persist partition, the current systemd setup can
cause the boot process to block waiting for /dev/disk/by-partlabel/persist,
resulting in long delays or timeouts during early boot.

As the persist partition is optional, solutions based on static systemd
service dependencies, generators, or ordering against generic targets
(such as multi-user.target) are not reliable in this case, as
/dev/disk/by-partlabel/persist is only created after udev has processed
all block device events, and systemd explicitly discourages depending on
udev-settle for correctness.

Convert persist partition formatting and mounting to an event-driven
model without hard systemd dependencies. Mounting is triggered
directly by a udev event when the persist partition appears, ensuring
that systems without the partition do not block during boot, while
preserving strict ordering so the filesystem check and format service
always runs before the mount.