### PR TITLE
linux-qcom-next: update to tag qcom-next-7.0-rc6-20260415

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -12,8 +12,8 @@ LINUX_VERSION ?= "6.19+7.0-rc6"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.0-rc6-20260409
-SRCREV ?= "9097b3fed74955e3a247770312184c05e64926e2"
+# tag: qcom-next-7.0-rc6-20260415
+SRCREV ?= "845dd9aa8918041832f63864f99a4a655ff16cec"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Changelog:
FROMLIST: arm64: dts: qcom: monaco: Add monaco-ac EVK board
FROMLIST: dt-bindings: arm: qcom: Add monaco-ac-evk support
FROMLIST: arm64: dts: qcom: monaco-evk: Extract common EVK hardware into shared dtsi
FROMLIST: phy: qcom-qmp-ufs: Fix kaanapali PHY PLL lock failure after SM8650 G4 fi
