### PR TITLE
Fix lemans-el2 DTBO name typo in fit-dtb-compatible.inc

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -87,7 +87,7 @@ FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx] = " \
     qcom,qcs9100-qam-r2.0 \
     qcom,qcs9100-socv2.0-qam-r2.0-camx \
 "
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+fdt-lemans-el2] = " \
+FIT_DTB_COMPATIBLE[qcs9100-ride-r3+lemans-el2] = " \
     qcom,qcs9100-qam-r2.0-el2kvm \
     qcom,qcs9100-socv2.0-qam-r2.0-el2kvm \
 "


### PR DESCRIPTION
Fix a typo in the DT overlay name used in FIT_DTB_COMPATIBLE for the
qcs9100-ride-r3 platform.

Replace the incorrect `fdt-lemans-el2` reference with `lemans-el2` so the
base+overlay combination is matched correctly during FIT image generation.