### PR TITLE
CAMX: revision update for Kodiak, Lemans, Talos

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.16.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.16.bb
@@ -8,15 +8,15 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260404"
+PBT_BUILD_DATE = "260411"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
    "
-SRC_URI[camxlib.sha256sum] = "bd9652a8337af92449ca844db5299c4110baae99ea5d326f67abad1638cdf301"
-SRC_URI[camx.sha256sum] = "d8e3b778be981d6c390713294f11ab150f1faff0c62d5e1ce37e5cd2ba3b9c52"
-SRC_URI[chicdk.sha256sum] = "bbcda983a28383853ecea0a64dde001b1dc960b6ef92616d5a53a2441d7299ca"
+SRC_URI[camxlib.sha256sum] = "e816f8b5fd0996bc98a149e16e02873d94567a3ee711c5872c7ecb5c56c65e8d"
+SRC_URI[camx.sha256sum] = "e9f7ac3c99b08f38af75f7e7e5f45bab96762362ae8e1f188dae11257746082a"
+SRC_URI[chicdk.sha256sum] = "b1280a7c398352564ba9c29cf8ddcb8f22a812ee7c62984379bfb877d3a5f6c2"
 
 S = "${UNPACKDIR}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.17.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.17.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260403"
+PBT_BUILD_DATE = "260411"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum]     = "c3a2899a19078c0ced7ae6ec4605b84834eae33893820f05a34e864f198bdfc9"
-SRC_URI[camx.sha256sum]        = "91bfc42dad35adef895656dfef48f4eacb4059e49b813dec9cbece9a4b30a309"
-SRC_URI[chicdk.sha256sum]      = "4c83df2a4690759979087d112633d43420599ab4906f233109591528107d4769"
-SRC_URI[camxcommon.sha256sum]  = "89ee02d0b4bd09dcca091be2f2339ff50b6a34fc50ca51c612b0e633768a956d"
+SRC_URI[camxlib.sha256sum]     = "3ddbe79a9753b3238f3fb6072022a9a572be946576e1c9c43c383795a1f9cb4e"
+SRC_URI[camx.sha256sum]        = "5733fecdfb12339c9a4063e0058badf1c69a79327afb0be754a33832c577b149"
+SRC_URI[chicdk.sha256sum]      = "d26a55a95c11dcd8d350f6161465ee81845b5f0cdb9231997092c85fc95a60e5"
+SRC_URI[camxcommon.sha256sum]  = "e035bb3a34231dd12f3d2c73f87c10d116c1ec8bc6b289efd20924d9a6fbd00e"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.6.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260403"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "f99804775c05cd859934270cdc8f43ef8eb27e827bba2df3aec9d0b5700c8a77"
-SRC_URI[camx.sha256sum]        = "b6b2dde850ff7d194560d33687615de5417959d154e85036cfa714ae58bc9a2e"
-SRC_URI[chicdk.sha256sum]      = "2a0f036e59c035e593d21a4cc7e5b6a3c5a011bfc3e7f0a55d841849443065bc"
-SRC_URI[camxcommon.sha256sum]  = "7db3128a0b23c1f001ef799655d6b14f8d4384d78cfa5e3afe8150b9811a3a31"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.7.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.7.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260411"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "33d6f7056107232b8187e3787613ba33dde0f4efc205a3fa22c1f4a48d32b3cf"
+SRC_URI[camx.sha256sum]        = "62a9be143095694ba78e40048b8ea93f4b1d5d00c72aa9285c232130ee4be059"
+SRC_URI[chicdk.sha256sum]      = "dc0bf69137d495f4ba4e577a023a1cf121130a97021e9e11b7c106acee69bb3c"
+SRC_URI[camxcommon.sha256sum]  = "7c2f75948c218b91f1807f7fa9f34a3d8d8b8b1fcd9e7b7dcdba69399e70a67d"


### PR DESCRIPTION
The versions used here now include the same set of features and changes as those in QLI 1.8.