### PR TITLE
firmware-qcom-nhlos: make sure that meta firmware package is empty

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-nhlos.inc
+++ b/recipes-bsp/firmware/firmware-qcom-nhlos.inc
@@ -64,3 +64,7 @@ do_install:prepend() {
         done
     fi
 }
+
+# Make sure that there is nothing in the meta-package, all firmware must go to
+# a particular package.
+FILES:${PN} = ""

--- a/recipes-bsp/firmware/firmware-qcom-nhlos.inc
+++ b/recipes-bsp/firmware/firmware-qcom-nhlos.inc
@@ -50,15 +50,17 @@ do_compile:prepend() {
 }
 
 do_install:prepend() {
-    install -d ${D}${FW_QCOM_PATH}
+    if [ -n "${NHLOS_URI}${PROPRIETARY_URI}" ] ; then
+        install -d ${D}${FW_QCOM_PATH}
 
-    for fw in ${FW_QCOM_LIST} ; do
-        if [ -r ${S}/proprietary/$fw ] ; then
-            install -m 0644 ${S}/proprietary/$fw ${D}${FW_QCOM_PATH}
-        elif [ -r ${B}/$fw ] ; then
-            install -m 0644 ${B}/$fw ${D}${FW_QCOM_PATH}
-        elif [ -r ${B}/firmware/image/$fw ] ; then
-            install -m 0644 ${B}/firmware/image/$fw ${D}${FW_QCOM_PATH}
-        fi
-    done
+        for fw in ${FW_QCOM_LIST} ; do
+            if [ -r ${S}/proprietary/$fw ] ; then
+                install -m 0644 ${S}/proprietary/$fw ${D}${FW_QCOM_PATH}
+            elif [ -r ${B}/$fw ] ; then
+                install -m 0644 ${B}/$fw ${D}${FW_QCOM_PATH}
+            elif [ -r ${B}/firmware/image/$fw ] ; then
+                install -m 0644 ${B}/firmware/image/$fw ${D}${FW_QCOM_PATH}
+            fi
+        done
+    fi
 }

--- a/recipes-bsp/firmware/firmware-qcom-qar2130p.bb
+++ b/recipes-bsp/firmware/firmware-qcom-qar2130p.bb
@@ -40,5 +40,5 @@ do_install:prepend() {
     fi
 }
 
-FILES:linux-firmware-qcom-adreno-gmu-a621 += "${FW_QCOM_BASE_PATH}/a621_gmu.bin"
+FILES:linux-firmware-qcom-adreno-gmu-a621 += "${FW_QCOM_BASE_PATH}/a621_gmu.bin*"
 FILES:${PN} += "${nonarch_base_libdir}/firmware/ath12k"


### PR DESCRIPTION
Follow the logic of linux-firmware recipe and set FILES list for PN to an empty value, ensuring that all firmware files are correctly handled and pushed to the individual packages.