### PR TITLE
ci: base.lock.yml: update meta-openembedded and meta-updater

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -9,7 +9,7 @@ overrides:
         meta-arm:
             commit: d987a5945802dcbbc06be91a0d34f00431ea840e
         meta-openembedded:
-            commit: 96a803a50d55a455b0584d8a81168351d0f8c697
+            commit: d2e6069771e435231a220a8ecac20c0e7ceff037
         meta-virtualization:
             commit: 4e6c583591c1da7e898254dd33eca5cc04c739a9
         meta-audioreach:
@@ -17,6 +17,6 @@ overrides:
         meta-selinux:
             commit: 4904b87b12c51a68efc5b9cd45c7b519fdc48af1
         meta-updater:
-            commit: bcea37a06cb8b17ddcd7f3209b4a3c5643fee4d5
+            commit: 2f51f8d7fe658a49d0991ddd0d0af7ff1535c6b4
         meta-security:
             commit: 8028c573db6923525c2918724f2bd36d4a420e0b


### PR DESCRIPTION
Update both meta-openembedded and meta-updater layers to include fixes for mosquitto (service fails to start in qcom-multimedia-image) and to also include the latest ostree release (required to avoid a build failure as it was updated in meta-oe).

```
meta-openembedded changes:
- d2e6069771 gthumb: Upgrade to 3.12.10
- ea3df4e2c6 mosquitto: install default mosquitto.conf for systemd compatibility
- 6b29351885 coremark: add missing license file for LicenseRef-EEMBC-AUA
- d0cdd0805a CoreMark: Add CoreMark to benchmark CPU performance
- b171aba911 xterm: upgrade 407 -> 408
- 15a56e9d95 stunnel: upgrade 5.77 -> 5.78
- 22854e60c4 python3-zopeinterface: upgrade 8.2 -> 8.3
- e0fc1b6d29 python3-virtualenv: upgrade 21.2.0 -> 21.2.1
- e8272fb33d python3-tox: upgrade 4.52.0 -> 4.52.1
- bd948393d9 python3-soundcard: upgrade 0.4.5 -> 0.4.6
- df1c485e18 python3-smbus2: upgrade 0.6.0 -> 0.6.1
- 00ee8e3bff python3-rich: upgrade 14.3.3 -> 15.0.0
- 18d1c54c72 python3-python-multipart: upgrade 0.0.24 -> 0.0.26
- 845d15ae2a python3-pytest-httpx: upgrade 0.36.0 -> 0.36.2
- 02e82f58c2 python3-pymodbus: upgrade 3.12.1 -> 3.13.0
- e249a4e8df python3-pyais: upgrade 2.20.1 -> 3.0.0
- d61051de6b python3-platformdirs: upgrade 4.9.4 -> 4.9.6
- 8bf9ef4452 python3-inline-snapshot: upgrade 0.32.5 -> 0.32.6
- 85617f68bf python3-imgtool: upgrade 2.3.0 -> 2.4.0
- ab0b7e4e59 python3-greenlet: upgrade 3.3.2 -> 3.4.0
- e799080b87 python3-google-auth: upgrade 2.48.0 -> 2.49.2
- 6157dd3159 python3-git-pw: upgrade 2.7.1 -> 2.8.0
- 79ea9d58cd python3-gevent: upgrade 25.9.1 -> 26.4.0
- c115689120 ostree: upgrade 2025.7 -> 2026.1
- d244f85aa0 nano: upgrade 8.7.1 -> 9.0
- 38402132a9 mpich: upgrade 5.0.0 -> 5.0.1
- e5546d6d09 libsodium: upgrade 1.0.21 -> 1.0.22
- 541345b393 libgedit-gfls: upgrade 0.4.0 -> 0.4.1
- 946243ec05 imagemagick: upgrade 7.1.2-18 -> 7.1.2-19
- 68f73e67d8 graphviz: upgrade 14.1.4 -> 14.1.5
- a2366fee7d gnome-online-accounts: upgrade 3.58.0 -> 3.58.1
- cb7da084bc glaze: upgrade 7.3.0 -> 7.3.3
- f2df8812c4 geoclue: upgrade 2.8.0 -> 2.8.1
- 485e91f5f4 babl: upgrade 0.1.124 -> 0.1.126
- c3461d98fb b4: upgrade 0.15.1 -> 0.15.2
- f266b3db88 atftp: upgrade 0.8.0 -> 0.8.1
- 4e07ea136a webkitgtk3: fix escaping in CVE_PRODUCT
- 8093eeb036 xerces-c: fix escaping in CVE_PRODUCT
- 58b1309892 dracut: upgrade 109 -> 110
- 44a29c54f9 openct: Drop this recipe
- 647d2b6e70 parole: fix do_compile failure
- f70eb0ec00 libxfce4ui: add wayland PACKAGECONFIG
- fa2a8fd7a4 thunar: remove x11 from REQUIRED_DISTRO_FEATURES
- 5434650e26 xfce4-panel: Remove x11 from REQUIRED_DISTRO_FEATURES
- 0c62131dda xfce4-pulseaudio-plugin: remove x11 from REQUIRED_DISTRO_FEATURES
- 3c3e80d39d pavucontrol: remove x11 from REQUIRED_DISTRO_FEATURES
- 081a8b15b8 gtkmm4: remove x11 from REQUIRED_DISTRO_FEATURES
- bc788c6649 xdg-dbus-proxy: upgrade 0.1.6 -> 0.1.7
- 054e388728 wolfssl: upgrade 5.9.0 -> 5.9.1
- b5d466f731 ntp: Fix build with -std=gnu23
- d13ec66639 python3-django: upgrade 5.2.12 -> 5.2.13
- a408ffedd8 python3-django: upgrade 6.0.3 -> 6.0.4
- b483760dba nodejs: mark CVE-2026-21710 patched
- 4c8dec585a minio: ignore irrelevant CVEs
- 7355320e12 libraw: mark fixed CVEs patched
- 15b3c0f141 flatpak: upgrade 1.17.3 -> 1.17.6
- 85f7185fec ez-ipupdate: add CVE tag to CVE-fixing patch
- af73e716bc corosync: patch CVE-2026-35092
- 701b22fda3 corosync: patch CVE-2026-35091
- f58d124eb5 tbb: Fix build with LLD linker
- b65b0206b5 keyutils: Fix build with lld linker
- 3551db3839 python3-blivet: upgrade 3.12.1 -> 3.13.2

meta-updater changes:
- 2f51f8d ostree: update bbappend to 2026.1
```