### PR TITLE
CAMX: revision update for Kodiak, Lemans, Talos

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.17.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.17.bb
@@ -8,15 +8,15 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260411"
+PBT_BUILD_DATE = "260416"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
    "
-SRC_URI[camxlib.sha256sum] = "e816f8b5fd0996bc98a149e16e02873d94567a3ee711c5872c7ecb5c56c65e8d"
-SRC_URI[camx.sha256sum] = "e9f7ac3c99b08f38af75f7e7e5f45bab96762362ae8e1f188dae11257746082a"
-SRC_URI[chicdk.sha256sum] = "b1280a7c398352564ba9c29cf8ddcb8f22a812ee7c62984379bfb877d3a5f6c2"
+SRC_URI[camxlib.sha256sum] = "e15364eca7470de18598039dd9f8d672ba8e0e952c05785c9f19e0e3a0903bca"
+SRC_URI[camx.sha256sum] = "0149f330b2ebf77e478ffb0e887056154fde52496f0b7a8f4bf3557a356a3036"
+SRC_URI[chicdk.sha256sum] = "e6abd44ce8c9bfef2de22626d286d389cf87e90f4eaf4c93d38cfd78d1860711"
 
 S = "${UNPACKDIR}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.18.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.18.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260411"
+PBT_BUILD_DATE = "260416"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum]     = "3ddbe79a9753b3238f3fb6072022a9a572be946576e1c9c43c383795a1f9cb4e"
-SRC_URI[camx.sha256sum]        = "5733fecdfb12339c9a4063e0058badf1c69a79327afb0be754a33832c577b149"
-SRC_URI[chicdk.sha256sum]      = "d26a55a95c11dcd8d350f6161465ee81845b5f0cdb9231997092c85fc95a60e5"
-SRC_URI[camxcommon.sha256sum]  = "e035bb3a34231dd12f3d2c73f87c10d116c1ec8bc6b289efd20924d9a6fbd00e"
+SRC_URI[camxlib.sha256sum]     = "13039dd2d9d31bc9e21d55bb8165920aa367da90a0604c95f0459c8902a33da8"
+SRC_URI[camx.sha256sum]        = "70e9a815f7a1e83bb5d9ee0ff18c1b79a0ccc6b0ec9758c4f39d82c6c259e698"
+SRC_URI[chicdk.sha256sum]      = "5922944716bc3949a93984e29ec00b1d2076efec0c8da7cecb3713ff52879a92"
+SRC_URI[camxcommon.sha256sum]  = "7ee0f8cd78e42237058d3a3d7df8a70c0be7bd2316642f17e3bcf4b6e6637934"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.7.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.7.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260411"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "33d6f7056107232b8187e3787613ba33dde0f4efc205a3fa22c1f4a48d32b3cf"
-SRC_URI[camx.sha256sum]        = "62a9be143095694ba78e40048b8ea93f4b1d5d00c72aa9285c232130ee4be059"
-SRC_URI[chicdk.sha256sum]      = "dc0bf69137d495f4ba4e577a023a1cf121130a97021e9e11b7c106acee69bb3c"
-SRC_URI[camxcommon.sha256sum]  = "7c2f75948c218b91f1807f7fa9f34a3d8d8b8b1fcd9e7b7dcdba69399e70a67d"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.8.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.8.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260416"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "79977f594f20a0779cd5e6314edddaacd416416c1a5c22f1399251826b69b7e1"
+SRC_URI[camx.sha256sum]        = "280262a4b5c7edbc80dbd131a2fd0270bb83e8ac247eb5bf6abd393a9ae9262e"
+SRC_URI[chicdk.sha256sum]      = "74a24691659d5c3248364287dd6b0a735a726bbe78d5d5fbf4f4a5e05371df69"
+SRC_URI[camxcommon.sha256sum]  = "9de2262cf02d39279048472ffa780e5da3eae70e0b5c9405cf3c484fd47b3518"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.5.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.5.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260403"
+PBT_BUILD_DATE = "260416"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "d41ad9775559a9f69689b12c116fd70201e47b9f93b1fd19aff2e20ece7271e8"
+SRC_URI[sha256sum] = "0e7d0f397ec896483d1b01e689e0f0019dd5e800c8846196b1655d61ac6ffc28"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
- Add offlinepostproc feature related headers
- Add OEM's sensor resolutions to availableimagesizes
- OEM's can now customize static capability.
- OEM's can change static caps attribute "availableStreamConfigurations".
- bug fixed of JPEG.