### PR TITLE
camxlib-talos: Update to the 1.0.19 revision

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.19.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.19.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260424"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "51a1bf62ddfef442d44c44a83b8a045f127b214eeeb3b855cd1c310c698766d8"
+SRC_URI[camx.sha256sum]        = "dd2142bcf8cfbc989d7c42b416314d424f08e198ded488b5a0d67f0b2fb3a137"
+SRC_URI[chicdk.sha256sum]      = "969f860c8c931e5a3673b8dea3c7cd9230d7b89c55b86f6a5e5a4da2128c9687"
+SRC_URI[camxcommon.sha256sum]  = "4f31213d5bf56d5091c43612a23ec440c94153f1e49c3b8e991d435f1f9f13a8"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.8.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.8.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260416"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "79977f594f20a0779cd5e6314edddaacd416416c1a5c22f1399251826b69b7e1"
-SRC_URI[camx.sha256sum]        = "280262a4b5c7edbc80dbd131a2fd0270bb83e8ac247eb5bf6abd393a9ae9262e"
-SRC_URI[chicdk.sha256sum]      = "74a24691659d5c3248364287dd6b0a735a726bbe78d5d5fbf4f4a5e05371df69"
-SRC_URI[camxcommon.sha256sum]  = "9de2262cf02d39279048472ffa780e5da3eae70e0b5c9405cf3c484fd47b3518"


### PR DESCRIPTION
- Fix firmware timeout regression affecting snapshot use case introduced in v1.0.6.