### PR TITLE
image_types_qcom.bbclass: fatal error if xbl_config.elf is missing

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -115,6 +115,8 @@ create_qcomflash_pkg() {
 
         if [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" ]; then
             install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" xbl_config.elf
+        else
+            bbfatal "File NOT found: ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}"
         fi
 
         # bootloader selection


### PR DESCRIPTION
Add bbfatal in the else branch when xbl_config is not found in DEPLOY_DIR_IMAGE/QCOM_BOOT_FILES_SUBDIR, preventing silent failures during flash package creation.

Fixes: https://github.com/qualcomm-linux/meta-qcom/issues/1946