### PR TITLE
Add Glymur CRD initramfs firmware image

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-glymur-crd-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-glymur-crd-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with glymur CRD firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-glymur-crd-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Introduce initramfs firmware image recipe for Glymur CRD board to include required
firmware files via packagegroup-glymur-crd-firmware for kernel validation workflows.