### PR TITLE
fit-dtb-compatible: Update lemans-evk-ifp-mezz compatible to v0.3

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -30,11 +30,11 @@ FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2+lemans-camx-el2] = " \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine] = " \
     qcom,qcs9075-iot-subtype1 \
-    qcom,qcs9075v2-iot-subtype1 \
+    qcom,qcs9075-socv2.0-iot-subtype1 \
 "
 FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-evk-staging] = " \
     qcom,qcs9075-iot-subtype1-staging \
-    qcom,qcs9075v2-iot-subtype1-staging \
+    qcom,qcs9075-socv2.0-iot-subtype1-staging \
 "
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577+monaco-el2] = "qcom,qcs8275-iot-el2kvm"
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"


### PR DESCRIPTION
Update the compatible string of lemans-evk-ifp mezzanine to support v0.3 compatible string format.