### PR TITLE
Restrict the SDK for multimedia images

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -85,7 +85,9 @@ runs:
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
           # SDK only with the default kernel and qcom-distro
           if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then
-            $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk
+            $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
+              --target qcom-multimedia-image \
+              --target qcom-multimedia-proprietary-image
             $KAS_CONTAINER shell ${KAS_YAMLS} \
               -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
             ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -83,8 +83,8 @@ runs:
         mv $KAS_WORK_DIR/build/buildchart.svg .
 
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
-          # SDK only with the default kernel
-          if [ "${INPUTS_KERNEL_YAML}" = "" ] ; then
+          # SDK only with the default kernel and qcom-distro
+          if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then
             $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk
             $KAS_CONTAINER shell ${KAS_YAMLS} \
               -c "buildstats-summary --sort duration --highlight 0 --shortest 300"


### PR DESCRIPTION
We don't need to validate the SDK in the qcom distro and we can restrict it to only multimedia images:
- qcom-multimedia-image
- qcom-multimedia-proprietary-image