### PR TITLE
qps615-dlkm: Add patch to implement phy-mode DT overlay for SGMII

### DIFF
--- a/recipes-kernel/qps615-module/qps615-dlkm/0013-net-ethernet-tc956x-Implement-phy-mode-DT-overlay-fo.patch
+++ b/recipes-kernel/qps615-module/qps615-dlkm/0013-net-ethernet-tc956x-Implement-phy-mode-DT-overlay-fo.patch
@@ -1,0 +1,72 @@
+From bfb38c3349dcd4aeb2af8f1339a30710e70ad75d Mon Sep 17 00:00:00 2001
+From: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
+Date: Thu, 16 Apr 2026 10:49:06 +0530
+Subject: [PATCH 13/13] net: ethernet: tc956x: Implement phy-mode DT overlay
+ for SGMII
+
+The first port on the RB3 Gen2 Industrial Kit uses an SGMII PHY,
+whereas the driver defaults to 10GBASE-R. Implement
+tc956x_platform_port_interface_overlay() to read the phy-mode
+property from the DT node and configure the port interface when
+SGMII is specified.
+
+Upstream-Status: Submitted [https://github.com/TC956X/TC9564_Host_Driver/pull/6]
+Signed-off-by: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
+---
+ .../net/ethernet/toshiba/tc956x/tc956x_qcom.c | 30 +++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/toshiba/tc956x/tc956x_qcom.c b/drivers/net/ethernet/toshiba/tc956x/tc956x_qcom.c
+index 4f69734..c1ef1cb 100644
+--- a/drivers/net/ethernet/toshiba/tc956x/tc956x_qcom.c
++++ b/drivers/net/ethernet/toshiba/tc956x/tc956x_qcom.c
+@@ -7,6 +7,7 @@
+ #include <linux/gpio/consumer.h>
+ #include <linux/kernel.h>
+ #include <linux/of_irq.h>
++#include <linux/of_net.h>
+ #include <linux/pinctrl/consumer.h>
+ #include <linux/regulator/consumer.h>
+ 
+@@ -84,11 +85,36 @@ static int tc956x_phy_power_off(struct tc956xmac_priv *priv)
+ 	return ret;
+ }
+ 
++/* tc956xmac_pci_probe calls this function and expects a
++ * non-zero return value if an overlay is present.
++ */
+ int tc956x_platform_port_interface_overlay(struct device *dev,
+ 					   struct tc956xmac_resources *res)
+ {
+-	/* Currently unused */
+-	return 0;
++	phy_interface_t phy_iface;
++	int ret;
++
++	if (!dev->of_node)
++		return 0;
++
++	ret = of_get_phy_mode(dev->of_node, &phy_iface);
++	if (ret) {
++		if (ret != -ENODEV)
++			dev_warn(dev, "Failed to read phy-mode: %d\n", ret);
++		return 0;
++	}
++
++	switch (phy_iface) {
++	case PHY_INTERFACE_MODE_SGMII:
++		res->port_interface = ENABLE_SGMII_INTERFACE;
++		res->c45_state = false;
++		res->mdc_clk = TC956XMAC_XGMAC_MDC_CSR_62;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 1;
+ }
+ 
+ static int tc956x_platform_of_parse(struct device *dev,
+-- 
+2.34.1
+

--- a/recipes-kernel/qps615-module/qps615-dlkm_6.0.1.bb
+++ b/recipes-kernel/qps615-module/qps615-dlkm_6.0.1.bb
@@ -23,6 +23,7 @@ SRC_URI = "\
 	file://0010-net-ethernet-tc956x-Use-kvfree-instead-of-vfree.patch \
 	file://0011-net-ethernet-tc956x-Fix-module-auto-loading.patch \
 	file://0012-net-ethernet-tc956x-Add-Qualcomm-platform-driver-and.patch \
+	file://0013-net-ethernet-tc956x-Implement-phy-mode-DT-overlay-fo.patch \
 "
 
 B = "${S}/drivers/net/ethernet/toshiba/tc956x"


### PR DESCRIPTION
Add a patch to the QPS615 DLKM recipe that implements phy-mode DT overlay support for SGMII on the Rb3Gen2 Industrial Kit.

The first port on the Rb3Gen2 Industrial Kit is wired to an RTL8221 SGMII PHY, but the TC956X driver defaults to 10GBASE-R for port 0. Without this patch, the port fails to link up on that board variant.

The new patch implements tc956x_platform_port_interface_overlay() to read the "phy-mode" property from the device tree node at probe time. When SGMII is specified, the function configures the required parameters for RTL8221. For any other or absent "phy-mode" value the function returns 0 and the driver proceeds with its default configuration.

The upstream change has been added to the Qualcomm Platform support PR at https://github.com/TC956X/TC9564_Host_Driver/pull/6.

