### PR TITLE
conf: machine: iq-x5121-evk: switch to support UFS build by default

### DIFF
--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -20,7 +20,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 # IQ-X5121 and IQ-x7181 share the same partition configuration.
 QCOM_CDT_FILE = "IQ_X_EVK_CDT"
 QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/nvme"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
 # IQ-X5121 and IQ-x7181 share the same boot firmware.


### PR DESCRIPTION
Support UFS build by default as UFS storage is always available on device and some devices may not has NVMe card by default.

Build structure
```
build/tmp/deploy/images/iq-x5121-evk/qcom-multimedia-image-iq-x5121-evk.rootfs.qcomflash/
├── dtb.bin
├── dtb-purwa-iot-evk-image.vfat
├── efi.bin
├── gpt_backup0.bin
├── gpt_both0.bin
├── gpt_main0.bin
├── patch0.xml
├── rawprogram0.xml
├── rootfs.img
├── spinor
│   ├── adsp_dtbs.elf
│   ├── adsp_lite.lzma
│   ├── aop_devcfg.mbn
│   ├── aop.mbn
│   ├── cdt.bin
│   ├── contents.xml
│   ├── cpucp_dtbs.elf
│   ├── cpucp.elf
│   ├── devcfg_iot.mbn
│   ├── dtb.bin
│   ├── gpt_backup0.bin
│   ├── gpt_both0.bin
│   ├── gpt_main0.bin
│   ├── hypvm.mbn
│   ├── imagefv.elf
│   ├── IQ_X_EVK_CDT.bin
│   ├── multi_image.mbn
│   ├── patch0.xml
│   ├── qupv3fw.elf
│   ├── rawprogram0.xml
│   ├── shrm.elf
│   ├── tz.mbn
│   ├── uefi_dtbs.xz
│   ├── uefi.elf
│   ├── uefi_sec.mbn
│   ├── xbl_config.elf
│   ├── XblRamdump.xz
│   ├── xbl_s_devprg_ns.melf
│   ├── xbl_s.melf
│   ├── zeros_1sector.bin
│   ├── zeros_33sectors.bin
│   └── zeros_5sectors.bin
├── vmlinux
├── xbl_s_devprg_ns.melf
├── zeros_1sector.bin
├── zeros_33sectors.bin
└── zeros_5sectors.bin
```