### PR TITLE
workflows: upgrade lava-action to v11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Submit ${{ matrix.target.name }}
         timeout-minutes: 20
         id: submit
-        uses: foundriesio/lava-action@v9
+        uses: foundriesio/lava-action@v11
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'
@@ -217,7 +217,7 @@ jobs:
 
       - name: Submit ${{ matrix.target.name }}
         timeout-minutes: 20
-        uses: foundriesio/lava-action@v9
+        uses: foundriesio/lava-action@v11
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'


### PR DESCRIPTION
lava-action@v11 runs on node24. This patch removes the github warning about deprecated node20.