### PR TITLE
firmware-qcom-boot-x7181: Update tag to 00010 and enable tech pack based releases

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
@@ -4,16 +4,14 @@ LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27
 
 include firmware-qcom-boot-common.inc
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Ubuntu_Qualcomm_IoT.SPF.1.0/ubuntu_qualcomm_iot.spf.1.0-test-device-public"
-FW_BUILD_ID = "r1.0.r1_${PV}/HAMOA_IOT.UBUN.1.0.R1"
-FW_BIN_PATH = "common/build/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Hamoa_bootbinaries.1.0/hamoa_bootbinaries.1.0-test-device-public/"
 BOOTBINARIES = "HAMOA_bootbinaries"
 
 S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/HAMOA_bootbinaries.zip;downloadfilename=HAMOA_bootbinaries_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/HAMOA_bootbinaries_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/X1E80100/cdt/IQ-X.1.2-EVK-CDT.tar.gz;downloadfilename=cdt-iq-x7181-evk_${PV}.tar.gz;name=cdt-iq-x7181-evk \
     "
 SRC_URI[cdt-iq-x7181-evk.sha256sum] = "279c47ff8f1a7f4300d296fcb7fbb3d025d903e4c16f62fbb74939804949584e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00008.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00008.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6da4295c827eb14f5a2734b0f38033639e5f3f141668eba69a0923fc3adaf39e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00010.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00010.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "6bab4c5e33506fb8babc1ad290ac2f6643cb2750286aa9e82c3659381148b9a6"


### PR DESCRIPTION
Tech pack based release path and versioning is for SPF agnostic paths across QLI targets. This enabled SP level versioning of boot bins.

Known fixes:
-enable secure boot validation and stable capsule updates 
-improve boot reliability through memory map optimization