### PR TITLE
initramfs-firmware-iq-x7181-evk-image: firmware image for Hamoa IoT EVK

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-iq-x7181-evk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-iq-x7181-evk-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with IQ-x7181 EVK firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-hamoa-iot-evk-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Add recipe to generiate small initramfs image with firmware for the Hamoa IoT EVK.