### PR TITLE
Update boot firmware release to 00123 and enable tech pack based releases

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -2,14 +2,12 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS615 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public"
-FW_BUILD_ID = "r1.0_${PV}/QCS615.LE.1.0"
-FW_BIN_PATH = "common/build/common/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS615_bootbinaries.1.0/qcs615_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "QCS615_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
     "
 SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00122.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00122.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "973a3116f77fab22e378848d6e40c48ba20ce4b14e019e44234c844c8bb87838"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00123.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "9693a9d6ceeb8ecd47f6d8f7a4e28180602973d7d47da77673023a6fa7ad5789"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
@@ -2,14 +2,12 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Robotics RB3Gen2 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public"
-FW_BUILD_ID = "r1.0_${PV}/QCM6490.LE.1.0"
-FW_BIN_PATH = "common/build/ufs/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCM6490_bootbinaries.1.0/qcm6490_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "QCM6490_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/qcm6490-idp.zip;downloadfilename=cdt-qcm6490-idp_${PV}.zip;name=qcm6490-idp \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-industrial-kit.zip;downloadfilename=cdt-rb3gen2-industrial-kit_${PV}.zip;name=rb3gen2-industrial-kit \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00122.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00122.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "287ac42f1429a36e9867e09cf6a6fd979ebf929e6606ca9308bf15f901d010df"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00123.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "df120b750128166c9f8f9ad28c7ecd30d3938c2750a250f2a12362757dc416b0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -2,14 +2,12 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS8300 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public"
-FW_BUILD_ID = "r1.0_${PV}/QCS8300.LE.1.0"
-FW_BIN_PATH = "common/build/ufs/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS8300_bootbinaries.1.0/qcs8300_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "QCS8300_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \
     "

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00122.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00122.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "f14c2f0dc9911f081e90c6be077139e4f29cd70d8b0f0089f4e1b9e592613a06"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00123.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "a0fca33863d5a665535717aa943d668d3ffa9e2970bbc10e7e5d04d9269a1b1f"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -2,14 +2,12 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS9100 platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public"
-FW_BUILD_ID = "r1.0_${PV}/QCS9100.LE.1.0"
-FW_BIN_PATH = "common/build/ufs/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS9100_bootbinaries.1.0/qcs9100_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "QCS9100_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx_v3.zip;downloadfilename=cdt-qcs9100-ride-sx-v3_${PV}.zip;name=qcs9100-ride-sx \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/rb8_core_kit.zip;downloadfilename=cdt-qcs9100-rb8-core-kit_${PV}.zip;name=qcs9100-rb8-ck \
     "

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00122.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00122.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "0b2bfc49a1501bdc2985a2d82b2c5395c87d4ca21070686a8da73a03c73e1fdc"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00123.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "74bc46555034173a4d5282fe96b1e96e0874cfd7f874f4483d431eaa72300345"


### PR DESCRIPTION
Tech pack based release path and versioning is for SPF agnostic paths across QLI targets. This enabled SP level versioning of boot bins.

Known fixes:

QCS9100
fix(spi): improve AC policy logic and ensure operations stay within timing and access constraints to prevent faults
feat(can): add support for CAN channel 0
fix(sbl): prevent unauthorized privilege escalation during boot
fix(tee): resolve random app crashes in concurrent secure sessions

QCS8300
fix(spi): improve AC policy logic and ensure operations stay within timing and access constraints to prevent faults
feat(can): add support for CAN channel 0
feat(kvm): enable KVM PIL Auth & Reset
feat(dsp): enable DSP start and stop via remoteproc in Gunyah/KVM
fix(sbl): prevent unauthorized privilege escalation during boot
fix(tee): resolve random app crashes in concurrent secure sessions

QCS615
feat(kvm): enable KVM PIL Auth & Reset
feat(dsp): enable DSP start and stop via remoteproc in Gunyah/KVM
fix(sbl): prevent unauthorized privilege escalation during boot
fix(tee): resolve random app crashes in concurrent secure sessions
fix(camera): resolve firmware download failure causing camera test failures

QCM6490
fix(sbl): prevent unauthorized privilege escalation during boot
fix(tee): resolve random app crashes in concurrent secure sessions