### PR TITLE
linux-qcom-next: update to tag qcom-next-7.0-rc6-20260416

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -12,8 +12,8 @@ LINUX_VERSION ?= "6.19+7.0-rc6"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.0-rc6-20260415
-SRCREV ?= "845dd9aa8918041832f63864f99a4a655ff16cec"
+# tag: qcom-next-7.0-rc6-20260416
+SRCREV ?= "aa085abae3ad03a0b6e379734665e3d7d8266076"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Changelog:
PEDNING: arm64: dts: qcom: qcs6490-rb3gen2: fix root node overlay for phy-vreg
PENDING: arm64: dts: qcom: rb3gen2: add overlay for QPS615 ethernet
PENDING: arm64: dts: qcom: monaco-evk: add overlay for QPS615 ethernet
PENDING: arm64: dts: qcom: lemans-evk: add overlay for QPS615 ethernet
Revert "FROMLIST: arm64: dts: qcom: monaco-evk: Extract common EVK hardware into shared dtsi"
Revert "FROMLIST: dt-bindings: arm: qcom: Add monaco-ac-evk support"
Revert "FROMLIST: arm64: dts: qcom: monaco: Add monaco-ac EVK board"