### PR TITLE
qcom-partition-conf: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "3be6f3c1761c5a4333e46e9c8abf83393e8b80a1"
+SRCREV = "7b3365284e2c19f1457e335eb25d545e9a2c08a6"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Shoudi Li (4):
    platforms/iq-x7181-evk: move CDT to top to align with secure region offset
    platforms/iq-x7181-evk: move SD_MGR partition to protected region
    platform/iq-x7181-evk: add QWESLICCACHE partition
    platform/iq-x7181-evk: update the size of test_partion

Igor Opaniuk (11):
    Introduce pyproject.toml for dev tool configuration
    msp: fix ruff lint violations
    ptool: fix ruff lint violations
    utils: fix ruff lint violations
    gen_partition: fix ruff lint violations
    gen_contents: fix mypy type errors
    gen_partition: fix mypy type errors
    msp: fix mypy type errors
    ptool: fix mypy type errors
    Makefile, CI: switch lint target from pycodestyle to ruff/mypy
    README: document dependencies and Makefile targets
   
Ricardo Salveti (1):
    qrb2210-unoq: update partitions based on the edk2-downstream boot firmware
