### PR TITLE
packagegroup-rb3gen2: include firmware for LT9611UXC

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb3gen2.bb
@@ -17,6 +17,7 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcm6490-wifi', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \
     camxfirmware-kodiak \
+    linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm6490-audio \
     linux-firmware-qcom-qcm6490-compute \
     linux-firmware-qcom-qcm6490-qupv3fw \


### PR DESCRIPTION
RB3 Gen2 uses LT9611UXC DSI-to-HDMI bridge. Include firmware for this chip into the device-specific packagegroup to let users reflash it.