### PR TITLE
iq-8275-evk: build sdcc feature DTs as overlays

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -104,24 +104,47 @@ FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
 
 # ---------- monaco ----------
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging"
+
+# Add entries for combinations whose overlays are available only in
+# LINUX_QCOM_KERNEL_DEVICETREE. Move these to fit-dtb-compatible.inc once
+# the overlays are available in linux-yocto.
+
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2"
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx] = "monaco-evk monaco-evk-camx"
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx] = "monaco-evk monaco-evk-camx monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-emmc] = "monaco-evk monaco-evk-camx monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging] = \
-    "monaco-evk monaco-evk-camx monaco-staging"
+    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0] = "monaco-ac-evk monaco-evk-camera-imx577"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1] = "monaco-ac-evk monaco-evk-ifp-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-staging monaco-el2 monaco-camx-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0-emmc] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1-emmc] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-emmc] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
-    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging-emmc] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-emmc"
 
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride monaco-el2"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -20,6 +20,8 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
                       qcom/monaco-evk-staging.dtbo \
                       qcom/monaco-staging.dtbo \
+                      qcom/monaco-evk-emmc.dtbo \
+                      qcom/monaco-evk-sd-card.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
arm64: dts: qcom: monaco-evk: add metadata-based eMMC/SD overlays

Monaco EVK supports either eMMC or SD card, but only one storage medium
can be active at a time because both use the same host controller. The
active medium is selected through a DIP switch on the board.

Since both configurations cannot be described simultaneously in the base
DT without conflicting definitions for the shared host controller, model
the storage-specific differences through metadata-based overlays.

Add separate overlays for the eMMC and SD-card configurations so the
appropriate storage setup can be selected to match the board's DIP
switch setting. This allows a single build to support both Monaco EVK
storage variants without maintaining separate base DTs.