### PR TITLE
Add Kaanapali MTP initramfs firmware image

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-kaanapali-mtp-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-kaanapali-mtp-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with Kaanapali MTP firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-kaanapali-mtp-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Introduce initramfs firmware image recipe for Kaanapali MTP board to include required
firmware files via packagegroup-kaanapali-mtp-firmware for kernel validation workflows.