### PR TITLE
README: Add reference to meta-qcom milestone release repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ Make sure that ModemManager is not running, disable it if necessary.
    READ64 image: 13 offset: 0x0 length: 0x40
    ```
 
+## Releases
+
+Milestone releases for meta-qcom are managed in a separate repository:
+[meta-qcom-releases](https://github.com/qualcomm-linux/meta-qcom-releases)
+
+The meta-qcom-releases repository contains kas lock files corresponding to each official milestone release.
+These lock files capture the exact revisions of meta-qcom and all dependent meta-layers used during a
+given release, ensuring reproducible and stable builds.
+
 ## Contributing
 
 Please submit any patches against the `meta-qcom` layer (branch **master**)


### PR DESCRIPTION
A meta-qcom build pulls metadata from 10+ layers (oe-core, bitbake, meta-oe, ..). Hence, we need a lock file to
store all the meta layers shas for a milestone release which can then be used by customers for reproducing a stable build.
Introduced a Releases section in the README that points users to the meta‑qcom‑releases
repository which holds the lock file for meta-qcom milestone releases.