### PR TITLE
Add devicetree overlay to support QPS615 on Rb3Gen2 Industrial Mezzanine

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -74,6 +74,10 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
     qcom,qcs5430-iot-subtype9 \
     qcom,qcs6490-iot-subtype9 \
 "
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+qcs6490-rb3gen2-industrial-mezzanine-staging] = " \
+    qcom,qcs5430-iot-subtype9-staging \
+    qcom,qcs6490-iot-subtype9-staging \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
     qcom,qcs5430-iot-subtype2 \
     qcom,qcs6490-iot-subtype2 \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -17,6 +17,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-vision-mezzanine-camx.dtbo \
                       qcom/qcs6490-rb3gen2-staging.dtbo \
+                      qcom/qcs6490-rb3gen2-industrial-mezzanine-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
This series adds Device Tree overlay (DTBO) support for the QPS615 PCIe Ethernet switch on the RB3Gen2 Industrial Mezzanine board. The RB3Gen2 Industrial Kit carries 3x QPS615 PCIe switches, of which 2 have dual ethernet ports. The QPS615's Ethernet functionality is enabled by an out-of-tree kernel driver (qps615-dlkm) that requires platform-specific devicetree properties to access hardware resources.

This is a "staging" DTBO due to its downstream nature; it lives in the LINUX_QCOM_KERNEL_DEVICETREE list and is referenced via a FIT_DTB_COMPATIBLE overlay combination in the FIT image.

**This PR depends on kernel changes to add the dtso's to qcom-next and qcom-6.18.y branches. They still need to be merged and consumed by their revision tag in meta-qcom.**

**Exception details:** Until the QPS615 driver is upstreamed to the kernel (third-party ETA: end of 2026), an exception has been approved to include the driver + DT overlay (QLIJIRA-99).
