### PR TITLE
Migrate SRC_URI for QWES prebuilts to QArtifactory

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/qwes/qwes_1.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/qwes/qwes_1.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.qcom-2;md5=165287851294f
 
 PBT_BUILD_DATE = "260409"
 
-SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/sec-userspace.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qwes_${PV}_armv8a.tar.gz"
+SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sec-userspace.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qwes_${PV}_armv8a.tar.gz"
 SRC_URI[sha256sum] = "2fc38e033aa32e59a1749017526d29e9ad71f38f168ff652383eb06a05be3985"
 
 S = "${UNPACKDIR}"


### PR DESCRIPTION
Migrate the SRC_URI for prebuilt binaries from sofware center paths to direct QArtifactory-edge URLs to align with QLI recommendations.
Using QArtifactory-edge directly in recipes to ensure efficient, reliable way to fetch prebuilts over softwarecenter as it eliminates redirects.
It improves build performance by leveraging direct edge-node caching for fetching the binaries.