### PR TITLE
pipewire: allow AudioReach DMA-HEAP access

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,6 +22,8 @@ LICENSE_PATH += "${LAYERDIR}/licenses"
 BBFILES_DYNAMIC += " \
     meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bb \
     meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bbappend \
+    meta-audioreach:${LAYERDIR}/dynamic-layers/meta-audioreach/*/*/*.bb \
+    meta-audioreach:${LAYERDIR}/dynamic-layers/meta-audioreach/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \

--- a/dynamic-layers/meta-audioreach/recipes-multimedia/pipewire/files/dmaheap.conf
+++ b/dynamic-layers/meta-audioreach/recipes-multimedia/pipewire/files/dmaheap.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Allow PipeWire to access DMA-HEAP when AudioReach is enabled
+
+[Service]
+SupplementaryGroups=dmaheap

--- a/dynamic-layers/meta-audioreach/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/dynamic-layers/meta-audioreach/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:qcom = " file://dmaheap.conf"
+
+do_install:append:qcom() {
+    install -d ${D}${systemd_system_unitdir}/pipewire.service.d
+    install -m 0644 ${UNPACKDIR}/dmaheap.conf \
+        ${D}${systemd_system_unitdir}/pipewire.service.d/dmaheap.conf
+}


### PR DESCRIPTION
AudioReach audio pipelines require PipeWire to allocate buffers from DMA-HEAP. Without appropriate permissions, PipeWire fails to initialize AudioReach graphs due to access errors on /dev/dma_heap.

Install a systemd drop-in granting PipeWire dmaheap group membership via a dynamic layer that activates only when meta-audioreach is present, keeping base images unaffected.