### PR TITLE
packagegroup-qcom: stop installing pd-mapper

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -11,7 +11,6 @@ PACKAGES = " \
 "
 
 RDEPENDS:${PN}-boot-essential = " \
-    pd-mapper \
     qrtr \
     rmtfs \
     tqftpserv \


### PR DESCRIPTION
The userspace pd-mapper is a daemon providing protection domain mapping for the DSPs. The kernels inside meta-qcom have CONFIG_QCOM_PD_MAPPER enabled, which provides the same functionality but in the kernel space. Stop installing userspace component which duplicates the kernel feature.