### PR TITLE
gst-plugins-imsdk-oss: move media packaging from packaging.inc to oss

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk-oss_0.1.1.bb
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk-oss_0.1.1.bb
@@ -7,3 +7,11 @@ DESCRIPTION = "Open-source Qualcomm IMSDK GStreamer multimedia plugins"
 DEPENDS += "gst-plugins-imsdk-base"
 
 PACKAGECONFIG ??= "sw tools videoproc"
+
+PACKAGES += "${PN}-media"
+
+FILES:${PN}-media = " \
+    ${datadir}/qdemo/* \
+"
+
+RDEPENDS:${PN}-apps += "${@bb.utils.contains('PACKAGECONFIG', 'python-apps', '${PN}-media', '', d)}"

--- a/recipes-multimedia/imsdk/gst-plugins-imsdk-packaging.inc
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk-packaging.inc
@@ -13,12 +13,6 @@ python split_imsdk_module_packages () {
     do_split_packages(d, imsdk_root, r'([^/]+)/modules/[^/]+\.so', d.expand('${PN}-%s-modules'), 'IMSDK runtime modules for %s plugin', recursive=True, extra_depends='', match_path=True)
 }
 
-PACKAGES += "${PN}-configs ${PN}-media"
+PACKAGES += "${PN}-configs"
 
 FILES:${PN}-configs = "${sysconfdir}/configs/"
-
-FILES:${PN}-media = " \
-    ${datadir}/qdemo/* \
-"
-
-RDEPENDS:${PN}-apps += "${PN}-media"


### PR DESCRIPTION
Move the media packaging from packaging.inc to oss as it is preventing the proprietary plugins from getting packed into the image.