### PR TITLE
ci: ci.yml: temporarily use RPM for nodistro due issues with ipk

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -9,3 +9,5 @@ local_conf_header:
   ci: |
     BB_SIGNATURE_HANDLER = "OEBasicHash"
     FIRMWARE_COMPRESSION:qcom-armv8a = "zst"
+    # Workaround needed due https://bugzilla.yoctoproject.org/show_bug.cgi?id=16010
+    PACKAGE_CLASSES = "package_rpm"


### PR DESCRIPTION
We are often facing
https://bugzilla.yoctoproject.org/show_bug.cgi?id=16010 even with nodistro lately, which was the exact reason why we migrated qcom-distro to RPM by default (known to work better). Since our CI is currently unreliable due the same issue, but now with nodistro, temporarily move it to use RPM in order to fix our CI.

Jose will keep investigating the upstream issue, or move forward with a suggestion to change nodistro to another package manager.