### PR TITLE
compile/action: start with a build using setscene only

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -67,6 +67,7 @@ runs:
     - name: Kas qcom world build
       shell: bash
       run: |
+        $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml -- --setscene-only
         $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
         $KAS_CONTAINER shell ${KAS_YAMLS}:ci/world.yml \
           -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
@@ -76,6 +77,7 @@ runs:
     - name: Kas build images
       shell: bash
       run: |
+        $KAS_CONTAINER build ${KAS_YAMLS} -- --setscene-only
         $KAS_CONTAINER build ${KAS_YAMLS}
         $KAS_CONTAINER shell ${KAS_YAMLS} \
           -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
@@ -85,6 +87,7 @@ runs:
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
           # SDK only with the default kernel
           if [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
+            $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk -- --setscene-only
             $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk
             $KAS_CONTAINER shell ${KAS_YAMLS} \
               -c "buildstats-summary --sort duration --highlight 0 --shortest 300"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -108,6 +108,13 @@ jobs:
           mkdir $KAS_WORK_DIR
           $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
 
+      - name: Kas build world (setscene)
+        if:  inputs.world
+        shell: bash
+        run: |
+          $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml -- --setscene-only
+          $KAS_CONTAINER shell ${KAS_YAMLS} --command "buildstats-summary --sort duration --highlight 0"
+
       - name: Kas build world
         if:  inputs.world
         shell: bash
@@ -122,6 +129,13 @@ jobs:
           rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
           mv $KAS_WORK_DIR/build/buildstats* .
 
+      - name: Kas build images (setscene)
+        if:  inputs.target
+        shell: bash
+        run: |
+          $KAS_CONTAINER build ${KAS_YAMLS} -- --setscene-only
+          $KAS_CONTAINER shell ${KAS_YAMLS} --command "buildstats-summary --sort duration --highlight 0"
+
       - name: Kas build images
         if:  inputs.target
         shell: bash
@@ -134,6 +148,16 @@ jobs:
         run: |
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           mv $KAS_WORK_DIR/build/buildstats* .
+
+      - name: Kas build SDK (setscene)
+        if:  inputs.sdk
+        shell: bash
+        run: |
+          $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
+            --target qcom-multimedia-image \
+            --target qcom-multimedia-proprietary-image \
+              -- --setscene-only
+          $KAS_CONTAINER shell ${KAS_YAMLS} --command "buildstats-summary --sort duration --highlight 0"
 
       - name: Kas build SDK
         if:  inputs.sdk


### PR DESCRIPTION
Since the sstate-cache used in CI is hosted on a NFS server, this change will allow measuring its latency.

Performing an initial build at each subbuild step using only the bitbake setscene tasks, will allow us to measure the time of that task. Which basically consists of executing all the task that can be accelerated using the stored sstate-cache. These tasks make exhaustive use of the NFS filesystem to acquire the sstate-cache artifacts.

With this change, it will be easy to distinguish between the time required to acquire and unpack the sstate-cache artifacts and the time spent on the build itself.