### PR TITLE
iris-video-dlkm: update iris driver to v1.0.6

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.6.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.6.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "4e5e930893ba95e6684b69fcad8db33999fd2412"
+SRCREV  = "3892363b2e5c72ed04c82eb2935832f015da8ada"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.6 brings below updates for Qcom Iris

- Update KLM platform data to optimize memory usage for high concurrency
- Switch to resolution-based buffer sizing when session count exceeds 16
- Prevent memory exhaustion in 24/32 concurrent session scenarios
- Update session count limits and related KLM platform parameters
- Add clock scaling support for the Kodiak target