### PR TITLE
kgsl-dlkm: Update to v1.0.1

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.1.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.1.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "5999fdfc8e135318f3a4d50f1aece761b07457ed"
+SRCREV = "885d476b899441cd56ee40e1d51dbd1ae4530e0d"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.1 brings below fixes:

- Support for gen7_5_0 GPU.
- qcom_scm_gpu_init_regs() usage support.
- Fix in DDR BW table preparation.