### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260419

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.18"
+LINUX_VERSION ?= "6.18.21"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260414
-SRCREV ?= "cad3efc403505af8ed0b4709e173b61bfb0327a1"
+# tag:qcom-6.18.y-20260419
+SRCREV ?= "2f43e5abac7c92e736109e693fd376fa033fe1ef"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260416

Changelog:
Merge tag 'v6.18.21' into qcom-6.18.y
FROMLIST: arm64: dts: qcom: lemans-evk: Move SD card support to overlay
FROMLIST: arm64: dts: qcom: lemans-evk: Add SDHCI support for eMMC via overlay
FROMLIST: PCI: dwc: Remove MSI/MSIX capability if iMSI-RX is used as MSI controller
FROMLIST: bus: mhi: host: pci_generic: Switch to async power up to avoid boot delays
FROMLIST: bus: mhi: host: pci_generic: Add pm_runtime_forbid() in remove callback
FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool
FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation
Revert "FROMLIST: arm64: dts: qcom: talos: Add GPR node, audio services, and MI2S1 TLMM pins"
Revert "FROMLIST: arm64: dts: qcom: talos-evk: Add sound card support with DA7212 codec"
FROMLIST: arm64: dts: qcom: talos: Add GPR node, audio services, and MI2S1 TLMM pins
FROMLIST: arm64: dts: qcom: talos-evk: Add sound card support with DA7212 codec
QCLINUX: arm64: configs: Enable SmartPQI support
FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe
FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL
FROMLIST: arm64: dts: qcom: kodiak: Add iface clock and power domain for ice sdhc
FROMLIST: arm64: dts: qcom: monaco: Add iface clock and power domain for ice sdhc
QCLINUX: memory-dump: fix array size issue for Talos
QCLINUX: qcom-dcc: add logic to configure linked list in probe
QCLINUX: qcom-dcc: add register list for the Talos
QCLINUX: qcom-dcc: use late_initcall and build as built-in for boot debug
QCLINUX: memory-dump: use late_initcall and build as built-in for boot debug
FROMLIST: ASoC: codecs: lpass-wsa-macro: Switch to PM clock framework for runtime PM
FROMLIST: ASoC: codecs: lpass-va-macro: Switch to PM clock framework for runtime PM
FROMLIST: ASoC: codecs: lpass-wsa-macro: Guard optional NPL clock rate programming
PENDING: arm64: qcom: dts: talos: add TGU device in staging dtso
PENDING: arm64: dts: qcom: lemans: add TGU device in staging dtso
PENDING: arm64: dts: qcom: monaco: add TGU device in staging dtso
PENDING: arm64: dts: qcom: kodiak: add TGU device in staging dtso
FROMLIST: dt-bindings: crypto: ice: add operating-points-v2 property for QCOM ICE
FROMLIST: soc: qcom: ice: Add OPP-based clock scaling support for ICE
FROMLIST: ufs: host: Add ICE clock scaling during UFS clock changes
FROMLIST: mmc: sdhci-msm: Set ICE clk to TURBO at sdhci ICE init
FROMLIST: arm64: dts: qcom: kodiak: Add OPP-table for ICE UFS and ICE eMMC nodes
FROMLIST: arm64: dts: qcom: monaco: Add OPP-table for ICE UFS and ICE eMMC nodes
FROMLIST: arm64: dts: qcom: monaco-evk: Extract common EVK hardware into shared dtsi
FROMLIST: dt-bindings: arm: qcom: Add monaco-ac-evk support
FROMLIST: arm64: dts: qcom: monaco: Add monaco-ac EVK board
QCLINUX: arm64: dts: qcom: Enable combo mode for CSI1 port
QCLINUX: qcom.config: Enable MMC_CRYPTO for ICE emmc
Revert "FROMLIST: PCI: dwc: Remove MSI/MSIX capability if iMSI-RX is used as MSI controller"
FROMLIST: pinctrl: qcom: lpass-lpi: Switch to PM clock framework for runtime PM
FROMLIST: pinctrl: qcom: lpass-lpi: Fix GPIO register access helper return types
FROMLIST: pinctrl: qcom: lpass-lpi: Resume clocks for GPIO access
Revert "FROMLIST: arm64: dts: qcom: monaco-evk: Extract common EVK hardware into shared dtsi"
Revert "FROMLIST: dt-bindings: arm: qcom: Add monaco-ac-evk support"
Revert "FROMLIST: arm64: dts: qcom: monaco: Add monaco-ac EVK board"
Revert "FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool"
Revert "FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation"
Revert "FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe"
Revert "FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL"