### PR TITLE
firmware-qcom-boot-sm8750: update tag to 00043 and enable tech pack based releases

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
@@ -2,14 +2,13 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm SM8750-MTP platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/software/chip/qualcomm_linux-spf-0-0/qualcomm-linux-spf-0-0_test_device_public"
-FW_BUILD_ID = "r0.0_${PV}/pakala-le-0-0"
-FW_BIN_PATH = "common/build/ufs/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/SM8750_bootbinaries.1.0/sm8750_bootbinaries.1.0-test-device-public"
+
 BOOTBINARIES = "pakala_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SM8750/cdt/sm8750-mtp_wcn7881.zip;downloadfilename=sm8750-mtp_wcn7881_${PV}.zip;name=sm8750-mtp_wcn7881 \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00008.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00008.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-sm8750.inc
-
-SRC_URI[bootbinaries.sha256sum] = "3e09eef0dbdecf2c5680f9278ed4fd6f32b0b5f89cb16e7ad3459a56986c4469"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00043.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00043.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-sm8750.inc
+
+SRC_URI[bootbinaries.sha256sum] = "e56b8cb82fd2566b9de9ca771e342dd7559bbfb51c94587a65c4ae395f605805"


### PR DESCRIPTION
Tech pack based release path and versioning is for SPF agnostic paths across QLI targets. This enabled SP level versioning of boot bins. 
This change is required because Pakala does not use prog_firehose_ddr.elf or prog_firehose_lite.elf as the device programmer and instead it uses xbl_s_devprg_ns.melf.

