### PR TITLE
Revert "ci/ci: revert the default rm_work inherit on CI"

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -9,4 +9,3 @@ local_conf_header:
   ci: |
     BB_SIGNATURE_HANDLER = "OEBasicHash"
     FIRMWARE_COMPRESSION:qcom-armv8a = "zst"
-    INHERIT:remove = "rm_work"


### PR DESCRIPTION
Our CI currently builds a large number of packages and images, and we are increasingly running into disk space issues on the runners. Re-enabling rm_work significantly reduces disk pressure, at the cost of a little longer build times.

This reverts commit e0efca0bf853f2a0f959bc944937fa1b38553bbd.