### PR TITLE
ci: yocto-pybootchartgui: analyze the most recent build

### DIFF
--- a/ci/yocto-pybootchartgui.sh
+++ b/ci/yocto-pybootchartgui.sh
@@ -21,15 +21,21 @@ _is_dir(){
 _is_dir "$REPO_DIR"
 _is_dir "$WORK_DIR"
 
+# latest buildstats folder
+BUILDSTATS="$WORK_DIR/build/tmp/buildstats"
+BUILDSTATS="$BUILDSTATS/$(ls $BUILDSTATS | tail -1)"
+
 # pybootchartgui tool
 CMD="$CMD $WORK_DIR/oe-core/scripts/pybootchartgui/pybootchartgui.py"
 # display time in minutes instead of seconds
 CMD="$CMD --minutes"
+# display the full time regardless of which processes are currently shown
+CMD="$CMD --full-time"
 # image format (png, svg, pdf); default format png
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
 CMD="$CMD --output=buildchart"
 # /path/to/tmp/buildstats/<recipe-machine>/<BUILDNAME>/
-CMD="$CMD $WORK_DIR/build/tmp/buildstats"
+CMD="$CMD $BUILDSTATS"
 
 exec $CMD


### PR DESCRIPTION
The pybootchartgui script needs the full path because otherwise it will always use the same build from among the available ones. What was happening was that we were always analyzing the first one when we should have been looking at the last one.

Also add --full-time argument to display the full time regardless
of which processes are currently shown.