### PR TITLE
add SoC staging overlay dtbo files for KLMT targets

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -16,6 +16,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk-camx.dtbo \
                       qcom/talos-el2.dtbo \
+                      qcom/talos-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk-camx.dtbo \
+                      qcom/talos-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk-camx.dtbo \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
                       qcom/monaco-evk-staging.dtbo \
+                      qcom/monaco-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-camx-el2.dtbo \
                       qcom/lemans-evk-ifp-mezzanine.dtbo \
                       qcom/lemans-evk-staging.dtbo \
+                      qcom/lemans-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -9,6 +9,10 @@ MACHINE_FEATURES += "efi pci phone"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \
                       "
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+                      qcom/kodiak-staging.dtbo \
+                      "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb3gen2-firmware \

--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-el2.dtbo \
+                      qcom/talos-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -17,6 +17,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-el2.dtbo \
                       qcom/monaco-camx-el2.dtbo \
                       qcom/qcs8300-ride-camx.dtbo \
+                      qcom/monaco-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -20,6 +20,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-el2.dtbo \
                       qcom/lemans-camx-el2.dtbo \
                       qcom/sa8775p-ride-camx.dtbo \
+                      qcom/lemans-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-vision-mezzanine-camx.dtbo \
                       qcom/qcs6490-rb3gen2-staging.dtbo \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine-staging.dtbo \
+                      qcom/kodiak-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -17,6 +17,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-vision-mezzanine-camx.dtbo \
                       qcom/qcs6490-rb3gen2-staging.dtbo \
+                      qcom/kodiak-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
The initial staging dtbo for each target contains the TGU device nodes for enabling IPCB logging.

Lore link for the driver:
https://lore.kernel.org/all/20260402092838.341295-1-songwei.chai@oss.qualcomm.com/