### PR TITLE
ci/base: override wget fetch command to set curl User-Agent

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -45,6 +45,8 @@ local_conf_header:
     git://.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
+  fetchcmd: |
+    FETCHCMD_wget = "/usr/bin/env wget --tries=2 --timeout=100 --user-agent='curl'"
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |


### PR DESCRIPTION
Some servers like crates.io, rejecting default wget requests when
no User-Agent header is present, causing fetcher failures.

To overcome this, set FETCHCMD_wget in local.conf with `curl` as a
compatible User-Agent and add retry-connrefused option to retry
on connection refusal.