### PR TITLE
mount-tee-partition: add usb_fw mount and xHCI bind rule for qcm6490

### DIFF
--- a/recipes-bsp/partition/mount-tee-partition/var-usbfw.mount
+++ b/recipes-bsp/partition/mount-tee-partition/var-usbfw.mount
@@ -1,0 +1,15 @@
+#Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+#SPDX-License-Identifier: BSD-3-Clause-Clear
+
+[Unit]
+Description=mount usb_fw unit
+Before=local-fs.target
+
+[Mount]
+What=/dev/disk/by-partlabel/usb_fw
+Where=/var/usbfw
+DirectoryMode=0744
+Type=ext4
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-bsp/partition/mount-tee-partition/xhci-bind.rules
+++ b/recipes-bsp/partition/mount-tee-partition/xhci-bind.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="pci", ATTR{class}=="0x0c0330", TEST=="/sys/bus/pci/drivers/xhci_hcd/bind", RUN+="/bin/sh -c 'echo %k > /sys/bus/pci/drivers/xhci_hcd/bind'"

--- a/recipes-bsp/partition/mount-tee-partition_1.0.bb
+++ b/recipes-bsp/partition/mount-tee-partition_1.0.bb
@@ -9,6 +9,8 @@ SRC_URI = " \
     file://check-tee-partition-fs.sh \
     file://format-tee-partition.service \
     file://persist.rules \
+    file://var-usbfw.mount \
+    file://xhci-bind.rules \
 "
 
 inherit features_check systemd
@@ -32,6 +34,18 @@ do_install() {
     install -Dm 0644 ${UNPACKDIR}/persist.rules \
             ${D}${nonarch_base_libdir}/udev/rules.d/99-persist.rules
 }
+
+do_install:append:qcm6490 () {
+    install -d ${D}${systemd_unitdir}/system/local-fs.target.wants
+    install -Dm 0644 ${UNPACKDIR}/var-usbfw.mount ${D}${systemd_system_unitdir}/system/var-usbfw.mount
+    install -Dm 0644 ${UNPACKDIR}/xhci-bind.rules ${D}${nonarch_libdir}/udev/rules.d/99-xhci-bind.rules
+    install -d ${D}${nonarch_base_libdir}/firmware/
+    ln -sf ${systemd_unitdir}/system/var-usbfw.mount ${D}${systemd_unitdir}/system/local-fs.target.wants/var-usbfw.mount
+    ln -sf /var/usbfw/renesas_usb_fw.mem ${D}${nonarch_base_libdir}/firmware/renesas_usb_fw.mem
+}
+
+FILES:${PN}:append:qcm6490 = " ${systemd_unitdir}/system/* \
+                               ${nonarch_base_libdir}/firmware/*"
 
 PACKAGES = "${PN}"
 


### PR DESCRIPTION
Add qcm6490-specific installation of a systemd mount unit to mount the usb_fw partition at /var/usbfw during local-fs startup.

Also add a udev rule to bind xHCI PCI devices to xhci_hcd and create a firmware symlink from /lib/firmware/renesas_usb_fw.mem to the firmware image stored in /var/usbfw.

This ensures the Renesas USB firmware is available from the mounted partition and accessible through the standard firmware path.