### PR TITLE
TEMP: NO MERGE: linux-firmware: install Cologne firmware path

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,3 +8,7 @@ inherit_defer ${ALTERNATIVES_CLASS}
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin${@fw_compr_file_suffix(d)}"
+
+do_install:append:rb3gen2-core-kit() {
+    install -d ${D}${nonarch_base_libdir}/firmware/ath12k/QCC2072/hw1.0
+}


### PR DESCRIPTION
Install /lib/firmware/ath12k/QCC2072/hw1.0 for engineering META to include firmware builds.