### PR TITLE
refpolicy-targeted: add Qualcomm-specific PipeWire SELinux support

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,3 +4,5 @@ SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
 "
+
+POLICY_CUSTOM_BUILDOPT:qcom = "pipewire_system_service"


### PR DESCRIPTION
Introduce a new SELinux policy module 'pipewire_stack' to confine the
PipeWire multimedia daemon and its associated runtime under a dedicated
least-privilege domain.

Changes include:

- pipewire_stack.fc: File context definitions for PipeWire executables,
  configuration, shared data, runtime sockets, and persistent state
  under /usr/bin, /etc/pipewire, /usr/share/pipewire, /run/pipewire,
  and /var/lib/pipewire respectively.

- pipewire_stack.if: Interface file stub for the pipewire_stack policy
  module, reserved for future cross-module interface definitions.

- pipewire_stack.te: Type enforcement policy for the pipewire_t domain
  covering:
  - Process control: fork, signal handling, and scheduling (sys_nice)
    for low-latency audio operation
  - Runtime socket and directory management under /run/pipewire
  - ALSA sound device access (sound_device_t)
  - DMA device access (dma_device_t) for hardware audio offload
  - Shared memory (tmpfs/memfd) for zero-copy audio buffer handling
  - PulseAudio runtime compatibility (/run/pulse probing and PID file
    management)
  - sysfs and procfs read access for hardware discovery
  - System logging via syslog and systemd journal
  - Suppressed audit noise for expected /proc scan denials via
    dontaudit rules