### PR TITLE
u-boot-qcom: drop devupstream AUTOREV support and pin SRCREV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,17 +7,10 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.01+2026.04-rc1+git"
 
-SRCREV ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/bootloader", "u-boot-qcom-upstream", "${AUTOREV}", "7b9fb537f19db0fa48b824ecc883c9c8512f0e21", d)}'
-
+SRCREV = "7b9fb537f19db0fa48b824ecc883c9c8512f0e21"
 SRCBRANCH = "nobranch=1"
-SRCBRANCH:class-devupstream = "branch=qcom-next"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"
-
-# To build tip of qcom-next branch set preferred
-# virtual/bootloader provider to 'u-boot-qcom-upstream'
-BBCLASSEXTEND = "devupstream:target"
-PN:class-devupstream = "u-boot-qcom-upstream"
 
 python __anonymous() {
     ubootconfig = (d.getVar('UBOOT_CONFIG') or "").split()


### PR DESCRIPTION
The devupstream class previously allowed building U-Boot from the tip of the qcom-next branch using AUTOREV. This setup introduced additional complexity and resulted in fragile fetch-time behavior.

Since U-Boot must be built using explicit, validated SRCREV values, remove the devupstream class extension and pin the recipe to a fixed validated revision unconditionally.