### PR TITLE
linux-yocto: Add support for KVM across multiple SoCs

### DIFF
--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/mdtloader/0004-soc-qcom-mdtloader-Add-PAS-context-aware-qcom_mdt_pa.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/mdtloader/0004-soc-qcom-mdtloader-Add-PAS-context-aware-qcom_mdt_pa.patch
@@ -1,0 +1,150 @@
+From 5df4e58dcc528bcdb294b74236b166899d8d49f5 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:54 +0530
+Subject: [PATCH 04/12] soc: qcom: mdtloader: Add PAS context aware
+ qcom_mdt_pas_load() function
+
+Introduce a new PAS context-aware function, qcom_mdt_pas_load(), for
+remote processor drivers. This function utilizes the PAS context
+pointer returned from qcom_scm_pas_ctx_init() to perform firmware
+metadata verification and memory setup via SMC calls.
+
+The qcom_mdt_pas_load() and qcom_mdt_load() functions are largely
+similar, but the former is designed for clients using the PAS
+context-based data structure. Over time, all users of qcom_mdt_load()
+can be migrated to use qcom_mdt_pas_load() for consistency and
+improved abstraction.
+
+As the remoteproc PAS driver (qcom_q6v5_pas) has already adopted the
+PAS context-based approach, update it to use qcom_mdt_pas_load().
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 8a4fcffde6c8]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c  | 24 +++++-----------------
+ drivers/soc/qcom/mdt_loader.c       | 31 +++++++++++++++++++++++++++++
+ include/linux/soc/qcom/mdt_loader.h | 10 ++++++++++
+ 3 files changed, 46 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 5f90976e5b41..0c4ec72352e3 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -239,15 +239,9 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 			return ret;
+ 		}
+ 
+-		ret = qcom_mdt_pas_init(pas->dev, pas->dtb_firmware, pas->dtb_firmware_name,
+-					pas->dtb_pas_id, pas->dtb_mem_phys,
+-					pas->dtb_pas_ctx);
+-		if (ret)
+-			goto release_dtb_firmware;
+-
+-		ret = qcom_mdt_load_no_init(pas->dev, pas->dtb_firmware, pas->dtb_firmware_name,
+-					    pas->dtb_mem_region, pas->dtb_mem_phys,
+-					    pas->dtb_mem_size, &pas->dtb_mem_reloc);
++		ret = qcom_mdt_pas_load(pas->dtb_pas_ctx, pas->dtb_firmware,
++					pas->dtb_firmware_name, pas->dtb_mem_region,
++					&pas->dtb_mem_reloc);
+ 		if (ret)
+ 			goto release_dtb_metadata;
+ 	}
+@@ -256,8 +250,6 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 
+ release_dtb_metadata:
+ 	qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
+-
+-release_dtb_firmware:
+ 	release_firmware(pas->dtb_firmware);
+ 
+ 	return ret;
+@@ -305,14 +297,8 @@ static int qcom_pas_start(struct rproc *rproc)
+ 		}
+ 	}
+ 
+-	ret = qcom_mdt_pas_init(pas->dev, pas->firmware, rproc->firmware, pas->pas_id,
+-				pas->mem_phys, pas->pas_ctx);
+-	if (ret)
+-		goto disable_px_supply;
+-
+-	ret = qcom_mdt_load_no_init(pas->dev, pas->firmware, rproc->firmware,
+-				    pas->mem_region, pas->mem_phys, pas->mem_size,
+-				    &pas->mem_reloc);
++	ret = qcom_mdt_pas_load(pas->pas_ctx, pas->firmware, rproc->firmware,
++				pas->mem_region, &pas->mem_reloc);
+ 	if (ret)
+ 		goto release_pas_metadata;
+ 
+diff --git a/drivers/soc/qcom/mdt_loader.c b/drivers/soc/qcom/mdt_loader.c
+index fe35038c5342..847941d232f7 100644
+--- a/drivers/soc/qcom/mdt_loader.c
++++ b/drivers/soc/qcom/mdt_loader.c
+@@ -486,5 +486,36 @@ int qcom_mdt_load_no_init(struct device *dev, const struct firmware *fw,
+ }
+ EXPORT_SYMBOL_GPL(qcom_mdt_load_no_init);
+ 
++/**
++ * qcom_mdt_pas_load - Loads and authenticates the metadata of the firmware
++ * (typically contained in the .mdt file), followed by loading the actual
++ * firmware segments (e.g., .bXX files). Authentication of the segments done
++ * by a separate call.
++ *
++ * The PAS context must be initialized using qcom_scm_pas_context_init()
++ * prior to invoking this function.
++ *
++ * @ctx:        Pointer to the PAS (Peripheral Authentication Service) context
++ * @fw:         Firmware object representing the .mdt file
++ * @firmware:   Name of the firmware used to construct segment file names
++ * @mem_region: Memory region allocated for loading the firmware
++ * @reloc_base: Physical address adjusted after relocation
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
++		      const char *firmware, void *mem_region, phys_addr_t *reloc_base)
++{
++	int ret;
++
++	ret = qcom_mdt_pas_init(ctx->dev, fw, firmware, ctx->pas_id, ctx->mem_phys, ctx);
++	if (ret)
++		return ret;
++
++	return qcom_mdt_load_no_init(ctx->dev, fw, firmware, mem_region, ctx->mem_phys,
++				     ctx->mem_size, reloc_base);
++}
++EXPORT_SYMBOL_GPL(qcom_mdt_pas_load);
++
+ MODULE_DESCRIPTION("Firmware parser for Qualcomm MDT format");
+ MODULE_LICENSE("GPL v2");
+diff --git a/include/linux/soc/qcom/mdt_loader.h b/include/linux/soc/qcom/mdt_loader.h
+index 07c278841816..7d57746fbbfa 100644
+--- a/include/linux/soc/qcom/mdt_loader.h
++++ b/include/linux/soc/qcom/mdt_loader.h
+@@ -23,6 +23,9 @@ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 		  phys_addr_t mem_phys, size_t mem_size,
+ 		  phys_addr_t *reloc_base);
+ 
++int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
++		      const char *firmware, void *mem_region, phys_addr_t *reloc_base);
++
+ int qcom_mdt_load_no_init(struct device *dev, const struct firmware *fw,
+ 			  const char *fw_name, void *mem_region,
+ 			  phys_addr_t mem_phys, size_t mem_size,
+@@ -52,6 +55,13 @@ static inline int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 	return -ENODEV;
+ }
+ 
++static inline int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx,
++				    const struct firmware *fw, const char *firmware,
++				    void *mem_region, phys_addr_t *reloc_base)
++{
++	return -ENODEV;
++}
++
+ static inline int qcom_mdt_load_no_init(struct device *dev,
+ 					const struct firmware *fw,
+ 					const char *fw_name, void *mem_region,
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/mdtloader/0005-soc-qcom-mdtloader-Remove-qcom_mdt_pas_init-from-exp.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/mdtloader/0005-soc-qcom-mdtloader-Remove-qcom_mdt_pas_init-from-exp.patch
@@ -1,0 +1,107 @@
+From 06dc70ab11551f5e2d234bfbc528a452cf6462bd Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:55 +0530
+Subject: [PATCH 05/12] soc: qcom: mdtloader: Remove qcom_mdt_pas_init() from
+ exported symbols
+
+qcom_mdt_pas_init() was previously used only by the remoteproc driver
+(drivers/remoteproc/qcom_q6v5_pas.c). Since that driver has now
+transitioned to using PAS context-based qcom_mdt_pas_load() function,
+making qcom_mdt_pas_init() obsolete for external use.
+
+Removes qcom_mdt_pas_init() from the list of exported symbols and make
+it static to limit its scope to internal use within mdtloader.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 928dbaaa9d89]
+---
+ drivers/soc/qcom/mdt_loader.c       | 22 +++++-----------------
+ include/linux/soc/qcom/mdt_loader.h | 10 ----------
+ 2 files changed, 5 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/soc/qcom/mdt_loader.c b/drivers/soc/qcom/mdt_loader.c
+index 847941d232f7..1ca03472552c 100644
+--- a/drivers/soc/qcom/mdt_loader.c
++++ b/drivers/soc/qcom/mdt_loader.c
+@@ -227,20 +227,9 @@ void *qcom_mdt_read_metadata(const struct firmware *fw, size_t *data_len,
+ }
+ EXPORT_SYMBOL_GPL(qcom_mdt_read_metadata);
+ 
+-/**
+- * qcom_mdt_pas_init() - initialize PAS region for firmware loading
+- * @dev:	device handle to associate resources with
+- * @fw:		firmware object for the mdt file
+- * @fw_name:	name of the firmware, for construction of segment file names
+- * @pas_id:	PAS identifier
+- * @mem_phys:	physical address of allocated memory region
+- * @ctx:	PAS context, ctx->metadata to be released by caller
+- *
+- * Returns 0 on success, negative errno otherwise.
+- */
+-int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+-		      const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-		      struct qcom_scm_pas_context *ctx)
++static int __qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
++			       const char *fw_name, int pas_id, phys_addr_t mem_phys,
++			       struct qcom_scm_pas_context *ctx)
+ {
+ 	const struct elf32_phdr *phdrs;
+ 	const struct elf32_phdr *phdr;
+@@ -302,7 +291,6 @@ int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+ out:
+ 	return ret;
+ }
+-EXPORT_SYMBOL_GPL(qcom_mdt_pas_init);
+ 
+ static bool qcom_mdt_bins_are_split(const struct firmware *fw)
+ {
+@@ -456,7 +444,7 @@ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ {
+ 	int ret;
+ 
+-	ret = qcom_mdt_pas_init(dev, fw, firmware, pas_id, mem_phys, NULL);
++	ret = __qcom_mdt_pas_init(dev, fw, firmware, pas_id, mem_phys, NULL);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -508,7 +496,7 @@ int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *f
+ {
+ 	int ret;
+ 
+-	ret = qcom_mdt_pas_init(ctx->dev, fw, firmware, ctx->pas_id, ctx->mem_phys, ctx);
++	ret = __qcom_mdt_pas_init(ctx->dev, fw, firmware, ctx->pas_id, ctx->mem_phys, ctx);
+ 	if (ret)
+ 		return ret;
+ 
+diff --git a/include/linux/soc/qcom/mdt_loader.h b/include/linux/soc/qcom/mdt_loader.h
+index 7d57746fbbfa..82372e0db0a1 100644
+--- a/include/linux/soc/qcom/mdt_loader.h
++++ b/include/linux/soc/qcom/mdt_loader.h
+@@ -15,9 +15,6 @@ struct qcom_scm_pas_context;
+ #if IS_ENABLED(CONFIG_QCOM_MDT_LOADER)
+ 
+ ssize_t qcom_mdt_get_size(const struct firmware *fw);
+-int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+-		      const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-		      struct qcom_scm_pas_context *pas_ctx);
+ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 		  const char *fw_name, int pas_id, void *mem_region,
+ 		  phys_addr_t mem_phys, size_t mem_size,
+@@ -40,13 +37,6 @@ static inline ssize_t qcom_mdt_get_size(const struct firmware *fw)
+ 	return -ENODEV;
+ }
+ 
+-static inline int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+-				    const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-				    struct qcom_scm_pas_context *pas_ctx)
+-{
+-	return -ENODEV;
+-}
+-
+ static inline int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 				const char *fw_name, int pas_id,
+ 				void *mem_region, phys_addr_t mem_phys,
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0003-remoteproc-pas-Replace-metadata-context-with-PAS-con.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0003-remoteproc-pas-Replace-metadata-context-with-PAS-con.patch
@@ -1,0 +1,239 @@
+From 3d7b6159d1946586d5c881d20229964fbcb36ca7 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:53 +0530
+Subject: [PATCH 03/12] remoteproc: pas: Replace metadata context with PAS
+ context structure
+
+As a superset of the existing metadata context, the PAS context
+structure enables both remoteproc and non-remoteproc subsystems to
+better support scenarios where the SoC runs with or without the Gunyah
+hypervisor. To reflect this, relevant SCM and metadata functions are
+updated to incorporate PAS context awareness and remove metadata context
+data structure completely.
+
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git b13d8baf5601]
+---
+ drivers/firmware/qcom/qcom_scm.c       |  8 +++---
+ drivers/remoteproc/qcom_q6v5_pas.c     | 38 ++++++++++++++++++--------
+ drivers/soc/qcom/mdt_loader.c          |  4 +--
+ include/linux/firmware/qcom/qcom_scm.h | 10 ++-----
+ include/linux/soc/qcom/mdt_loader.h    |  6 ++--
+ 5 files changed, 38 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index 2e51c4d80fdc..f60254eb117e 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -601,7 +601,7 @@ EXPORT_SYMBOL_GPL(devm_qcom_scm_pas_context_alloc);
+  *		and optional blob of data used for authenticating the metadata
+  *		and the rest of the firmware
+  * @size:	size of the metadata
+- * @ctx:	optional metadata context
++ * @ctx:	optional pas context
+  *
+  * Return: 0 on success.
+  *
+@@ -610,7 +610,7 @@ EXPORT_SYMBOL_GPL(devm_qcom_scm_pas_context_alloc);
+  * qcom_scm_pas_metadata_release() by the caller.
+  */
+ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+-			    struct qcom_scm_pas_metadata *ctx)
++			    struct qcom_scm_pas_context *ctx)
+ {
+ 	dma_addr_t mdata_phys;
+ 	void *mdata_buf;
+@@ -674,9 +674,9 @@ EXPORT_SYMBOL_GPL(qcom_scm_pas_init_image);
+ 
+ /**
+  * qcom_scm_pas_metadata_release() - release metadata context
+- * @ctx:	metadata context
++ * @ctx:	pas context
+  */
+-void qcom_scm_pas_metadata_release(struct qcom_scm_pas_metadata *ctx)
++void qcom_scm_pas_metadata_release(struct qcom_scm_pas_context *ctx)
+ {
+ 	if (!ctx->ptr)
+ 		return;
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 158bcd6cc85c..5f90976e5b41 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -117,8 +117,8 @@ struct qcom_pas {
+ 	struct qcom_rproc_ssr ssr_subdev;
+ 	struct qcom_sysmon *sysmon;
+ 
+-	struct qcom_scm_pas_metadata pas_metadata;
+-	struct qcom_scm_pas_metadata dtb_pas_metadata;
++	struct qcom_scm_pas_context *pas_ctx;
++	struct qcom_scm_pas_context *dtb_pas_ctx;
+ };
+ 
+ static void qcom_pas_segment_dump(struct rproc *rproc,
+@@ -211,9 +211,9 @@ static int qcom_pas_unprepare(struct rproc *rproc)
+ 	 * auth_and_reset() was successful, but in other cases clean it up
+ 	 * here.
+ 	 */
+-	qcom_scm_pas_metadata_release(&pas->pas_metadata);
++	qcom_scm_pas_metadata_release(pas->pas_ctx);
+ 	if (pas->dtb_pas_id)
+-		qcom_scm_pas_metadata_release(&pas->dtb_pas_metadata);
++		qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
+ 
+ 	return 0;
+ }
+@@ -241,7 +241,7 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 
+ 		ret = qcom_mdt_pas_init(pas->dev, pas->dtb_firmware, pas->dtb_firmware_name,
+ 					pas->dtb_pas_id, pas->dtb_mem_phys,
+-					&pas->dtb_pas_metadata);
++					pas->dtb_pas_ctx);
+ 		if (ret)
+ 			goto release_dtb_firmware;
+ 
+@@ -255,7 +255,7 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 	return 0;
+ 
+ release_dtb_metadata:
+-	qcom_scm_pas_metadata_release(&pas->dtb_pas_metadata);
++	qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
+ 
+ release_dtb_firmware:
+ 	release_firmware(pas->dtb_firmware);
+@@ -306,7 +306,7 @@ static int qcom_pas_start(struct rproc *rproc)
+ 	}
+ 
+ 	ret = qcom_mdt_pas_init(pas->dev, pas->firmware, rproc->firmware, pas->pas_id,
+-				pas->mem_phys, &pas->pas_metadata);
++				pas->mem_phys, pas->pas_ctx);
+ 	if (ret)
+ 		goto disable_px_supply;
+ 
+@@ -332,9 +332,9 @@ static int qcom_pas_start(struct rproc *rproc)
+ 		goto release_pas_metadata;
+ 	}
+ 
+-	qcom_scm_pas_metadata_release(&pas->pas_metadata);
++	qcom_scm_pas_metadata_release(pas->pas_ctx);
+ 	if (pas->dtb_pas_id)
+-		qcom_scm_pas_metadata_release(&pas->dtb_pas_metadata);
++		qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
+ 
+ 	/* firmware is used to pass reference from qcom_pas_start(), drop it now */
+ 	pas->firmware = NULL;
+@@ -342,9 +342,9 @@ static int qcom_pas_start(struct rproc *rproc)
+ 	return 0;
+ 
+ release_pas_metadata:
+-	qcom_scm_pas_metadata_release(&pas->pas_metadata);
++	qcom_scm_pas_metadata_release(pas->pas_ctx);
+ 	if (pas->dtb_pas_id)
+-		qcom_scm_pas_metadata_release(&pas->dtb_pas_metadata);
++		qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
+ disable_px_supply:
+ 	if (pas->px_supply)
+ 		regulator_disable(pas->px_supply);
+@@ -779,6 +779,22 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	qcom_add_ssr_subdev(rproc, &pas->ssr_subdev, desc->ssr_name);
++
++	pas->pas_ctx = devm_qcom_scm_pas_context_alloc(pas->dev, pas->pas_id,
++						       pas->mem_phys, pas->mem_size);
++	if (IS_ERR(pas->pas_ctx)) {
++		ret = PTR_ERR(pas->pas_ctx);
++		goto remove_ssr_sysmon;
++	}
++
++	pas->dtb_pas_ctx = devm_qcom_scm_pas_context_alloc(pas->dev, pas->dtb_pas_id,
++							   pas->dtb_mem_phys,
++							   pas->dtb_mem_size);
++	if (IS_ERR(pas->dtb_pas_ctx)) {
++		ret = PTR_ERR(pas->dtb_pas_ctx);
++		goto remove_ssr_sysmon;
++	}
++
+ 	ret = rproc_add(rproc);
+ 	if (ret)
+ 		goto remove_ssr_sysmon;
+diff --git a/drivers/soc/qcom/mdt_loader.c b/drivers/soc/qcom/mdt_loader.c
+index a5c80d4fcc36..fe35038c5342 100644
+--- a/drivers/soc/qcom/mdt_loader.c
++++ b/drivers/soc/qcom/mdt_loader.c
+@@ -234,13 +234,13 @@ EXPORT_SYMBOL_GPL(qcom_mdt_read_metadata);
+  * @fw_name:	name of the firmware, for construction of segment file names
+  * @pas_id:	PAS identifier
+  * @mem_phys:	physical address of allocated memory region
+- * @ctx:	PAS metadata context, to be released by caller
++ * @ctx:	PAS context, ctx->metadata to be released by caller
+  *
+  * Returns 0 on success, negative errno otherwise.
+  */
+ int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+ 		      const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-		      struct qcom_scm_pas_metadata *ctx)
++		      struct qcom_scm_pas_context *ctx)
+ {
+ 	const struct elf32_phdr *phdrs;
+ 	const struct elf32_phdr *phdr;
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index 5045f8fe876d..ad69b51fe6fc 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -66,12 +66,6 @@ int qcom_scm_set_warm_boot_addr(void *entry);
+ void qcom_scm_cpu_power_down(u32 flags);
+ int qcom_scm_set_remote_state(u32 state, u32 id);
+ 
+-struct qcom_scm_pas_metadata {
+-	void *ptr;
+-	dma_addr_t phys;
+-	ssize_t size;
+-};
+-
+ struct qcom_scm_pas_context {
+ 	struct device *dev;
+ 	u32 pas_id;
+@@ -87,8 +81,8 @@ struct qcom_scm_pas_context *devm_qcom_scm_pas_context_alloc(struct device *dev,
+ 							     phys_addr_t mem_phys,
+ 							     size_t mem_size);
+ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+-			    struct qcom_scm_pas_metadata *ctx);
+-void qcom_scm_pas_metadata_release(struct qcom_scm_pas_metadata *ctx);
++			    struct qcom_scm_pas_context *ctx);
++void qcom_scm_pas_metadata_release(struct qcom_scm_pas_context *ctx);
+ int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size);
+ int qcom_scm_pas_auth_and_reset(u32 pas_id);
+ int qcom_scm_pas_shutdown(u32 pas_id);
+diff --git a/include/linux/soc/qcom/mdt_loader.h b/include/linux/soc/qcom/mdt_loader.h
+index 8ea8230579a2..07c278841816 100644
+--- a/include/linux/soc/qcom/mdt_loader.h
++++ b/include/linux/soc/qcom/mdt_loader.h
+@@ -10,14 +10,14 @@
+ 
+ struct device;
+ struct firmware;
+-struct qcom_scm_pas_metadata;
++struct qcom_scm_pas_context;
+ 
+ #if IS_ENABLED(CONFIG_QCOM_MDT_LOADER)
+ 
+ ssize_t qcom_mdt_get_size(const struct firmware *fw);
+ int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+ 		      const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-		      struct qcom_scm_pas_metadata *pas_metadata_ctx);
++		      struct qcom_scm_pas_context *pas_ctx);
+ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 		  const char *fw_name, int pas_id, void *mem_region,
+ 		  phys_addr_t mem_phys, size_t mem_size,
+@@ -39,7 +39,7 @@ static inline ssize_t qcom_mdt_get_size(const struct firmware *fw)
+ 
+ static inline int qcom_mdt_pas_init(struct device *dev, const struct firmware *fw,
+ 				    const char *fw_name, int pas_id, phys_addr_t mem_phys,
+-				    struct qcom_scm_pas_metadata *pas_metadata_ctx)
++				    struct qcom_scm_pas_context *pas_ctx)
+ {
+ 	return -ENODEV;
+ }
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0010-remoteproc-pas-Extend-parse_fw-callback-to-fetch-res.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0010-remoteproc-pas-Extend-parse_fw-callback-to-fetch-res.patch
@@ -1,0 +1,121 @@
+From 2e946be4d903d467987ef3546adddcd6e03a5a6d Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:53:00 +0530
+Subject: [PATCH 10/12] remoteproc: pas: Extend parse_fw callback to fetch
+ resources via SMC call
+
+Qualcomm remote processor may rely on static and dynamic resources for
+it to be functional. For most of the Qualcomm SoCs, when run with Gunyah
+or older QHEE hypervisor, all the resources whether it is static or
+dynamic, is managed by the hypervisor. Dynamic resources if it is
+present for a remote processor will always be coming from secure world
+via SMC call while static resources may be present in remote processor
+firmware binary or it may be coming from SMC call along with dynamic
+resources.
+
+Remoteproc already has method like rproc_elf_load_rsc_table() to check
+firmware binary has resources or not and if it is not having then we
+pass NULL and zero as input resource table and its size argument
+respectively to qcom_scm_pas_get_rsc_table() and while it has resource
+present then it should pass the present resources to Trustzone(TZ) so that
+it could authenticate the present resources and append dynamic resource
+to return in output_rt argument along with authenticated resources.
+
+Extend parse_fw callback to include SMC call to get resources from
+Trustzone and to leverage resource table parsing and mapping and
+unmapping code from the remoteproc framework.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git a4584bff63c8]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 59 +++++++++++++++++++++++++++++-
+ 1 file changed, 57 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 0c4ec72352e3..dc0e1878e6b4 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -413,6 +413,61 @@ static void *qcom_pas_da_to_va(struct rproc *rproc, u64 da, size_t len, bool *is
+ 	return pas->mem_region + offset;
+ }
+ 
++static int qcom_pas_parse_firmware(struct rproc *rproc, const struct firmware *fw)
++{
++	struct qcom_pas *pas = rproc->priv;
++	struct resource_table *table = NULL;
++	size_t output_rt_size;
++	void *output_rt;
++	size_t table_sz;
++	int ret;
++
++	ret = qcom_register_dump_segments(rproc, fw);
++	if (ret) {
++		dev_err(pas->dev, "Error in registering dump segments\n");
++		return ret;
++	}
++
++	if (!rproc->has_iommu)
++		return 0;
++
++	ret = rproc_elf_load_rsc_table(rproc, fw);
++	if (ret)
++		dev_dbg(&rproc->dev, "Failed to load resource table from firmware\n");
++
++	table = rproc->table_ptr;
++	table_sz = rproc->table_sz;
++
++	/*
++	 * The resources consumed by Qualcomm remote processors fall into two categories:
++	 * static (such as the memory carveouts for the rproc firmware) and dynamic (like
++	 * shared memory pools). Both are managed by a Qualcomm hypervisor (such as QHEE
++	 * or Gunyah), if one is present. Otherwise, a resource table must be retrieved
++	 * via an SCM call. That table will list all dynamic resources (if any) and possibly
++	 * the static ones. The static resources may also come from a resource table embedded
++	 * in the rproc firmware instead.
++	 *
++	 * Here, we call rproc_elf_load_rsc_table() to check firmware binary has resources
++	 * or not and if it is not having then we pass NULL and zero as input resource
++	 * table pointer and size respectively to the argument of qcom_scm_pas_get_rsc_table()
++	 * and this is even true for Qualcomm remote processor who does follow remoteproc
++	 * framework.
++	 */
++	output_rt = qcom_scm_pas_get_rsc_table(pas->pas_ctx, table, table_sz, &output_rt_size);
++	ret = IS_ERR(output_rt) ? PTR_ERR(output_rt) : 0;
++	if (ret) {
++		dev_err(pas->dev, "Error in getting resource table: %d\n", ret);
++		return ret;
++	}
++
++	kfree(rproc->cached_table);
++	rproc->cached_table = output_rt;
++	rproc->table_ptr = rproc->cached_table;
++	rproc->table_sz = output_rt_size;
++
++	return ret;
++}
++
+ static unsigned long qcom_pas_panic(struct rproc *rproc)
+ {
+ 	struct qcom_pas *pas = rproc->priv;
+@@ -425,7 +480,7 @@ static const struct rproc_ops qcom_pas_ops = {
+ 	.start = qcom_pas_start,
+ 	.stop = qcom_pas_stop,
+ 	.da_to_va = qcom_pas_da_to_va,
+-	.parse_fw = qcom_register_dump_segments,
++	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+ 	.panic = qcom_pas_panic,
+ };
+@@ -435,7 +490,7 @@ static const struct rproc_ops qcom_pas_minidump_ops = {
+ 	.start = qcom_pas_start,
+ 	.stop = qcom_pas_stop,
+ 	.da_to_va = qcom_pas_da_to_va,
+-	.parse_fw = qcom_register_dump_segments,
++	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+ 	.panic = qcom_pas_panic,
+ 	.coredump = qcom_pas_minidump,
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0011-remoteproc-qcom-pas-Enable-Secure-PAS-support-with-I.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0011-remoteproc-qcom-pas-Enable-Secure-PAS-support-with-I.patch
@@ -1,0 +1,163 @@
+From e569dcebcab71a4cba1cbeda6af06ec33fb21d39 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:53:01 +0530
+Subject: [PATCH 11/12] remoteproc: qcom: pas: Enable Secure PAS support with
+ IOMMU managed by Linux
+
+Most Qualcomm platforms feature Gunyah hypervisor, which typically
+handles IOMMU configuration. This includes mapping memory regions and
+device memory resources for remote processors by intercepting
+qcom_scm_pas_auth_and_reset() calls. These mappings are later removed
+during teardown. Additionally, SHM bridge setup is required to enable
+memory protection for both remoteproc metadata and its memory regions.
+When the aforementioned hypervisor is absent, the operating system must
+perform these configurations instead.
+
+When Linux runs as the hypervisor (@ EL2) on a SoC, it will have its
+own device tree overlay file that specifies the firmware stream ID now
+managed by Linux for a particular remote processor. If the iommus
+property is specified in the remoteproc device tree node, it indicates
+that IOMMU configuration must be handled by Linux. In this case, the
+has_iommu flag is set for the remote processor, which ensures that the
+resource table, carveouts, and SHM bridge are properly configured before
+memory is passed to TrustZone for authentication. Otherwise, the
+has_iommu flag remains unset, which indicates default behavior.
+
+Enables Secure PAS support for remote processors when IOMMU configuration
+is managed by Linux.
+
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 5c720260e840]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 48 ++++++++++++++++++++++++++----
+ 1 file changed, 43 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index dc0e1878e6b4..f8516739736d 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -11,6 +11,7 @@
+ #include <linux/delay.h>
+ #include <linux/firmware.h>
+ #include <linux/interrupt.h>
++#include <linux/iommu.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/of.h>
+@@ -255,6 +256,22 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 	return ret;
+ }
+ 
++static void qcom_pas_unmap_carveout(struct rproc *rproc, phys_addr_t mem_phys, size_t size)
++{
++	if (rproc->has_iommu)
++		iommu_unmap(rproc->domain, mem_phys, size);
++}
++
++static int qcom_pas_map_carveout(struct rproc *rproc, phys_addr_t mem_phys, size_t size)
++{
++	int ret = 0;
++
++	if (rproc->has_iommu)
++		ret = iommu_map(rproc->domain, mem_phys, mem_phys, size,
++				IOMMU_READ | IOMMU_WRITE, GFP_KERNEL);
++	return ret;
++}
++
+ static int qcom_pas_start(struct rproc *rproc)
+ {
+ 	struct qcom_pas *pas = rproc->priv;
+@@ -289,11 +306,15 @@ static int qcom_pas_start(struct rproc *rproc)
+ 	}
+ 
+ 	if (pas->dtb_pas_id) {
+-		ret = qcom_scm_pas_auth_and_reset(pas->dtb_pas_id);
++		ret = qcom_pas_map_carveout(rproc, pas->dtb_mem_phys, pas->dtb_mem_size);
++		if (ret)
++			goto disable_px_supply;
++
++		ret = qcom_scm_pas_prepare_and_auth_reset(pas->dtb_pas_ctx);
+ 		if (ret) {
+ 			dev_err(pas->dev,
+ 				"failed to authenticate dtb image and release reset\n");
+-			goto disable_px_supply;
++			goto unmap_dtb_carveout;
+ 		}
+ 	}
+ 
+@@ -304,18 +325,22 @@ static int qcom_pas_start(struct rproc *rproc)
+ 
+ 	qcom_pil_info_store(pas->info_name, pas->mem_phys, pas->mem_size);
+ 
+-	ret = qcom_scm_pas_auth_and_reset(pas->pas_id);
++	ret = qcom_pas_map_carveout(rproc, pas->mem_phys, pas->mem_size);
++	if (ret)
++		goto release_pas_metadata;
++
++	ret = qcom_scm_pas_prepare_and_auth_reset(pas->pas_ctx);
+ 	if (ret) {
+ 		dev_err(pas->dev,
+ 			"failed to authenticate image and release reset\n");
+-		goto release_pas_metadata;
++		goto unmap_carveout;
+ 	}
+ 
+ 	ret = qcom_q6v5_wait_for_start(&pas->q6v5, msecs_to_jiffies(5000));
+ 	if (ret == -ETIMEDOUT) {
+ 		dev_err(pas->dev, "start timed out\n");
+ 		qcom_scm_pas_shutdown(pas->pas_id);
+-		goto release_pas_metadata;
++		goto unmap_carveout;
+ 	}
+ 
+ 	qcom_scm_pas_metadata_release(pas->pas_ctx);
+@@ -327,10 +352,16 @@ static int qcom_pas_start(struct rproc *rproc)
+ 
+ 	return 0;
+ 
++unmap_carveout:
++	qcom_pas_unmap_carveout(rproc, pas->mem_phys, pas->mem_size);
+ release_pas_metadata:
+ 	qcom_scm_pas_metadata_release(pas->pas_ctx);
+ 	if (pas->dtb_pas_id)
+ 		qcom_scm_pas_metadata_release(pas->dtb_pas_ctx);
++
++unmap_dtb_carveout:
++	if (pas->dtb_pas_id)
++		qcom_pas_unmap_carveout(rproc, pas->dtb_mem_phys, pas->dtb_mem_size);
+ disable_px_supply:
+ 	if (pas->px_supply)
+ 		regulator_disable(pas->px_supply);
+@@ -386,8 +417,12 @@ static int qcom_pas_stop(struct rproc *rproc)
+ 		ret = qcom_scm_pas_shutdown(pas->dtb_pas_id);
+ 		if (ret)
+ 			dev_err(pas->dev, "failed to shutdown dtb: %d\n", ret);
++
++		qcom_pas_unmap_carveout(rproc, pas->dtb_mem_phys, pas->dtb_mem_size);
+ 	}
+ 
++	qcom_pas_unmap_carveout(rproc, pas->mem_phys, pas->mem_size);
++
+ 	handover = qcom_q6v5_unprepare(&pas->q6v5);
+ 	if (handover)
+ 		qcom_pas_handover(&pas->q6v5);
+@@ -757,6 +792,7 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 		return -ENOMEM;
+ 	}
+ 
++	rproc->has_iommu = of_property_present(pdev->dev.of_node, "iommus");
+ 	rproc->auto_boot = desc->auto_boot;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+@@ -836,6 +872,8 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 		goto remove_ssr_sysmon;
+ 	}
+ 
++	pas->pas_ctx->use_tzmem = rproc->has_iommu;
++	pas->dtb_pas_ctx->use_tzmem = rproc->has_iommu;
+ 	ret = rproc_add(rproc);
+ 	if (ret)
+ 		goto remove_ssr_sysmon;
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0012-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/remoteproc/0012-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch
@@ -1,0 +1,205 @@
+From b48ddc0e95b7ef05ef91b3944dfb531b1bb06677 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Tue, 10 Mar 2026 19:22:05 +0530
+Subject: [PATCH 12/12] FROMLIST: remoteproc: qcom: pas: Map/unmap subsystem
+ region before auth_and_reset
+
+Qualcomm remoteproc drivers such as qcom_q6v5_mss, which do not use the
+Peripheral Authentication Service (PAS), always map the MBA region before
+use and unmap it once the usage is complete. This behavior was introduced
+to avoid issues seen in the past where speculative accesses from the
+application processor to the MBA region after it was assigned to the remote
+Q6 led to an XPU violation. The issue was mitigated by unmapping the region
+before handing control to the remote Q6.
+
+Currently, most Qualcomm SoCs using the PAS driver run either with a
+standalone QHEE or the Gunyah hypervisor. In these environments, the
+hypervisor unmaps the Q6 memory from HLOS Stage-2 and remaps it into the
+Q6 Stage-2 page table. As a result, speculative accesses from HLOS cannot
+reach the region even if it remains mapped in HLOS Stage-1; therefore, XPU
+violations cannot occur.
+
+However, when the same SoC runs Linux at EL2, Linux itself must perform the
+unmapping to avoid such issues. It is still correct to apply this mapping/
+unmapping sequence even for SoCs that run under Gunyah, so this behavior
+should not be conditional.
+
+Link: https://lore.kernel.org/lkml/20260325191301.164579-2-mukesh.ojha@oss.qualcomm.com/
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/lkml/20260325191301.164579-2-mukesh.ojha@oss.qualcomm.com/]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c  | 43 +++++++++++++++++++----------
+ drivers/soc/qcom/mdt_loader.c       | 18 +++++++++---
+ include/linux/soc/qcom/mdt_loader.h |  4 +--
+ 3 files changed, 44 insertions(+), 21 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index f8516739736d..e11ad4cab0a8 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -148,7 +148,16 @@ static void qcom_pas_minidump(struct rproc *rproc)
+ 	if (rproc->dump_conf == RPROC_COREDUMP_DISABLED)
+ 		return;
+ 
++	pas->mem_region = ioremap_wc(pas->mem_phys, pas->mem_size);
++	if (!pas->mem_region) {
++		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
++			&pas->mem_phys, pas->mem_size);
++		return;
++	}
++
+ 	qcom_minidump(rproc, pas->minidump_id, qcom_pas_segment_dump);
++	iounmap(pas->mem_region);
++	pas->mem_region = NULL;
+ }
+ 
+ static int qcom_pas_pds_enable(struct qcom_pas *pas, struct device **pds,
+@@ -241,7 +250,7 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 		}
+ 
+ 		ret = qcom_mdt_pas_load(pas->dtb_pas_ctx, pas->dtb_firmware,
+-					pas->dtb_firmware_name, pas->dtb_mem_region,
++					pas->dtb_firmware_name,
+ 					&pas->dtb_mem_reloc);
+ 		if (ret)
+ 			goto release_dtb_metadata;
+@@ -319,7 +328,7 @@ static int qcom_pas_start(struct rproc *rproc)
+ 	}
+ 
+ 	ret = qcom_mdt_pas_load(pas->pas_ctx, pas->firmware, rproc->firmware,
+-				pas->mem_region, &pas->mem_reloc);
++				&pas->mem_reloc);
+ 	if (ret)
+ 		goto release_pas_metadata;
+ 
+@@ -510,6 +519,22 @@ static unsigned long qcom_pas_panic(struct rproc *rproc)
+ 	return qcom_q6v5_panic(&pas->q6v5);
+ }
+ 
++static void qcom_pas_coredump(struct rproc *rproc)
++{
++	struct qcom_pas *pas = rproc->priv;
++
++	pas->mem_region = ioremap_wc(pas->mem_phys, pas->mem_size);
++	if (!pas->mem_region) {
++		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
++			&pas->mem_phys, pas->mem_size);
++		return;
++	}
++
++	rproc_coredump(rproc);
++	iounmap(pas->mem_region);
++	pas->mem_region = NULL;
++}
++
+ static const struct rproc_ops qcom_pas_ops = {
+ 	.unprepare = qcom_pas_unprepare,
+ 	.start = qcom_pas_start,
+@@ -518,6 +543,7 @@ static const struct rproc_ops qcom_pas_ops = {
+ 	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+ 	.panic = qcom_pas_panic,
++	.coredump = qcom_pas_coredump,
+ };
+ 
+ static const struct rproc_ops qcom_pas_minidump_ops = {
+@@ -641,13 +667,6 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
+ 
+ 	pas->mem_phys = pas->mem_reloc = rmem->base;
+ 	pas->mem_size = rmem->size;
+-	pas->mem_region = devm_ioremap_wc(pas->dev, pas->mem_phys, pas->mem_size);
+-	if (!pas->mem_region) {
+-		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
+-			&rmem->base, pas->mem_size);
+-		return -EBUSY;
+-	}
+-
+ 	if (!pas->dtb_pas_id)
+ 		return 0;
+ 
+@@ -666,12 +685,6 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
+ 
+ 	pas->dtb_mem_phys = pas->dtb_mem_reloc = rmem->base;
+ 	pas->dtb_mem_size = rmem->size;
+-	pas->dtb_mem_region = devm_ioremap_wc(pas->dev, pas->dtb_mem_phys, pas->dtb_mem_size);
+-	if (!pas->dtb_mem_region) {
+-		dev_err(pas->dev, "unable to map dtb memory region: %pa+%zx\n",
+-			&rmem->base, pas->dtb_mem_size);
+-		return -EBUSY;
+-	}
+ 
+ 	return 0;
+ }
+diff --git a/drivers/soc/qcom/mdt_loader.c b/drivers/soc/qcom/mdt_loader.c
+index 1ca03472552c..3936839da329 100644
+--- a/drivers/soc/qcom/mdt_loader.c
++++ b/drivers/soc/qcom/mdt_loader.c
+@@ -11,6 +11,7 @@
+ #include <linux/device.h>
+ #include <linux/elf.h>
+ #include <linux/firmware.h>
++#include <linux/io.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/firmware/qcom/qcom_scm.h>
+@@ -486,22 +487,31 @@ EXPORT_SYMBOL_GPL(qcom_mdt_load_no_init);
+  * @ctx:        Pointer to the PAS (Peripheral Authentication Service) context
+  * @fw:         Firmware object representing the .mdt file
+  * @firmware:   Name of the firmware used to construct segment file names
+- * @mem_region: Memory region allocated for loading the firmware
+  * @reloc_base: Physical address adjusted after relocation
+  *
+  * Return: 0 on success or a negative error code on failure.
+  */
+ int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
+-		      const char *firmware, void *mem_region, phys_addr_t *reloc_base)
++		      const char *firmware, phys_addr_t *reloc_base)
+ {
++	void *mem_region;
+ 	int ret;
+ 
+ 	ret = __qcom_mdt_pas_init(ctx->dev, fw, firmware, ctx->pas_id, ctx->mem_phys, ctx);
+ 	if (ret)
+ 		return ret;
+ 
+-	return qcom_mdt_load_no_init(ctx->dev, fw, firmware, mem_region, ctx->mem_phys,
+-				     ctx->mem_size, reloc_base);
++	mem_region = ioremap_wc(ctx->mem_phys, ctx->mem_size);
++	if (!mem_region) {
++		dev_err(ctx->dev, "unable to map memory region: %pa+%zx\n", &ctx->mem_phys,
++			ctx->mem_size);
++		return -EINVAL;
++	}
++
++	ret = qcom_mdt_load_no_init(ctx->dev, fw, firmware, mem_region, ctx->mem_phys,
++				    ctx->mem_size, reloc_base);
++	iounmap(mem_region);
++	return ret;
+ }
+ EXPORT_SYMBOL_GPL(qcom_mdt_pas_load);
+ 
+diff --git a/include/linux/soc/qcom/mdt_loader.h b/include/linux/soc/qcom/mdt_loader.h
+index 82372e0db0a1..7c551b98e182 100644
+--- a/include/linux/soc/qcom/mdt_loader.h
++++ b/include/linux/soc/qcom/mdt_loader.h
+@@ -21,7 +21,7 @@ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 		  phys_addr_t *reloc_base);
+ 
+ int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
+-		      const char *firmware, void *mem_region, phys_addr_t *reloc_base);
++		      const char *firmware, phys_addr_t *reloc_base);
+ 
+ int qcom_mdt_load_no_init(struct device *dev, const struct firmware *fw,
+ 			  const char *fw_name, void *mem_region,
+@@ -47,7 +47,7 @@ static inline int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 
+ static inline int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx,
+ 				    const struct firmware *fw, const char *firmware,
+-				    void *mem_region, phys_addr_t *reloc_base)
++				    phys_addr_t *reloc_base)
+ {
+ 	return -ENODEV;
+ }
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0001-firmware-qcom_scm-Rename-peripheral-as-pas_id.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0001-firmware-qcom_scm-Rename-peripheral-as-pas_id.patch
@@ -1,0 +1,166 @@
+From 2a4e7f6705d13b9494ecdc66399b313fc5660d62 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:51 +0530
+Subject: [PATCH 01/12] firmware: qcom_scm: Rename peripheral as pas_id
+
+Peripheral and pas_id refers to unique id for a subsystem and used only
+when peripheral authentication service from secure world is utilized.
+
+Lets rename peripheral to pas_id to reflect closer to its meaning.
+
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 69054348cc1c]
+---
+ drivers/firmware/qcom/qcom_scm.c       | 30 +++++++++++++-------------
+ include/linux/firmware/qcom/qcom_scm.h | 10 ++++-----
+ 2 files changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index e777b7cb9b12..3379607eaf94 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -562,7 +562,7 @@ static void qcom_scm_set_download_mode(u32 dload_mode)
+  * qcom_scm_pas_init_image() - Initialize peripheral authentication service
+  *			       state machine for a given peripheral, using the
+  *			       metadata
+- * @peripheral: peripheral id
++ * @pas_id:	peripheral authentication service id
+  * @metadata:	pointer to memory containing ELF header, program header table
+  *		and optional blob of data used for authenticating the metadata
+  *		and the rest of the firmware
+@@ -575,7 +575,7 @@ static void qcom_scm_set_download_mode(u32 dload_mode)
+  * track the metadata allocation, this needs to be released by invoking
+  * qcom_scm_pas_metadata_release() by the caller.
+  */
+-int qcom_scm_pas_init_image(u32 peripheral, const void *metadata, size_t size,
++int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 			    struct qcom_scm_pas_metadata *ctx)
+ {
+ 	dma_addr_t mdata_phys;
+@@ -585,7 +585,7 @@ int qcom_scm_pas_init_image(u32 peripheral, const void *metadata, size_t size,
+ 		.svc = QCOM_SCM_SVC_PIL,
+ 		.cmd = QCOM_SCM_PIL_PAS_INIT_IMAGE,
+ 		.arginfo = QCOM_SCM_ARGS(2, QCOM_SCM_VAL, QCOM_SCM_RW),
+-		.args[0] = peripheral,
++		.args[0] = pas_id,
+ 		.owner = ARM_SMCCC_OWNER_SIP,
+ 	};
+ 	struct qcom_scm_res res;
+@@ -658,20 +658,20 @@ EXPORT_SYMBOL_GPL(qcom_scm_pas_metadata_release);
+ /**
+  * qcom_scm_pas_mem_setup() - Prepare the memory related to a given peripheral
+  *			      for firmware loading
+- * @peripheral:	peripheral id
++ * @pas_id:	peripheral authentication service id
+  * @addr:	start address of memory area to prepare
+  * @size:	size of the memory area to prepare
+  *
+  * Returns 0 on success.
+  */
+-int qcom_scm_pas_mem_setup(u32 peripheral, phys_addr_t addr, phys_addr_t size)
++int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size)
+ {
+ 	int ret;
+ 	struct qcom_scm_desc desc = {
+ 		.svc = QCOM_SCM_SVC_PIL,
+ 		.cmd = QCOM_SCM_PIL_PAS_MEM_SETUP,
+ 		.arginfo = QCOM_SCM_ARGS(3),
+-		.args[0] = peripheral,
++		.args[0] = pas_id,
+ 		.args[1] = addr,
+ 		.args[2] = size,
+ 		.owner = ARM_SMCCC_OWNER_SIP,
+@@ -699,18 +699,18 @@ EXPORT_SYMBOL_GPL(qcom_scm_pas_mem_setup);
+ /**
+  * qcom_scm_pas_auth_and_reset() - Authenticate the given peripheral firmware
+  *				   and reset the remote processor
+- * @peripheral:	peripheral id
++ * @pas_id:	peripheral authentication service id
+  *
+  * Return 0 on success.
+  */
+-int qcom_scm_pas_auth_and_reset(u32 peripheral)
++int qcom_scm_pas_auth_and_reset(u32 pas_id)
+ {
+ 	int ret;
+ 	struct qcom_scm_desc desc = {
+ 		.svc = QCOM_SCM_SVC_PIL,
+ 		.cmd = QCOM_SCM_PIL_PAS_AUTH_AND_RESET,
+ 		.arginfo = QCOM_SCM_ARGS(1),
+-		.args[0] = peripheral,
++		.args[0] = pas_id,
+ 		.owner = ARM_SMCCC_OWNER_SIP,
+ 	};
+ 	struct qcom_scm_res res;
+@@ -735,18 +735,18 @@ EXPORT_SYMBOL_GPL(qcom_scm_pas_auth_and_reset);
+ 
+ /**
+  * qcom_scm_pas_shutdown() - Shut down the remote processor
+- * @peripheral: peripheral id
++ * @pas_id:	peripheral authentication service id
+  *
+  * Returns 0 on success.
+  */
+-int qcom_scm_pas_shutdown(u32 peripheral)
++int qcom_scm_pas_shutdown(u32 pas_id)
+ {
+ 	int ret;
+ 	struct qcom_scm_desc desc = {
+ 		.svc = QCOM_SCM_SVC_PIL,
+ 		.cmd = QCOM_SCM_PIL_PAS_SHUTDOWN,
+ 		.arginfo = QCOM_SCM_ARGS(1),
+-		.args[0] = peripheral,
++		.args[0] = pas_id,
+ 		.owner = ARM_SMCCC_OWNER_SIP,
+ 	};
+ 	struct qcom_scm_res res;
+@@ -772,18 +772,18 @@ EXPORT_SYMBOL_GPL(qcom_scm_pas_shutdown);
+ /**
+  * qcom_scm_pas_supported() - Check if the peripheral authentication service is
+  *			      available for the given peripherial
+- * @peripheral:	peripheral id
++ * @pas_id:	peripheral authentication service id
+  *
+  * Returns true if PAS is supported for this peripheral, otherwise false.
+  */
+-bool qcom_scm_pas_supported(u32 peripheral)
++bool qcom_scm_pas_supported(u32 pas_id)
+ {
+ 	int ret;
+ 	struct qcom_scm_desc desc = {
+ 		.svc = QCOM_SCM_SVC_PIL,
+ 		.cmd = QCOM_SCM_PIL_PAS_IS_SUPPORTED,
+ 		.arginfo = QCOM_SCM_ARGS(1),
+-		.args[0] = peripheral,
++		.args[0] = pas_id,
+ 		.owner = ARM_SMCCC_OWNER_SIP,
+ 	};
+ 	struct qcom_scm_res res;
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index a55ca771286b..a13f703b16cd 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -72,13 +72,13 @@ struct qcom_scm_pas_metadata {
+ 	ssize_t size;
+ };
+ 
+-int qcom_scm_pas_init_image(u32 peripheral, const void *metadata, size_t size,
++int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 			    struct qcom_scm_pas_metadata *ctx);
+ void qcom_scm_pas_metadata_release(struct qcom_scm_pas_metadata *ctx);
+-int qcom_scm_pas_mem_setup(u32 peripheral, phys_addr_t addr, phys_addr_t size);
+-int qcom_scm_pas_auth_and_reset(u32 peripheral);
+-int qcom_scm_pas_shutdown(u32 peripheral);
+-bool qcom_scm_pas_supported(u32 peripheral);
++int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size);
++int qcom_scm_pas_auth_and_reset(u32 pas_id);
++int qcom_scm_pas_shutdown(u32 pas_id);
++bool qcom_scm_pas_supported(u32 pas_id);
+ 
+ int qcom_scm_io_readl(phys_addr_t addr, unsigned int *val);
+ int qcom_scm_io_writel(phys_addr_t addr, unsigned int val);
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0002-firmware-qcom_scm-Introduce-PAS-context-allocator-he.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0002-firmware-qcom_scm-Introduce-PAS-context-allocator-he.patch
@@ -1,0 +1,111 @@
+From c69b9fa0eaf969adc4016a90fb5126b9b5f1a419 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:52 +0530
+Subject: [PATCH 02/12] firmware: qcom_scm: Introduce PAS context allocator
+ helper function
+
+When the Peripheral Authentication Service (PAS) method runs on a SoC
+where Linux operates at EL2 (i.e., without the Gunyah hypervisor), the
+reset sequences are handled by TrustZone. In such cases, Linux must
+perform additional steps before invoking PAS SMC calls, such as creating
+a SHM bridge. Therefore, PAS SMC calls require awareness and handling of
+these additional steps when Linux runs at EL2.
+
+To support this, there is a need for a data structure that can be
+initialized prior to invoking any SMC or MDT functions. This structure
+allows those functions to determine whether they are operating in the
+presence or absence of the Gunyah hypervisor and behave accordingly.
+
+Currently, remoteproc and non-remoteproc subsystems use different
+variants of the MDT loader helper API, primarily due to differences in
+metadata context handling. Remoteproc subsystems retain the metadata
+context until authentication and reset are completed, while
+non-remoteproc subsystems (e.g., video, graphics, IPA, etc.) do not
+retain the metadata context and can free it within the
+qcom_scm_pas_init() call by passing a NULL context parameter and due to
+these differences, it is not possible to extend metadata context
+handling to support remoteproc and non remoteproc subsystem use PAS
+operations, when Linux operates at EL2.
+
+Add PAS context data structure allocator helper function.
+
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git ccb7bde5f7cc]
+---
+ drivers/firmware/qcom/qcom_scm.c       | 34 ++++++++++++++++++++++++++
+ include/linux/firmware/qcom/qcom_scm.h | 14 +++++++++++
+ 2 files changed, 48 insertions(+)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index 3379607eaf94..2e51c4d80fdc 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -558,6 +558,40 @@ static void qcom_scm_set_download_mode(u32 dload_mode)
+ 		dev_err(__scm->dev, "failed to set download mode: %d\n", ret);
+ }
+ 
++/**
++ * devm_qcom_scm_pas_context_alloc() - Allocate peripheral authentication service
++ *				       context for a given peripheral
++ *
++ * PAS context is device-resource managed, so the caller does not need
++ * to worry about freeing the context memory.
++ *
++ * @dev:	  PAS firmware device
++ * @pas_id:	  peripheral authentication service id
++ * @mem_phys:	  Subsystem reserve memory start address
++ * @mem_size:	  Subsystem reserve memory size
++ *
++ * Returns: The new PAS context, or ERR_PTR() on failure.
++ */
++struct qcom_scm_pas_context *devm_qcom_scm_pas_context_alloc(struct device *dev,
++							     u32 pas_id,
++							     phys_addr_t mem_phys,
++							     size_t mem_size)
++{
++	struct qcom_scm_pas_context *ctx;
++
++	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
++	if (!ctx)
++		return ERR_PTR(-ENOMEM);
++
++	ctx->dev = dev;
++	ctx->pas_id = pas_id;
++	ctx->mem_phys = mem_phys;
++	ctx->mem_size = mem_size;
++
++	return ctx;
++}
++EXPORT_SYMBOL_GPL(devm_qcom_scm_pas_context_alloc);
++
+ /**
+  * qcom_scm_pas_init_image() - Initialize peripheral authentication service
+  *			       state machine for a given peripheral, using the
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index a13f703b16cd..5045f8fe876d 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -72,6 +72,20 @@ struct qcom_scm_pas_metadata {
+ 	ssize_t size;
+ };
+ 
++struct qcom_scm_pas_context {
++	struct device *dev;
++	u32 pas_id;
++	phys_addr_t mem_phys;
++	size_t mem_size;
++	void *ptr;
++	dma_addr_t phys;
++	ssize_t size;
++};
++
++struct qcom_scm_pas_context *devm_qcom_scm_pas_context_alloc(struct device *dev,
++							     u32 pas_id,
++							     phys_addr_t mem_phys,
++							     size_t mem_size);
+ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 			    struct qcom_scm_pas_metadata *ctx);
+ void qcom_scm_pas_metadata_release(struct qcom_scm_pas_metadata *ctx);
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0006-firmware-qcom_scm-Add-a-prep-version-of-auth_and_res.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0006-firmware-qcom_scm-Add-a-prep-version-of-auth_and_res.patch
@@ -1,0 +1,113 @@
+From e569cdd6680d32f3fc093dc8a05b518ac5913aaf Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:56 +0530
+Subject: [PATCH 06/12] firmware: qcom_scm: Add a prep version of
+ auth_and_reset function
+
+For memory passed to TrustZone (TZ), it must either be part of a pool
+registered with TZ or explicitly registered via SHMbridge SMC calls.
+When Gunyah hypervisor is present, PAS SMC calls from Linux running at
+EL1 are trapped by Gunyah running @ EL2, which handles SHMbridge
+creation for both metadata and remoteproc carveout memory before
+invoking the calls to TZ.
+
+On SoCs running with a non-Gunyah-based hypervisor, Linux must take
+responsibility for creating the SHM bridge before invoking PAS SMC
+calls. For the auth_and_reset() call, the remoteproc carveout memory
+must first be registered with TZ via a SHMbridge SMC call and once
+authentication and reset are complete, the SHMbridge memory can be
+deregistered.
+
+Introduce qcom_scm_pas_prepare_and_auth_reset(), which sets up the SHM
+bridge over the remoteproc carveout memory when Linux operates at EL2.
+This behavior is indicated by a new field added to the PAS context data
+structure. The function then invokes the auth_and_reset SMC call.
+
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 4a7d6a78fbc6]
+---
+ drivers/firmware/qcom/qcom_scm.c       | 47 ++++++++++++++++++++++++++
+ include/linux/firmware/qcom/qcom_scm.h |  2 ++
+ 2 files changed, 49 insertions(+)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index f60254eb117e..144754dd358d 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -767,6 +767,53 @@ int qcom_scm_pas_auth_and_reset(u32 pas_id)
+ }
+ EXPORT_SYMBOL_GPL(qcom_scm_pas_auth_and_reset);
+ 
++/**
++ * qcom_scm_pas_prepare_and_auth_reset() - Prepare, authenticate, and reset the
++ *					   remote processor
++ *
++ * @ctx:	Context saved during call to qcom_scm_pas_context_init()
++ *
++ * This function performs the necessary steps to prepare a PAS subsystem,
++ * authenticate it using the provided metadata, and initiate a reset sequence.
++ *
++ * It should be used when Linux is in control setting up the IOMMU hardware
++ * for remote subsystem during secure firmware loading processes. The preparation
++ * step sets up a shmbridge over the firmware memory before TrustZone accesses the
++ * firmware memory region for authentication. The authentication step verifies
++ * the integrity and authenticity of the firmware or configuration using secure
++ * metadata. Finally, the reset step ensures the subsystem starts in a clean and
++ * sane state.
++ *
++ * Return: 0 on success, negative errno on failure.
++ */
++int qcom_scm_pas_prepare_and_auth_reset(struct qcom_scm_pas_context *ctx)
++{
++	u64 handle;
++	int ret;
++
++	/*
++	 * When Linux running @ EL1, Gunyah hypervisor running @ EL2 traps the
++	 * auth_and_reset call and create an shmbridge on the remote subsystem
++	 * memory region and then invokes a call to TrustZone to authenticate.
++	 */
++	if (!ctx->use_tzmem)
++		return qcom_scm_pas_auth_and_reset(ctx->pas_id);
++
++	/*
++	 * When Linux runs @ EL2 Linux must create the shmbridge itself and then
++	 * subsequently call TrustZone for authenticate and reset.
++	 */
++	ret = qcom_tzmem_shm_bridge_create(ctx->mem_phys, ctx->mem_size, &handle);
++	if (ret)
++		return ret;
++
++	ret = qcom_scm_pas_auth_and_reset(ctx->pas_id);
++	qcom_tzmem_shm_bridge_delete(handle);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(qcom_scm_pas_prepare_and_auth_reset);
++
+ /**
+  * qcom_scm_pas_shutdown() - Shut down the remote processor
+  * @pas_id:	peripheral authentication service id
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index ad69b51fe6fc..d6d83888bb75 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -74,6 +74,7 @@ struct qcom_scm_pas_context {
+ 	void *ptr;
+ 	dma_addr_t phys;
+ 	ssize_t size;
++	bool use_tzmem;
+ };
+ 
+ struct qcom_scm_pas_context *devm_qcom_scm_pas_context_alloc(struct device *dev,
+@@ -87,6 +88,7 @@ int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size);
+ int qcom_scm_pas_auth_and_reset(u32 pas_id);
+ int qcom_scm_pas_shutdown(u32 pas_id);
+ bool qcom_scm_pas_supported(u32 pas_id);
++int qcom_scm_pas_prepare_and_auth_reset(struct qcom_scm_pas_context *ctx);
+ 
+ int qcom_scm_io_readl(phys_addr_t addr, unsigned int *val);
+ int qcom_scm_io_writel(phys_addr_t addr, unsigned int val);
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0007-firmware-qcom_scm-Refactor-qcom_scm_pas_init_image.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0007-firmware-qcom_scm-Refactor-qcom_scm_pas_init_image.patch
@@ -1,0 +1,108 @@
+From 5723e4df7d1aa5ce9f42158afd29a803d951a000 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:57 +0530
+Subject: [PATCH 07/12] firmware: qcom_scm: Refactor qcom_scm_pas_init_image()
+
+Refactor qcom_scm_pas_init_image() by moving the memory allocation,
+copy, and free operations to a higher-level function, and isolate the
+actual SMC call in a separate function. The main intention is to allow
+flexibility for different allocators and to respect any constraints that
+the allocator API may impose before invoking the actual SCM function.
+
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 223a87168030]
+---
+ drivers/firmware/qcom/qcom_scm.c | 58 ++++++++++++++++++--------------
+ 1 file changed, 33 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index 144754dd358d..ab38a53a92f8 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -592,6 +592,37 @@ struct qcom_scm_pas_context *devm_qcom_scm_pas_context_alloc(struct device *dev,
+ }
+ EXPORT_SYMBOL_GPL(devm_qcom_scm_pas_context_alloc);
+ 
++static int __qcom_scm_pas_init_image(u32 pas_id, dma_addr_t mdata_phys,
++				     struct qcom_scm_res *res)
++{
++	struct qcom_scm_desc desc = {
++		.svc = QCOM_SCM_SVC_PIL,
++		.cmd = QCOM_SCM_PIL_PAS_INIT_IMAGE,
++		.arginfo = QCOM_SCM_ARGS(2, QCOM_SCM_VAL, QCOM_SCM_RW),
++		.args[0] = pas_id,
++		.owner = ARM_SMCCC_OWNER_SIP,
++	};
++	int ret;
++
++	ret = qcom_scm_clk_enable();
++	if (ret)
++		return ret;
++
++	ret = qcom_scm_bw_enable();
++	if (ret)
++		goto disable_clk;
++
++	desc.args[1] = mdata_phys;
++
++	ret = qcom_scm_call(__scm->dev, &desc, res);
++	qcom_scm_bw_disable();
++
++disable_clk:
++	qcom_scm_clk_disable();
++
++	return ret;
++}
++
+ /**
+  * qcom_scm_pas_init_image() - Initialize peripheral authentication service
+  *			       state machine for a given peripheral, using the
+@@ -612,17 +643,10 @@ EXPORT_SYMBOL_GPL(devm_qcom_scm_pas_context_alloc);
+ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 			    struct qcom_scm_pas_context *ctx)
+ {
++	struct qcom_scm_res res;
+ 	dma_addr_t mdata_phys;
+ 	void *mdata_buf;
+ 	int ret;
+-	struct qcom_scm_desc desc = {
+-		.svc = QCOM_SCM_SVC_PIL,
+-		.cmd = QCOM_SCM_PIL_PAS_INIT_IMAGE,
+-		.arginfo = QCOM_SCM_ARGS(2, QCOM_SCM_VAL, QCOM_SCM_RW),
+-		.args[0] = pas_id,
+-		.owner = ARM_SMCCC_OWNER_SIP,
+-	};
+-	struct qcom_scm_res res;
+ 
+ 	/*
+ 	 * During the scm call memory protection will be enabled for the meta
+@@ -643,23 +667,7 @@ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 
+ 	memcpy(mdata_buf, metadata, size);
+ 
+-	ret = qcom_scm_clk_enable();
+-	if (ret)
+-		goto out;
+-
+-	ret = qcom_scm_bw_enable();
+-	if (ret)
+-		goto disable_clk;
+-
+-	desc.args[1] = mdata_phys;
+-
+-	ret = qcom_scm_call(__scm->dev, &desc, &res);
+-	qcom_scm_bw_disable();
+-
+-disable_clk:
+-	qcom_scm_clk_disable();
+-
+-out:
++	ret = __qcom_scm_pas_init_image(pas_id, mdata_phys, &res);
+ 	if (ret < 0 || !ctx) {
+ 		dma_free_coherent(__scm->dev, size, mdata_buf, mdata_phys);
+ 	} else if (ctx) {
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0008-firmware-qcom_scm-Add-SHM-bridge-handling-for-PAS-wh.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0008-firmware-qcom_scm-Add-SHM-bridge-handling-for-PAS-wh.patch
@@ -1,0 +1,81 @@
+From 1d128a93d10f0940a5b8a9f3be818808661a993f Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:58 +0530
+Subject: [PATCH 08/12] firmware: qcom_scm: Add SHM bridge handling for PAS
+ when running without QHEE
+
+On SoCs running with a non-Gunyah-based hypervisor, Linux must take
+responsibility for creating the SHM bridge both for metadata (before
+calling qcom_scm_pas_init_image()) and for remoteproc memory (before
+calling qcom_scm_pas_auth_and_reset()). We have taken care the things
+required for qcom_scm_pas_auth_and_reset(). Lets put these awareness
+of above conditions into qcom_scm_pas_init_image() and
+qcom_scm_pas_metadata_release().
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git b019925838bc]
+---
+ drivers/firmware/qcom/qcom_scm.c | 32 +++++++++++++++++++++++++++++++-
+ 1 file changed, 31 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index ab38a53a92f8..e99128fd0d7b 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -623,6 +623,30 @@ static int __qcom_scm_pas_init_image(u32 pas_id, dma_addr_t mdata_phys,
+ 	return ret;
+ }
+ 
++static int qcom_scm_pas_prep_and_init_image(struct qcom_scm_pas_context *ctx,
++					    const void *metadata, size_t size)
++{
++	struct qcom_scm_res res;
++	phys_addr_t mdata_phys;
++	void *mdata_buf;
++	int ret;
++
++	mdata_buf = qcom_tzmem_alloc(__scm->mempool, size, GFP_KERNEL);
++	if (!mdata_buf)
++		return -ENOMEM;
++
++	memcpy(mdata_buf, metadata, size);
++	mdata_phys = qcom_tzmem_to_phys(mdata_buf);
++
++	ret = __qcom_scm_pas_init_image(ctx->pas_id, mdata_phys, &res);
++	if (ret < 0)
++		qcom_tzmem_free(mdata_buf);
++	else
++		ctx->ptr = mdata_buf;
++
++	return ret ? : res.result[0];
++}
++
+ /**
+  * qcom_scm_pas_init_image() - Initialize peripheral authentication service
+  *			       state machine for a given peripheral, using the
+@@ -648,6 +672,9 @@ int qcom_scm_pas_init_image(u32 pas_id, const void *metadata, size_t size,
+ 	void *mdata_buf;
+ 	int ret;
+ 
++	if (ctx && ctx->use_tzmem)
++		return qcom_scm_pas_prep_and_init_image(ctx, metadata, size);
++
+ 	/*
+ 	 * During the scm call memory protection will be enabled for the meta
+ 	 * data blob, so make sure it's physically contiguous, 4K aligned and
+@@ -689,7 +716,10 @@ void qcom_scm_pas_metadata_release(struct qcom_scm_pas_context *ctx)
+ 	if (!ctx->ptr)
+ 		return;
+ 
+-	dma_free_coherent(__scm->dev, ctx->size, ctx->ptr, ctx->phys);
++	if (ctx->use_tzmem)
++		qcom_tzmem_free(ctx->ptr);
++	else
++		dma_free_coherent(__scm->dev, ctx->size, ctx->ptr, ctx->phys);
+ 
+ 	ctx->ptr = NULL;
+ 	ctx->phys = 0;
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0009-firmware-qcom_scm-Add-qcom_scm_pas_get_rsc_table-to-.patch
+++ b/recipes-kernel/linux/linux-yocto-6.18/generic-drivers/scm/0009-firmware-qcom_scm-Add-qcom_scm_pas_get_rsc_table-to-.patch
@@ -1,0 +1,268 @@
+From 79b560b4a9075f9f99056cedbb44c4f3a4291795 Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Mon, 5 Jan 2026 18:52:59 +0530
+Subject: [PATCH 09/12] firmware: qcom_scm: Add qcom_scm_pas_get_rsc_table() to
+ get resource table
+
+Qualcomm remote processor may rely on Static and Dynamic resources for
+it to be functional. Static resources are fixed like for example,
+memory-mapped addresses required by the subsystem and dynamic
+resources, such as shared memory in DDR etc., are determined at
+runtime during the boot process.
+
+For most of the Qualcomm SoCs, when run with Gunyah or older QHEE
+hypervisor, all the resources whether it is static or dynamic, is
+managed by the hypervisor. Dynamic resources if it is present for a
+remote processor will always be coming from secure world via SMC call
+while static resources may be present in remote processor firmware
+binary or it may be coming qcom_scm_pas_get_rsc_table() SMC call along
+with dynamic resources.
+
+Some of the remote processor drivers, such as video, GPU, IPA, etc., do
+not check whether resources are present in their remote processor
+firmware binary. In such cases, the caller of this function should set
+input_rt and input_rt_size as NULL and zero respectively. Remoteproc
+framework has method to check whether firmware binary contain resources
+or not and they should be pass resource table pointer to input_rt and
+resource table size to input_rt_size and this will be forwarded to
+TrustZone for authentication. TrustZone will then append the dynamic
+resources and return the complete resource table in the passed output
+buffer.
+
+More about documentation on resource table format can be found in
+include/linux/remoteproc.h
+
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git 8b9d2050cfa0]
+---
+ drivers/firmware/qcom/qcom_scm.c       | 171 +++++++++++++++++++++++++
+ drivers/firmware/qcom/qcom_scm.h       |   1 +
+ include/linux/firmware/qcom/qcom_scm.h |   4 +
+ 3 files changed, 176 insertions(+)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index e99128fd0d7b..d8d96488a840 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -27,6 +27,7 @@
+ #include <linux/of_reserved_mem.h>
+ #include <linux/platform_device.h>
+ #include <linux/reset-controller.h>
++#include <linux/remoteproc.h>
+ #include <linux/sizes.h>
+ #include <linux/types.h>
+ 
+@@ -111,6 +112,8 @@ enum qcom_scm_qseecom_tz_cmd_info {
+ 	QSEECOM_TZ_CMD_INFO_VERSION		= 3,
+ };
+ 
++#define RSCTABLE_BUFFER_NOT_SUFFICIENT		20
++
+ #define QSEECOM_MAX_APP_NAME_SIZE		64
+ #define SHMBRIDGE_RESULT_NOTSUPP		4
+ 
+@@ -768,6 +771,174 @@ int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size)
+ }
+ EXPORT_SYMBOL_GPL(qcom_scm_pas_mem_setup);
+ 
++static void *__qcom_scm_pas_get_rsc_table(u32 pas_id, void *input_rt_tzm,
++					  size_t input_rt_size,
++					  size_t *output_rt_size)
++{
++	struct qcom_scm_desc desc = {
++		.svc = QCOM_SCM_SVC_PIL,
++		.cmd = QCOM_SCM_PIL_PAS_GET_RSCTABLE,
++		.arginfo = QCOM_SCM_ARGS(5, QCOM_SCM_VAL, QCOM_SCM_RO, QCOM_SCM_VAL,
++					 QCOM_SCM_RW, QCOM_SCM_VAL),
++		.args[0] = pas_id,
++		.owner = ARM_SMCCC_OWNER_SIP,
++	};
++	struct qcom_scm_res res;
++	void *output_rt_tzm;
++	int ret;
++
++	output_rt_tzm = qcom_tzmem_alloc(__scm->mempool, *output_rt_size, GFP_KERNEL);
++	if (!output_rt_tzm)
++		return ERR_PTR(-ENOMEM);
++
++	desc.args[1] = qcom_tzmem_to_phys(input_rt_tzm);
++	desc.args[2] = input_rt_size;
++	desc.args[3] = qcom_tzmem_to_phys(output_rt_tzm);
++	desc.args[4] = *output_rt_size;
++
++	/*
++	 * Whether SMC fail or pass, res.result[2] will hold actual resource table
++	 * size.
++	 *
++	 * If passed 'output_rt_size' buffer size is not sufficient to hold the
++	 * resource table TrustZone sends, response code in res.result[1] as
++	 * RSCTABLE_BUFFER_NOT_SUFFICIENT so that caller can retry this SMC call
++	 * with output_rt_tzm buffer with res.result[2] size however, It should not
++	 * be of unresonable size.
++	 */
++	ret = qcom_scm_call(__scm->dev, &desc, &res);
++	if (!ret && res.result[2] > SZ_1G) {
++		ret = -E2BIG;
++		goto free_output_rt;
++	}
++
++	*output_rt_size = res.result[2];
++	if (ret && res.result[1] == RSCTABLE_BUFFER_NOT_SUFFICIENT)
++		ret = -EOVERFLOW;
++
++free_output_rt:
++	if (ret)
++		qcom_tzmem_free(output_rt_tzm);
++
++	return ret ? ERR_PTR(ret) : output_rt_tzm;
++}
++
++/**
++ * qcom_scm_pas_get_rsc_table() - Retrieve the resource table in passed output buffer
++ *				  for a given peripheral.
++ *
++ * Qualcomm remote processor may rely on both static and dynamic resources for
++ * its functionality. Static resources typically refer to memory-mapped addresses
++ * required by the subsystem and are often embedded within the firmware binary
++ * and dynamic resources, such as shared memory in DDR etc., are determined at
++ * runtime during the boot process.
++ *
++ * On Qualcomm Technologies devices, it's possible that static resources are not
++ * embedded in the firmware binary and instead are provided by TrustZone However,
++ * dynamic resources are always expected to come from TrustZone. This indicates
++ * that for Qualcomm devices, all resources (static and dynamic) will be provided
++ * by TrustZone via the SMC call.
++ *
++ * If the remote processor firmware binary does contain static resources, they
++ * should be passed in input_rt. These will be forwarded to TrustZone for
++ * authentication. TrustZone will then append the dynamic resources and return
++ * the complete resource table in output_rt_tzm.
++ *
++ * If the remote processor firmware binary does not include a resource table,
++ * the caller of this function should set input_rt as NULL and input_rt_size
++ * as zero respectively.
++ *
++ * More about documentation on resource table data structures can be found in
++ * include/linux/remoteproc.h
++ *
++ * @ctx:	    PAS context
++ * @pas_id:	    peripheral authentication service id
++ * @input_rt:       resource table buffer which is present in firmware binary
++ * @input_rt_size:  size of the resource table present in firmware binary
++ * @output_rt_size: TrustZone expects caller should pass worst case size for
++ *		    the output_rt_tzm.
++ *
++ * Return:
++ *  On success, returns a pointer to the allocated buffer containing the final
++ *  resource table and output_rt_size will have actual resource table size from
++ *  TrustZone. The caller is responsible for freeing the buffer. On failure,
++ *  returns ERR_PTR(-errno).
++ */
++struct resource_table *qcom_scm_pas_get_rsc_table(struct qcom_scm_pas_context *ctx,
++						  void *input_rt,
++						  size_t input_rt_size,
++						  size_t *output_rt_size)
++{
++	struct resource_table empty_rsc = {};
++	size_t size = SZ_16K;
++	void *output_rt_tzm;
++	void *input_rt_tzm;
++	void *tbl_ptr;
++	int ret;
++
++	ret = qcom_scm_clk_enable();
++	if (ret)
++		return ERR_PTR(ret);
++
++	ret = qcom_scm_bw_enable();
++	if (ret)
++		goto disable_clk;
++
++	/*
++	 * TrustZone can not accept buffer as NULL value as argument hence,
++	 * we need to pass a input buffer indicating that subsystem firmware
++	 * does not have resource table by filling resource table structure.
++	 */
++	if (!input_rt) {
++		input_rt = &empty_rsc;
++		input_rt_size = sizeof(empty_rsc);
++	}
++
++	input_rt_tzm = qcom_tzmem_alloc(__scm->mempool, input_rt_size, GFP_KERNEL);
++	if (!input_rt_tzm) {
++		ret = -ENOMEM;
++		goto disable_scm_bw;
++	}
++
++	memcpy(input_rt_tzm, input_rt, input_rt_size);
++
++	output_rt_tzm = __qcom_scm_pas_get_rsc_table(ctx->pas_id, input_rt_tzm,
++						     input_rt_size, &size);
++	if (PTR_ERR(output_rt_tzm) == -EOVERFLOW)
++		/* Try again with the size requested by the TZ */
++		output_rt_tzm = __qcom_scm_pas_get_rsc_table(ctx->pas_id,
++							     input_rt_tzm,
++							     input_rt_size,
++							     &size);
++	if (IS_ERR(output_rt_tzm)) {
++		ret = PTR_ERR(output_rt_tzm);
++		goto free_input_rt;
++	}
++
++	tbl_ptr = kzalloc(size, GFP_KERNEL);
++	if (!tbl_ptr) {
++		qcom_tzmem_free(output_rt_tzm);
++		ret = -ENOMEM;
++		goto free_input_rt;
++	}
++
++	memcpy(tbl_ptr, output_rt_tzm, size);
++	*output_rt_size = size;
++	qcom_tzmem_free(output_rt_tzm);
++
++free_input_rt:
++	qcom_tzmem_free(input_rt_tzm);
++
++disable_scm_bw:
++	qcom_scm_bw_disable();
++
++disable_clk:
++	qcom_scm_clk_disable();
++
++	return ret ? ERR_PTR(ret) : tbl_ptr;
++}
++EXPORT_SYMBOL_GPL(qcom_scm_pas_get_rsc_table);
++
+ /**
+  * qcom_scm_pas_auth_and_reset() - Authenticate the given peripheral firmware
+  *				   and reset the remote processor
+diff --git a/drivers/firmware/qcom/qcom_scm.h b/drivers/firmware/qcom/qcom_scm.h
+index a56c8212cc0c..50d87c628d78 100644
+--- a/drivers/firmware/qcom/qcom_scm.h
++++ b/drivers/firmware/qcom/qcom_scm.h
+@@ -105,6 +105,7 @@ int qcom_scm_shm_bridge_enable(struct device *scm_dev);
+ #define QCOM_SCM_PIL_PAS_SHUTDOWN	0x06
+ #define QCOM_SCM_PIL_PAS_IS_SUPPORTED	0x07
+ #define QCOM_SCM_PIL_PAS_MSS_RESET	0x0a
++#define QCOM_SCM_PIL_PAS_GET_RSCTABLE	0x21
+ 
+ #define QCOM_SCM_SVC_IO			0x05
+ #define QCOM_SCM_IO_READ		0x01
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index d6d83888bb75..5747bd191bf1 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -88,6 +88,10 @@ int qcom_scm_pas_mem_setup(u32 pas_id, phys_addr_t addr, phys_addr_t size);
+ int qcom_scm_pas_auth_and_reset(u32 pas_id);
+ int qcom_scm_pas_shutdown(u32 pas_id);
+ bool qcom_scm_pas_supported(u32 pas_id);
++struct resource_table *qcom_scm_pas_get_rsc_table(struct qcom_scm_pas_context *ctx,
++						  void *input_rt, size_t input_rt_size,
++						  size_t *output_rt_size);
++
+ int qcom_scm_pas_prepare_and_auth_reset(struct qcom_scm_pas_context *ctx);
+ 
+ int qcom_scm_io_readl(phys_addr_t addr, unsigned int *val);
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -9,6 +9,7 @@ SRC_URI:append:qcom = " \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://monaco-evk-dts/0001-arm64-dts-qcom-monaco-evk-camera-Add-DT-overlay.patch \
     file://hamoa-iot-evk-dts/0001-arm64-dts-qcom-hamoa-iot-evk-camera-imx577-Add-DT-ov.patch \
+    file://generic-drivers/remoteproc/0001-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch \
 "
 
 # Include additional kernel configs.

--- a/recipes-kernel/linux/linux-yocto-dev/generic-drivers/remoteproc/0001-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/generic-drivers/remoteproc/0001-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch
@@ -1,0 +1,203 @@
+From 72f55726a8a82b55aacde0f4f70da2fcbe31f08a Mon Sep 17 00:00:00 2001
+From: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Date: Tue, 10 Mar 2026 19:22:05 +0530
+Subject: [PATCH] FROMLIST: remoteproc: qcom: pas: Map/unmap subsystem region
+ before auth_and_reset
+
+Qualcomm remoteproc drivers such as qcom_q6v5_mss, which do not use the
+Peripheral Authentication Service (PAS), always map the MBA region before
+use and unmap it once the usage is complete. This behavior was introduced
+to avoid issues seen in the past where speculative accesses from the
+application processor to the MBA region after it was assigned to the remote
+Q6 led to an XPU violation. The issue was mitigated by unmapping the region
+before handing control to the remote Q6.
+
+Currently, most Qualcomm SoCs using the PAS driver run either with a
+standalone QHEE or the Gunyah hypervisor. In these environments, the
+hypervisor unmaps the Q6 memory from HLOS Stage-2 and remaps it into the
+Q6 Stage-2 page table. As a result, speculative accesses from HLOS cannot
+reach the region even if it remains mapped in HLOS Stage-1; therefore, XPU
+violations cannot occur.
+
+However, when the same SoC runs Linux at EL2, Linux itself must perform the
+unmapping to avoid such issues. It is still correct to apply this mapping/
+unmapping sequence even for SoCs that run under Gunyah, so this behavior
+should not be conditional.
+
+Link: https://lore.kernel.org/lkml/20260325191301.164579-2-mukesh.ojha@oss.qualcomm.com/
+Signed-off-by: Mukesh Ojha <mukesh.ojha@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/lkml/20260325191301.164579-2-mukesh.ojha@oss.qualcomm.com/]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c  | 41 ++++++++++++++++++++---------
+ drivers/soc/qcom/mdt_loader.c       | 18 ++++++++++---
+ include/linux/soc/qcom/mdt_loader.h |  4 +--
+ 3 files changed, 44 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 46204da046fa..d0c9e24ff26e 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -148,7 +148,16 @@ static void qcom_pas_minidump(struct rproc *rproc)
+ 	if (rproc->dump_conf == RPROC_COREDUMP_DISABLED)
+ 		return;
+ 
++	pas->mem_region = ioremap_wc(pas->mem_phys, pas->mem_size);
++	if (!pas->mem_region) {
++		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
++			&pas->mem_phys, pas->mem_size);
++		return;
++	}
++
+ 	qcom_minidump(rproc, pas->minidump_id, qcom_pas_segment_dump);
++	iounmap(pas->mem_region);
++	pas->mem_region = NULL;
+ }
+ 
+ static int qcom_pas_pds_enable(struct qcom_pas *pas, struct device **pds,
+@@ -241,7 +250,7 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 		}
+ 
+ 		ret = qcom_mdt_pas_load(pas->dtb_pas_ctx, pas->dtb_firmware,
+-					pas->dtb_firmware_name, pas->dtb_mem_region,
++					pas->dtb_firmware_name,
+ 					&pas->dtb_mem_reloc);
+ 		if (ret)
+ 			goto release_dtb_metadata;
+@@ -319,7 +328,7 @@ static int qcom_pas_start(struct rproc *rproc)
+ 	}
+ 
+ 	ret = qcom_mdt_pas_load(pas->pas_ctx, pas->firmware, rproc->firmware,
+-				pas->mem_region, &pas->mem_reloc);
++				&pas->mem_reloc);
+ 	if (ret)
+ 		goto release_pas_metadata;
+ 
+@@ -510,6 +519,22 @@ static unsigned long qcom_pas_panic(struct rproc *rproc)
+ 	return qcom_q6v5_panic(&pas->q6v5);
+ }
+ 
++static void qcom_pas_coredump(struct rproc *rproc)
++{
++	struct qcom_pas *pas = rproc->priv;
++
++	pas->mem_region = ioremap_wc(pas->mem_phys, pas->mem_size);
++	if (!pas->mem_region) {
++		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
++			&pas->mem_phys, pas->mem_size);
++		return;
++	}
++
++	rproc_coredump(rproc);
++	iounmap(pas->mem_region);
++	pas->mem_region = NULL;
++}
++
+ static const struct rproc_ops qcom_pas_ops = {
+ 	.unprepare = qcom_pas_unprepare,
+ 	.start = qcom_pas_start,
+@@ -518,6 +543,7 @@ static const struct rproc_ops qcom_pas_ops = {
+ 	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+ 	.panic = qcom_pas_panic,
++	.coredump = qcom_pas_coredump,
+ };
+ 
+ static const struct rproc_ops qcom_pas_minidump_ops = {
+@@ -634,12 +660,6 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
+ 
+ 	pas->mem_phys = pas->mem_reloc = res.start;
+ 	pas->mem_size = resource_size(&res);
+-	pas->mem_region = devm_ioremap_resource_wc(pas->dev, &res);
+-	if (IS_ERR(pas->mem_region)) {
+-		dev_err(pas->dev, "unable to map memory region: %pR\n", &res);
+-		return PTR_ERR(pas->mem_region);
+-	}
+-
+ 	if (!pas->dtb_pas_id)
+ 		return 0;
+ 
+@@ -651,11 +671,6 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
+ 
+ 	pas->dtb_mem_phys = pas->dtb_mem_reloc = res.start;
+ 	pas->dtb_mem_size = resource_size(&res);
+-	pas->dtb_mem_region = devm_ioremap_resource_wc(pas->dev, &res);
+-	if (IS_ERR(pas->dtb_mem_region)) {
+-		dev_err(pas->dev, "unable to map dtb memory region: %pR\n", &res);
+-		return PTR_ERR(pas->dtb_mem_region);
+-	}
+ 
+ 	return 0;
+ }
+diff --git a/drivers/soc/qcom/mdt_loader.c b/drivers/soc/qcom/mdt_loader.c
+index c004d444d698..33f3543f8e55 100644
+--- a/drivers/soc/qcom/mdt_loader.c
++++ b/drivers/soc/qcom/mdt_loader.c
+@@ -11,6 +11,7 @@
+ #include <linux/device.h>
+ #include <linux/elf.h>
+ #include <linux/firmware.h>
++#include <linux/io.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/firmware/qcom/qcom_scm.h>
+@@ -478,22 +479,31 @@ EXPORT_SYMBOL_GPL(qcom_mdt_load);
+  * @ctx:        Pointer to the PAS (Peripheral Authentication Service) context
+  * @fw:         Firmware object representing the .mdt file
+  * @firmware:   Name of the firmware used to construct segment file names
+- * @mem_region: Memory region allocated for loading the firmware
+  * @reloc_base: Physical address adjusted after relocation
+  *
+  * Return: 0 on success or a negative error code on failure.
+  */
+ int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
+-		      const char *firmware, void *mem_region, phys_addr_t *reloc_base)
++		      const char *firmware, phys_addr_t *reloc_base)
+ {
++	void *mem_region;
+ 	int ret;
+ 
+ 	ret = __qcom_mdt_pas_init(ctx->dev, fw, firmware, ctx->pas_id, ctx->mem_phys, ctx);
+ 	if (ret)
+ 		return ret;
+ 
+-	return qcom_mdt_load_no_init(ctx->dev, fw, firmware, mem_region, ctx->mem_phys,
+-				     ctx->mem_size, reloc_base);
++	mem_region = ioremap_wc(ctx->mem_phys, ctx->mem_size);
++	if (!mem_region) {
++		dev_err(ctx->dev, "unable to map memory region: %pa+%zx\n", &ctx->mem_phys,
++			ctx->mem_size);
++		return -EINVAL;
++	}
++
++	ret = qcom_mdt_load_no_init(ctx->dev, fw, firmware, mem_region, ctx->mem_phys,
++				    ctx->mem_size, reloc_base);
++	iounmap(mem_region);
++	return ret;
+ }
+ EXPORT_SYMBOL_GPL(qcom_mdt_pas_load);
+ 
+diff --git a/include/linux/soc/qcom/mdt_loader.h b/include/linux/soc/qcom/mdt_loader.h
+index 82372e0db0a1..7c551b98e182 100644
+--- a/include/linux/soc/qcom/mdt_loader.h
++++ b/include/linux/soc/qcom/mdt_loader.h
+@@ -21,7 +21,7 @@ int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 		  phys_addr_t *reloc_base);
+ 
+ int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx, const struct firmware *fw,
+-		      const char *firmware, void *mem_region, phys_addr_t *reloc_base);
++		      const char *firmware, phys_addr_t *reloc_base);
+ 
+ int qcom_mdt_load_no_init(struct device *dev, const struct firmware *fw,
+ 			  const char *fw_name, void *mem_region,
+@@ -47,7 +47,7 @@ static inline int qcom_mdt_load(struct device *dev, const struct firmware *fw,
+ 
+ static inline int qcom_mdt_pas_load(struct qcom_scm_pas_context *ctx,
+ 				    const struct firmware *fw, const char *firmware,
+-				    void *mem_region, phys_addr_t *reloc_base)
++				    phys_addr_t *reloc_base)
+ {
+ 	return -ENODEV;
+ }
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-yocto_6.18.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.18.bbappend
@@ -4,4 +4,16 @@ SRC_URI:append:qcom = " \
     file://workarounds/f553aff9a3ab245e722349cc617bcdfe778c69af.patch \
     file://monaco-evk-dts/0001-arm64-dts-qcom-monaco-evk-camera-Add-DT-overlay.patch \
     file://hamoa-iot-evk-dts/0001-arm64-dts-qcom-hamoa-iot-evk-camera-imx577-Add-DT-ov.patch \
+    file://generic-drivers/scm/0001-firmware-qcom_scm-Rename-peripheral-as-pas_id.patch \
+    file://generic-drivers/scm/0002-firmware-qcom_scm-Introduce-PAS-context-allocator-he.patch \
+    file://generic-drivers/remoteproc/0003-remoteproc-pas-Replace-metadata-context-with-PAS-con.patch \
+    file://generic-drivers/mdtloader/0004-soc-qcom-mdtloader-Add-PAS-context-aware-qcom_mdt_pa.patch \
+    file://generic-drivers/mdtloader/0005-soc-qcom-mdtloader-Remove-qcom_mdt_pas_init-from-exp.patch \
+    file://generic-drivers/scm/0006-firmware-qcom_scm-Add-a-prep-version-of-auth_and_res.patch \
+    file://generic-drivers/scm/0007-firmware-qcom_scm-Refactor-qcom_scm_pas_init_image.patch \
+    file://generic-drivers/scm/0008-firmware-qcom_scm-Add-SHM-bridge-handling-for-PAS-wh.patch \
+    file://generic-drivers/scm/0009-firmware-qcom_scm-Add-qcom_scm_pas_get_rsc_table-to-.patch \
+    file://generic-drivers/remoteproc/0010-remoteproc-pas-Extend-parse_fw-callback-to-fetch-res.patch \
+    file://generic-drivers/remoteproc/0011-remoteproc-qcom-pas-Enable-Secure-PAS-support-with-I.patch \
+    file://generic-drivers/remoteproc/0012-FROMLIST-remoteproc-qcom-pas-Map-unmap-subsystem-reg.patch \
 "


### PR DESCRIPTION
Add generic API support which provide the platform to enable KVM for multiple client like video. It enables for targets like kodiak, lemans, monaco etc.

Qualcomm SoCs running with QHEE (EL2) have traditionally relied on the Peripheral Authentication Service (PAS) from TrustZone (TZ) firmware to securely authenticate and reset remote processors using a single SMC call (auth_and_reset). This call is first trapped by QHEE, which then invokes TZ for authentication. Once authentication is complete, control returns to QHEE, where the IOMMU translation scheme for the remote processors is configured before bringing them out of reset. Due to the design of the Qualcomm EL2 hypervisor, the Linux host OS running at EL1 is not permitted to configure IOMMU translations for remote processors, and only a single-stage translation is supported.

To make the remote processor bring-up (PAS) sequence hypervisor-independent, the auth_and_reset SMC call is now handled entirely by TrustZone. However, IOMMU configuration remains a challenge in scenarios where the KVM host is running at EL2 and does not have visibility into the remote processors’ IOMMU requirements. This is addressed by dynamically overlaying the IOMMU properties when the SoC runs a Linux host at EL2. An SMC interface provided by the TrustZone firmware allows the KVM host to retrieve the resource table for a given subsystem.
In addition, several remote processors—such as video, camera, and graphics—do not use the remoteproc framework to manage their lifecycle and instead rely on the Qualcomm PAS service to authenticate firmware. These processors must also be brought out of reset when Linux operates at EL2. Their client drivers use the MDT loader to load and authenticate firmware and, similar to the Qualcomm remoteproc PAS driver, are required to retrieve the resource table, create a shared memory bridge (shmbridge), and map the necessary resources before releasing the processors from reset.

This patch series enables Qualcomm infrastructure drivers such as SCM, remoteproc, and mdtloader to support the Secure PIL bring-up sequence when Linux runs as a hypervisor. All related patches have already been accepted upstream, except for one patch that is still FROMLIST. This remaining patch ensures that remote processor memory is unmapped from the Linux host before being handed over to the remote processor. Without this step, the memory region would remain mapped in the HLOS, allowing speculative CPU access while the remote processor is active, which poses a security risk.