### PR TITLE
android-tools-conf-configfs: reduce initial sleep from 10s to 1s

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -2,7 +2,7 @@
 
 set -e
 
-sleep 10
+sleep 1
 
 # Speed-only selection:
 # 1) Pick UDC with highest maximum_speed


### PR DESCRIPTION
The 10 second sleep in android-gadget-start is unnecessarily long and delays ADB availability at boot. Reduce it to 1 second.

Tracking the history of this script, this sleep was [increased from 3s to 10s](https://gitlab.almightyguru.cz/oss/yocto-project/meta-openembedded/-/commit/8403930ab43bc56829496180d28d74d07a14d912) due to an issue on the rpi0w. 
I expect Qualcomm hardware isn't affected by this reported issue with the rpi0w so the sleep time can be a lot less and I tested a 1s sleep on the IMDT QCS8550 SBC and it worked well. 


