### PR TITLE
Enable Hamoa camx DTB compilation for linux-qcom kernel

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -11,6 +11,10 @@ FIT_DTB_COMPATIBLE[hamoa-iot-evk+hamoa-iot-evk-camera-imx577] = " \
     qcom,hamoa-evk \
     qcom,hamoa-socv2.1-evk \
 "
+FIT_DTB_COMPATIBLE[hamoa-iot-evk+hamoa-evk-camx] = " \
+    qcom,hamoa-evk-camx \
+    qcom,hamoa-socv2.1-evk-camx \
+"
 FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577] = " \
     qcom,qcs9075-iot \

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -11,6 +11,11 @@ KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk-camera-imx577.dtbo \
                       "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/hamoa-evk-camx.dtbo \
+"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-hamoa-iot-evk-firmware \
     packagegroup-hamoa-iot-evk-hexagon-dsp-binaries \


### PR DESCRIPTION
Downstream camera DTB is not included in the final image
when building linux-qcom, linux-qcom-next, linux-qcom-rt,
or linux-qcom-next-rt kernels for the hamoa EVK board.
This prevents the downstream camera stack from being
enabled at boot, even though the kernel supports it.

Include the downstream camera DTB so it is packaged into
the final image and downstream camera functionality is
available for the IQ-x7181 EVK.

Add multi-DTB support for camx overlay to enable downstream 
camera for IQ-x7181 (hamoa-evk-camx).