### PR TITLE
weston: simplify fragment shader helpers and external texture sampling

### DIFF
--- a/recipes-graphics/wayland/weston/0001-libweston-avoid-duplicate-texture2D_swizzle-overload.patch
+++ b/recipes-graphics/wayland/weston/0001-libweston-avoid-duplicate-texture2D_swizzle-overload.patch
@@ -1,0 +1,110 @@
+From 67790ddaa6a8d97ba776dbc72b8e6a5b12743fe9 Mon Sep 17 00:00:00 2001
+From: Mahesh Angadi <mangadi@qti.qualcomm.com>
+Date: Mon, 20 Apr 2026 10:17:33 +0530
+Subject: [PATCH 1/2] libweston: avoid duplicate texture2D_swizzle overloads by
+ selecting sampler internally
+
+Shader compilation failures have been observed on Adreno when fragment
+shaders use sampler-typed overloads of texture2D_swizzle(), including
+variants operating on external textures. The compiler reports:
+
+  'texture2D_swizzle' : function already has a body
+
+This causes shader compilation to fail and breaks rendering paths that
+rely on GPU composition.
+
+Although these overloads are valid GLSL, the Adreno compiler incorrectly
+treats them as duplicate function definitions.
+
+To work around this, rework texture2D_swizzle() to accept only (unit,
+coord) and select the concrete sampler (tex/tex1/tex2) internally. This
+avoids sampler-typed overload resolution while preserving the effective
+sampling behavior.
+
+This is a temporary workaround for a compiler limitation. The Adreno
+compiler is expected to implement complete support for external sampler
+uniforms (samplerExternalOES) and related overload patterns. Once that
+support is available in the target driver releases, this workaround
+should be dropped in favor of the upstream shader design.
+
+Upstream-Status: Inappropriate [Temporary work around]
+Signed-off-by: Mahesh Angadi <mangadi@qti.qualcomm.com>
+
+diff --git a/libweston/renderer-gl/fragment.glsl b/libweston/renderer-gl/fragment.glsl
+index 5eb21136..b75e59a8 100644
+--- a/libweston/renderer-gl/fragment.glsl
++++ b/libweston/renderer-gl/fragment.glsl
+@@ -166,12 +166,23 @@ uniform HIGHPRECISION mat3 cvd_correction_matrix;
+  * to draw call.
+  */
+ vec4
+-texture2D_swizzle(sampler2D sampler, int unit, vec2 coord)
++texture2D_swizzle(int unit, vec2 coord)
+ {
+ #if GLES_API_MAJOR_VERSION == 3
+-	return texture2D(sampler, coord);
++	if (unit == 0)
++	    return texture2D(tex, coord);
++	if (unit == 1)
++	    return texture2D(tex1, coord);
++	if (unit == 2)
++	    return texture2D(tex2, coord);
+ #else
+-	vec4 color = texture2D(sampler, coord);
++        vec4 color;
++	if (unit == 0)
++	    color = texture2D(tex, coord);
++	if (unit == 1)
++	    color = texture2D(tex1, coord);
++	if (unit == 2)
++	    color = texture2D(tex2, coord);
+ 
+ 	/* Swizzle components. */
+ 	color = vec4(color[swizzle_idx[unit].x],
+@@ -184,14 +195,6 @@ texture2D_swizzle(sampler2D sampler, int unit, vec2 coord)
+ #endif
+ }
+ 
+-#if DEF_VARIANT == SHADER_VARIANT_EXTERNAL
+-vec4
+-texture2D_swizzle(samplerExternalOES sampler, int unit, vec2 coord)
+-{
+-	return texture2D(sampler, coord);
+-}
+-#endif
+-
+ vec4
+ sample_input_texture()
+ {
+@@ -204,21 +207,21 @@ sample_input_texture()
+ 
+ 	if (c_variant == SHADER_VARIANT_EXTERNAL ||
+ 	    c_variant == SHADER_VARIANT_RGBA)
+-		return texture2D_swizzle(tex, 0, v_texcoord);
++		return texture2D_swizzle(0, v_texcoord);
+ 
+ 	/* Requires conversion to RGBA */
+ 
+ 	if (c_variant == SHADER_VARIANT_Y_U_V) {
+-		yuva.x = texture2D_swizzle(tex, 0, v_texcoord).r;
+-		yuva.y = texture2D_swizzle(tex1, 1, v_texcoord).r;
+-		yuva.z = texture2D_swizzle(tex2, 2, v_texcoord).r;
++		yuva.x = texture2D_swizzle(0, v_texcoord).r;
++		yuva.y = texture2D_swizzle(1, v_texcoord).r;
++		yuva.z = texture2D_swizzle(2, v_texcoord).r;
+ 
+ 	} else if (c_variant == SHADER_VARIANT_Y_UV) {
+-		yuva.x = texture2D_swizzle(tex, 0, v_texcoord).r;
+-		yuva.yz = texture2D_swizzle(tex1, 1, v_texcoord).rg;
++		yuva.x = texture2D_swizzle(0, v_texcoord).r;
++		yuva.yz = texture2D_swizzle(1, v_texcoord).rg;
+ 
+ 	} else if (c_variant == SHADER_VARIANT_XYUV) {
+-		yuva.xyz = texture2D_swizzle(tex, 0, v_texcoord).rgb;
++		yuva.xyz = texture2D_swizzle(0, v_texcoord).rgb;
+ 
+ 	} else {
+ 		/* Never reached, bad variant value. */
+-- 
+2.34.1
+

--- a/recipes-graphics/wayland/weston/0001-libweston-inline-color-pipeline-and-wireframe-helper.patch
+++ b/recipes-graphics/wayland/weston/0001-libweston-inline-color-pipeline-and-wireframe-helper.patch
@@ -1,0 +1,133 @@
+From bc75ba659e241dc2b0a56250788806626d92e7c3 Mon Sep 17 00:00:00 2001
+From: Mahesh Angadi <mangadi@qti.qualcomm.com>
+Date: Mon, 20 Apr 2026 10:43:58 +0530
+Subject: [PATCH 2/2] libweston: inline color pipeline and wireframe helpers in
+ fragment shader
+
+Remove small helper functions used only by the fragment shader main()
+path and inline their logic directly at the call sites.
+
+This keeps all color pipeline, color effect, and wireframe handling
+self-contained in main(), reducing indirection and simplifying shader
+control flow without changing rendering behavior.
+
+This change is part of a temporary workaround for shader compilation
+issues observed on Adreno when using fragment shader helper patterns
+alongside external texture sampling.
+
+The Adreno compiler will implement complete functionality to correctly
+handle external sampler uniforms (samplerExternalOES) and related shader
+patterns. Once that support is available in the target driver releases,
+this workaround should be dropped in favor of the upstream shader
+design.
+
+Upstream-Status: Inappropriate [Temporary work around]
+Signed-off-by: Mahesh Angadi <mangadi@qti.qualcomm.com>
+
+diff --git a/libweston/renderer-gl/fragment.glsl b/libweston/renderer-gl/fragment.glsl
+index b75e59a8..ae4d56ed 100644
+--- a/libweston/renderer-gl/fragment.glsl
++++ b/libweston/renderer-gl/fragment.glsl
+@@ -439,53 +439,6 @@ color_mapping(vec3 color)
+ 		return vec3(1.0, 0.3, 1.0);
+ }
+ 
+-vec4
+-color_pipeline(vec4 color)
+-{
+-	color.rgb = color_curve(c_color_pre_curve, color_pre_curve_lut,
+-				color_pre_curve_par, color.rgb);
+-	color.rgb = color_mapping(color.rgb);
+-	color.rgb = color_curve(c_color_post_curve, color_post_curve_lut,
+-				color_post_curve_par, color.rgb);
+-
+-	return color;
+-}
+-
+-vec4
+-color_inversion(vec4 color)
+-{
+-	color.rgb = 1.0 - color.rgb;
+-
+-	return color;
+-}
+-
+-vec4
+-color_cvd_correction(vec4 color)
+-{
+-	vec3 original;
+-
+-	/**
+-	 * See weston_output_color_effect_cvd_correction() for more details.
+-	 */
+-
+-	original = color.rgb;
+-
+-	color.rgb = cvd_correction_matrix * original;
+-	color.rgb = clamp(color.rgb, 0.0, 1.0);
+-
+-	return color;
+-}
+-
+-vec4
+-wireframe()
+-{
+-	float edge1 = texture2D(tex_wireframe, vec2(v_barycentric.x, 0.5)).r;
+-	float edge2 = texture2D(tex_wireframe, vec2(v_barycentric.y, 0.5)).r;
+-	float edge3 = texture2D(tex_wireframe, vec2(v_barycentric.z, 0.5)).r;
+-
+-	return vec4(clamp(edge1 + edge2 + edge3, 0.0, 1.0));
+-}
+-
+ void
+ main()
+ {
+@@ -503,12 +456,26 @@ main()
+ 	}
+ 
+ 	/* For now color management and color effects do not coexist */
+-	if (c_need_color_pipeline)
+-		color = color_pipeline(color);
+-	else if (c_color_effect == SHADER_COLOR_EFFECT_INVERSION)
+-		color = color_inversion(color);
+-	else if (c_color_effect == SHADER_COLOR_EFFECT_CVD_CORRECTION)
+-		color = color_cvd_correction(color);
++	if (c_need_color_pipeline) {
++
++		color.rgb = color_curve(c_color_pre_curve, color_pre_curve_lut,
++					color_pre_curve_par, color.rgb);
++		color.rgb = color_mapping(color.rgb);
++		color.rgb = color_curve(c_color_post_curve, color_post_curve_lut,
++					color_post_curve_par, color.rgb);
++	}
++	else if (c_color_effect == SHADER_COLOR_EFFECT_INVERSION) {
++		color.rgb = 1.0 - color.rgb;
++	}
++	else if (c_color_effect == SHADER_COLOR_EFFECT_CVD_CORRECTION) {
++		vec3 original;
++		/**
++		 * See weston_output_color_effect_cvd_correction() for more details.
++		 */
++		original = color.rgb;
++		color.rgb = cvd_correction_matrix * original;
++		color.rgb = clamp(color.rgb, 0.0, 1.0);
++	}
+ 
+ 	/* Ensure pre-multiplied for blending */
+ 	if (!c_input_is_premult || (c_input_is_premult && c_need_straight_alpha))
+@@ -520,7 +487,11 @@ main()
+ 		color = color * vec4(1.0 - tint.a) + tint;
+ 
+ 	if (c_wireframe) {
+-		vec4 src = wireframe();
++		vec4 src;
++		float edge1 = texture2D(tex_wireframe, vec2(v_barycentric.x, 0.5)).r;
++		float edge2 = texture2D(tex_wireframe, vec2(v_barycentric.y, 0.5)).r;
++		float edge3 = texture2D(tex_wireframe, vec2(v_barycentric.z, 0.5)).r;
++		src = vec4(clamp(edge1 + edge2 + edge3, 0.0, 1.0));
+ 		color = color * vec4(1.0 - src.a) + src;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/recipes-graphics/wayland/weston_15.0.0.bbappend
+++ b/recipes-graphics/wayland/weston_15.0.0.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-libweston-avoid-duplicate-texture2D_swizzle-overload.patch \
+    file://0001-libweston-inline-color-pipeline-and-wireframe-helper.patch \
+"


### PR DESCRIPTION
weston: Mitigate Adreno fragment shader compilation failures in Westonv15
Weston v15 introduces fragment shader structures and helper patterns
that
exercise valid GLSL features such as helper functions and sampler-typed
overloads, including variants operating on external textures. On Adreno,
these patterns trigger fragment shader compilation failures, preventing
shader program generation.

The failure manifests as a compiler error:

  'texture2D_swizzle' : function already has a body

As a result, rendering paths that rely on GPU composition fail. In
practice, this affects use cases that cannot rely solely on hardware
planes, including scenarios involving external textures and
multi‑planar buffers, while hardware-plane-only paths remain unaffected.

Although the affected shader constructs are valid GLSL, the Adreno
compiler currently mishandles specific combinations of helper functions,
sampler-typed overloads, and external texture sampling. These issues are
exposed by the more structured and modular fragment shader code used in
Weston v15.

This series introduces a minimal and contained workaround in libweston
to
avoid triggering the problematic compiler paths:

- The first change reworks texture2D_swizzle() to eliminate
  sampler-typed
  overloads by selecting the concrete sampler internally based on the
  texture unit. This directly avoids the duplicate-definition error
while
  preserving the intended sampling behavior.

- The second change inlines small fragment shader helper functions into
  main(), reducing helper layering and shader indirection. While
  functionally neutral, this further avoids shader patterns that reach
  the same problematic compiler behavior.