### PR TITLE
hexagon-dspso: generate configs for FastRPC

### DIFF
--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-qar2130p.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for QAR2130P device"
 
 DSPSO_SOC = "sar2130p"
 DSPSO_DEVICE = "QAR2130P"
+DSPSO_DEVICE_MODEL = "Qualcomm Snapdragon AR2 Gen1 Smart Viewer Development Kit"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sdm845-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sdm845-hdk.bb
@@ -7,6 +7,9 @@ DESCRIPTION = "Hexagon DSP binaries for SDM845 HDK (aka HDK845) board"
 DSPSO_SOC = "sdm845"
 DSPSO_DEVICE = "SDM845-HDK"
 
+# Config for SDM845-HDK is a part of the main repo
+DSPSO_CONFIG = "hexagon-dsp-binaries-conf"
+
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
@@ -15,4 +18,6 @@ require hexagon-dspso.inc
 
 # Only package SLPI binaries, ADSP and CDSP are provided by
 # hexagon-dsp-binaries
-PACKAGES = "hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp"
+PACKAGES = " \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
+"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8150-hdk.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for SM8150 HDK (aka HDK855) board"
 
 DSPSO_SOC = "sm8150"
 DSPSO_DEVICE = "SM8150-HDK"
+DSPSO_DEVICE_MODEL = "Qualcomm Technologies, Inc. SM8150 HDK"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8350-hdk.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for SM8350 HDK (aka HDK888) board"
 
 DSPSO_SOC = "sm8350"
 DSPSO_DEVICE = "SM8350-HDK"
+DSPSO_DEVICE_MODEL = "Qualcomm Technologies, Inc. SM8350 HDK"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8450-hdk.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for SM8450 HDK board"
 
 DSPSO_SOC = "sm8450"
 DSPSO_DEVICE = "SM8450-HDK"
+DSPSO_DEVICE_MODEL = "Qualcomm Technologies, Inc. SM8450 HDK"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8550-hdk.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for SM8550 HDK board"
 
 DSPSO_SOC = "sm8550"
 DSPSO_DEVICE = "SM8550-HDK"
+DSPSO_DEVICE_MODEL = "Qualcomm Technologies, Inc. SM8550 HDK"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sm8650-hdk.bb
@@ -6,6 +6,7 @@ DESCRIPTION = "Hexagon DSP binaries for SM8650 HDK board"
 
 DSPSO_SOC = "sm8650"
 DSPSO_DEVICE = "SM8650-HDK"
+DSPSO_DEVICE_MODEL = "Qualcomm Technologies, Inc. SM8650 HDK"
 
 LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -15,20 +15,30 @@ SRC_URI += "${DSPSO_URI}"
 DSP_PKG_NAME ?= "${@d.getVar("PN").split("hexagon-dspso-")[-1]}"
 
 DSP_QCOM_BASE_PATH = "${datadir}/qcom"
-DSP_QCOM_PATH = "${DSP_QCOM_BASE_PATH}/${DSPSO_SOC}/${DSPSO_VENDOR}/${DSPSO_DEVICE}"
+DSP_QCOM_CONF_D_PATH = "${DSP_QCOM_BASE_PATH}/conf.d"
+DSP_QCOM_SUBPATH = "${DSPSO_SOC}/${DSPSO_VENDOR}/${DSPSO_DEVICE}"
+DSP_QCOM_PATH = "${DSP_QCOM_BASE_PATH}/${DSP_QCOM_SUBPATH}"
+
+DSPSO_CONFIG ?= "hexagon-dsp-binaries-${DSP_PKG_NAME}-config"
 
 DEPENDS += "e2fsprogs-native"
 
 inherit allarch
 
 PACKAGES = " \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-config \
     hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp \
     hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp \
     hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
 "
 
+RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "${DSPSO_CONFIG}"
+RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "${DSPSO_CONFIG}"
+RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "${DSPSO_CONFIG}"
+
 FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "${DSP_QCOM_PATH}/dsp/adsp"
 FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "${DSP_QCOM_PATH}/dsp/cdsp"
+FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-config = "${DSP_QCOM_CONF_D_PATH}"
 FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "${DSP_QCOM_PATH}/dsp/sdsp"
 
 ALLOW_EMPTY:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
@@ -67,15 +77,30 @@ handle_dspso_image() {
     done
 }
 
+generate_config() {
+    if [ -n "${DSPSO_DEVICE_MODEL}" ] ; then
+        cat >> ${B}/${BPN}.yaml << EOF
+machines:
+  ${DSPSO_DEVICE_MODEL}:
+    DSP_LIBRARY_PATH: ${DSP_QCOM_SUBPATH}
+EOF
+    fi
+}
+
 do_compile:prepend() {
     if [ -z "${DSPSO_URI}" ] ; then
         bbwarn "${PN}: not packaging DSPSO firmware. Please provide DSPSO_URI"
     else
         handle_dspso_image ${UNPACKDIR}/${@get_dspso_path(d.getVar("DSPSO_URI"))}
     fi
+    generate_config
 }
 
 do_install:prepend() {
+    if [ -f "${B}/${BPN}.yaml" ] ; then
+        install -d ${D}${DSP_QCOM_CONF_D_PATH}
+        install -m 0644 ${B}/${BPN}.yaml ${D}${DSP_QCOM_CONF_D_PATH}
+    fi
     ls ${B}/dspso-adsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/adsp && install -m 0644 ${B}/dspso-adsp/* ${D}${DSP_QCOM_PATH}/dsp/adsp
     ls ${B}/dspso-cdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/cdsp && install -m 0644 ${B}/dspso-cdsp/* ${D}${DSP_QCOM_PATH}/dsp/cdsp
     ls ${B}/dspso-sdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/sdsp && install -m 0644 ${B}/dspso-sdsp/* ${D}${DSP_QCOM_PATH}/dsp/sdsp


### PR DESCRIPTION
FastRPC requires YAML config file in order to be able to load DSP binaries. Provide the config file for the packaged DSP binaries.