### PR TITLE
ci: support CI on wrynose

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: "full" # values: pr | full
+      git_ref:
+        required: false
+        type: string
+        default: ""
     outputs:
       artifacts_url:
         description: "URL to retrieve build artifacts"
@@ -37,6 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_ref }}
 
       - name: Run kas lock
         if: ${{ hashFiles('ci/base.lock.yml') == '' }}
@@ -63,6 +68,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_ref }}
 
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
@@ -115,6 +121,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_ref }}
 
       - name: Run kas build
         uses: ./.github/actions/compile
@@ -293,6 +300,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_ref }}
 
       - name: Run kas build
         if: inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')
@@ -314,6 +322,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/print-build-output
         with:

--- a/.github/workflows/nightly-build-wrynose.yml
+++ b/.github/workflows/nightly-build-wrynose.yml
@@ -1,0 +1,54 @@
+name: Nightly Build (wrynose)
+
+on:
+  schedule:
+  # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
+  # so that build notification emails will be sent out properly.
+  # At 23:22 UTC everyday - picked a random "minute" as top of hour can be busy in github
+  - cron: "22 23 * * *"
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
+jobs:
+  # Resolve wrynose to a single SHA so all downstream jobs build the same commit,
+  # and so test results are attributed to the correct wrynose commit (not master's
+  # github.sha, which is what scheduled workflows expose by default).
+  resolve-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.get-sha.outputs.sha }}
+    steps:
+      - name: Resolve wrynose SHA
+        id: get-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/wrynose --jq '.object.sha')
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+
+  build-nightly:
+    needs: resolve-ref
+    uses: ./.github/workflows/build-yocto.yml
+    with:
+      git_ref: ${{ needs.resolve-ref.outputs.sha }}
+
+  test-nightly:
+    uses: ./.github/workflows/test.yml
+    needs: [resolve-ref, build-nightly]
+    secrets: inherit
+    with:
+      build_id: ${{ github.run_id }}
+
+  publish-test-results:
+    uses: ./.github/workflows/publish-results.yml
+    needs: [resolve-ref, test-nightly]
+    secrets: inherit
+    with:
+      workflow_id: ${{ github.run_id }}
+      event_name: ${{ github.event_name }}
+      event_file: ${{ github.event_path }}
+      commit: ${{ needs.resolve-ref.outputs.sha }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,4 @@
-name: Nightly Build
+name: Nightly Build (master)
 
 on:
   schedule:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,5 @@
 name: Build on PR
+run-name: "${{ github.base_ref }}: ${{ github.event.pull_request.title }}"
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,9 @@ run-name: "${{ github.base_ref }}: ${{ github.event.pull_request.title }}"
 
 on:
   pull_request:
+    branches:
+      - master
+      - wrynose
     paths-ignore:
       - 'README.md'
       - 'README'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,5 @@
 name: Build on push
+run-name: "${{ github.ref_name }}: ${{ github.event.head_commit.message }}"
 
 on:
   push:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - wrynose
 
 permissions:
   checks: write

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -2,9 +2,9 @@ name: QuIC Organization Repolinter
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, wrynose ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, wrynose ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Current CI settings are specific to master, separate workflows so they can be branch based and add support for specific wrynose-based workflows.

Needs to be merged by quic-yocto-ci due the cron related changes.