### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260414

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260408
-SRCREV ?= "085c63ce16cc2faedcd4f6400a64d3161df4f74c"
+# tag:qcom-6.18.y-20260414
+SRCREV ?= "cad3efc403505af8ed0b4709e173b61bfb0327a1"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260414

Changelog:
FROMLIST: iommu/arm-smmu-qcom: Fix fastrpc compatible string in ACTLR client match table
FROMLIST: mmc: host: sdhci-msm: Add support for wrapped keys
PENDING: arm64: dts: qcom: qcs6490-rb3gen2: fix root node overlay for phy-vreg
PENDING: arm64: dts: qcom: hamoa: switch iris iommus to iommu-map
PENDING: arm64: dts: qcom: lemans-ride: Drop video firmware from common
PENDING: arm64: dts: qcom: lemans: switch iris iommus to iommu-map
PENDING: dt-bindings: media: iris: add sm8550 iris context bank function IDs
PENDING: media: iris: add helper to select context bank device
FROMLIST: iommu/arm-smmu-qcom: Fix fastrpc compatible string in ACTLR client match table
FROMLIST: mmc: host: sdhci-msm: Add support for wrapped keys
PENDING: arm64: dts: qcom: qcs6490-rb3gen2: fix root node overlay for phy-vreg
PENDING: arm64: dts: qcom: hamoa: switch iris iommus to iommu-map
PENDING: arm64: dts: qcom: lemans-ride: Drop video firmware from common
PENDING: arm64: dts: qcom: lemans: switch iris iommus to iommu-map
PENDING: dt-bindings: media: iris: add sm8550 iris context bank function IDs
PENDING: media: iris: add helper to select context bank device
PENDING: media: iris: add context bank devices using iommu-map
PENDING: media: iris: enable sm8550 context banks via init_cb_devs
FROMLIST: arm64: dts: qcom: kodiak: Add EL2 overlay
FROMLIST: arm64: dts: qcom: monaco-evk: enable UART6 for robot board
FROMGIT: arm64: dts: qcom: x1-el2: Enable the APSS watchdog
FROMGIT: arm64: dts: qcom: hamoa: Add the APSS watchdog
FROMGIT: dt-bindings: watchdog: Document X1E80100 compatible
FROMGIT: arm64: dts: qcom: hamoa: Add remoteproc IOMMUS in EL2 device trees
FROMLIST: arm64: dts: qcom: monaco-evk: Add SDHCI support for eMMC via overlay
FROMLIST: arm64: dts: qcom: monaco-evk: Enable SDHCI for SD Card via overlay
FROMLIST: ASoC: qcom: qdsp6: topology: check widget type before accessing data
FROMLIST: ASoC: qcom: q6apm: remove child devices when apm is removed
FROMLIST: ASoC: qcom: q6apm: move component registration to unmanaged version
FROMLIST: ASoC: qcom: qdsp6: Fix q6apm remove ordering during ADSP stop and start
FROMLIST: cpuidle: Deny idle entry when CPU already have IPI interrupt pending
UPSTREAM: pmdomain: Extend the genpd governor for CPUs to account for IPIs
UPSTREAM: smp: Introduce a helper function to check for pending IPIs
FROMLIST: arm64: dts: qcom: purwa: Fix GPU IOMMU property
FROMLIST: of: Respect #{iommu,msi}-cells in maps
FROMLIST: of: Factor arguments passed to of_map_id() into a struct
FROMLIST: of: Add convenience wrappers for of_map_id()
FROMLIST: arm64: dts: qcom: monaco: Move eMMC CQE support from SoC to board DT
FROMLIST: arm64: dts: qcom: sm8750: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8650: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8550: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sm8450: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: kodiak: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: sc7180: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: monaco: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: lemans: Add power-domain and iface clk for ice node
FROMLIST: arm64: dts: qcom: kaanapali: Add power-domain and iface clk for ice node
FROMLIST: soc: qcom: ice: Allow explicit votes on 'iface' clock for ICE
FROMLIST: dt-bindings: crypto: qcom,ice: Fix missing power-domain and iface clk
Revert "soc: qcom: ice: Add explicit power-domain and clock voting calls for ICE"
Revert "arm64: dts: qcom: sm8750: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: sm8650: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: sm8550: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: sm8450: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: kodiak: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: sc7180: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: monaco: Add power-domain and iface clk for ice node"
Revert "arm64: dts: qcom: lemans: Add power-domain and iface clk for ice node"
Revert "dt-bindings: crypto: qcom,ice: Require power-domain and iface clk"
FROMLIST: wifi: ath12k: prepare REO update element only for primary link
FROMLIST: wifi: ath12k: fix incorrect channel survey index
UPSTREAM: wifi: ath12k: Add support TX hardware queue stats
UPSTREAM: wifi: ath12k: Add support RX PDEV stats
FROMLIST: arm64: dts: qcom: lemans-evk: enable UART0 for robot board
PENDING: arm64: dts: qcom: rb3gen2: add overlay for QPS615 ethernet
PENDING: arm64: dts: qcom: monaco-evk: add overlay for QPS615 ethernet
PENDING: arm64: dts: qcom: lemans-evk: add overlay for QPS615 ethernet
FROMLIST: arm64: dts: qcom: sm8450: Fix ICE reg size
FROMLIST: arm64: dts: qcom: kodiak: Fix ICE reg size
FROMLIST: arm64: dts: qcom: monaco: enable the inline crypto engine for SDHC
FROMLIST: arm64: dts: qcom: kodiak: enable the inline crypto engine for SDHC
FROMLIST: dt-bindings: mmc: sdhci-msm: Add ICE phandle
FROMLIST: arm64: defconfig: Enable VIDEOCC and CAMCC drivers on Qualcomm X1P42100
FROMLIST: arm64: dts: qcom: x1e80100: Add CAMCC block definition
FROMLIST: clk: qcom: camcc-x1p42100: Add support for camera clock controller
FROMLIST: clk: qcom: videocc-x1p42100: Add support for video clock controller
FROMLIST: dt-bindings: clock: qcom: Add X1P42100 video clock controller
FROMLIST: arm64: dts: qcom: sm8750: Enable cpufreq cooling devices
WORKAROUND: arm64: dts: qcom: Add flags to advertise PCIe ASPM incompatibility
WORKAROUND: pcie: aspm: Disable L0s\L1 for individual links
FROMLIST: arm64: dts: qcom: kodiak: increase fastrpc compute-cb session slots
FROMLIST: iommu/arm-smmu: Use pm_runtime in fault handlers
FROMGIT: arm64: dts: qcom: qcm6490-idp: Fix WCD9370 reset GPIO polarity
UPSTREAM: wifi: ath12k: support OBSS PD configuration for AP mode
UPSTREAM: wifi: ath12k: add WMI support for spatial reuse parameter configuration