### PR TITLE
ci: nighty-build: move back to one nightly per day

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,8 +4,8 @@ on:
   schedule:
   # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
   # so that build notification emails will be sent out properly.
-  # At 8:22 & 20:22 UTC everyday - picked a random "minute" as top of hour can be busy in github
-  - cron: "22 8,20 * * *"
+  # At 0:22 UTC everyday - picked a random "minute" as top of hour can be busy in github
+  - cron: "22 0 * * *"
 
 permissions:
   checks: write


### PR DESCRIPTION
The expected stream of changes reduced considerably now that we are approaching RC3, so move back nightly to run only once per day at 0:22 UTC, which should be enough for it to be completed at early IST.

This will help reducing the build & CI pressure we currently have.

This needs to be merged by quic-yocto-ci.