### PR TITLE
Revert "ci: nightly: temporarily disable building SDK"

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,7 +17,7 @@ jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml
     with:
-      sdk: "0" # temporarily until we can split IMSDK correctly
+      sdk: "1"
   test-nightly:
     uses: ./.github/workflows/test.yml
     needs: build-nightly


### PR DESCRIPTION
This reverts commit 59d0f27f773655bdf7f75ef1c7afb8be36c5011a to reenable SDK generation in nightly builds.

SDK generation was previously disabled due to failures caused by packaging proprietary licenses in qcom-multimedia-image, tracked in: https://github.com/qualcomm-linux/meta-qcom/issues/1833

This issue has been addressed by:
    - https://github.com/qualcomm-linux/meta-qcom/pull/1866
    - https://github.com/qualcomm-linux/meta-qcom/pull/1826