### PR TITLE
Include upstream camera DTBOs for Lemans/Monaco EL2 boot

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -20,7 +20,7 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx] = " \
     qcom,qcs9075-iot-camx \
     qcom,qcs9075-socv2.0-iot-camx \
 "
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-el2] = " \
+FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577+lemans-el2] = " \
     qcom,qcs9075-iot-el2kvm \
     qcom,qcs9075-socv2.0-iot-el2kvm \
 "
@@ -36,7 +36,7 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-evk-staging] = " \
     qcom,qcs9075-iot-subtype1-staging \
     qcom,qcs9075v2-iot-subtype1-staging \
 "
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-el2] = "qcom,qcs8275-iot-el2kvm"
+FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577+monaco-el2] = "qcom,qcs8275-iot-el2kvm"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx+monaco-el2+monaco-camx-el2] = "qcom,qcs8275-iot-camx-el2kvm"


### PR DESCRIPTION
For Lemans and Monaco upstream builds, camera DTB overlays are applied by default for normal (non-KVM) boot, but are missing for EL2/KVM-based boot under Config 1.

As a result, camera overlays such as:
  - lemans-evk-camera-csi1-imx577
  - monaco-evk-camera-imx577

are not selected during FIT image boot when EL2/KVM is enabled, since they are not present in the corresponding FIT_DTB_COMPATIBLE mappings.

Update FIT_DTB_COMPATIBLE entries to include the upstream camera DTBOs along with EL2-enabled DTBOs for:
  - Lemans EVK variants
  - Monaco EVK variants

This ensures camera DTBOs are consistently built, packaged, and selected during FIT boot for both non-KVM and EL2/KVM configurations.

- qcom-dtb-metadata EL2/KVM compatibility updates:
  - https://github.com/qualcomm-linux/qcom-dtb-metadata/pull/87