### PR TITLE
CAMX: revision update for Lemans, Talos,Kodiak

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.20.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.20.bb
@@ -8,15 +8,15 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260420"
+PBT_BUILD_DATE = "260502"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
    "
-SRC_URI[camxlib.sha256sum] = "ba191ef9f0e5aee2ec1ce5a6e2a14d6f04531807a2d89bdb80332fd87813827f"
-SRC_URI[camx.sha256sum] = "1c51319f2796a8331ce8acb5e5dcb34f207dd4b2ac3795ea6c8b694e4f1ea7dc"
-SRC_URI[chicdk.sha256sum] = "cfe99c73e4b86c7eea84c78e98d118e941c0c69b42bb767b1f8801f493404dd5"
+SRC_URI[camxlib.sha256sum] = "18fca4e8ea638eff0de96fddcc1461d82f77f90124e00d6dd5e972d3450d6688"
+SRC_URI[camx.sha256sum] = "46155ae50ebcfc8fc86f904c3e68a1e125db397c51d092519dc4612a64d3ba8b"
+SRC_URI[chicdk.sha256sum] = "a1925d6aad4c1e4c912a90f3a5d4a3948377c0e13866dd33254f553b4ec1c39d"
 
 S = "${UNPACKDIR}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.22.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.22.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260416"
+PBT_BUILD_DATE = "260502"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum]     = "13039dd2d9d31bc9e21d55bb8165920aa367da90a0604c95f0459c8902a33da8"
-SRC_URI[camx.sha256sum]        = "70e9a815f7a1e83bb5d9ee0ff18c1b79a0ccc6b0ec9758c4f39d82c6c259e698"
-SRC_URI[chicdk.sha256sum]      = "5922944716bc3949a93984e29ec00b1d2076efec0c8da7cecb3713ff52879a92"
-SRC_URI[camxcommon.sha256sum]  = "7ee0f8cd78e42237058d3a3d7df8a70c0be7bd2316642f17e3bcf4b6e6637934"
+SRC_URI[camxlib.sha256sum]     = "43119d312121b4e4b5588326df6568bf487aa530c6cc26409eefb5a53d1e04ff"
+SRC_URI[camx.sha256sum]        = "07107a3275df5cd6077cecdf2116598181d2d63934c9ecb4191ad20377caabd6"
+SRC_URI[chicdk.sha256sum]      = "7daaaf8601355137ec0323948710ec962fb4d8e5ffe73393971628d5ebf3b966"
+SRC_URI[camxcommon.sha256sum]  = "ed04306b348d141b4c02038860d908eadf6fa4fdf2776f572ec776357ac115ff"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.20.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.20.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260426"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "8f406d7d8613bb193a042426bb4c72f5917fea0b0fd0e0b42b1925f7b0deaa47"
-SRC_URI[camx.sha256sum]        = "733d26978dc436e89ec3f79f224537c530164d4410a68105f7c1a9d021e5797c"
-SRC_URI[chicdk.sha256sum]      = "0194a1d990e5873a5fc670de0535e03b8b225b388c9ca8dd08a8b0be7b64c1d0"
-SRC_URI[camxcommon.sha256sum]  = "6b050cc0aed123128fbe431bde1b7b0839d0ec2f5d955cbb269a26396c17a07d"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.22.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.22.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260502"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "6e1c7895f93c812a55416601415f9c5a255ef7dd62bbefc6587fab905b9aa9d1"
+SRC_URI[camx.sha256sum]        = "cd4b4408b904b633d9d3220887abac5f2bde9556553531de57e622b177d661b9"
+SRC_URI[chicdk.sha256sum]      = "dfc7b4e4baa556720c47b162d392a9662ec929400101c643d3a35dad4408d256"
+SRC_URI[camxcommon.sha256sum]  = "a6071ab6907fb29e469391aa23e3629a73d407d59513d18cb00c60c1d871f497"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.7.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.7.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260420"
+PBT_BUILD_DATE = "260428.2"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "b99d2630d4cc083e8cf9eca4d851eaaea639bcc909be6ebe4056b7ced6d39030"
+SRC_URI[sha256sum] = "68f08592e3aa60d0510194d4346d941074634371c46c44866c37ede53310ea8d"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
This change removes the TMPDIR leak to the generated object files (by using the -ffile-prefix-map compiler option).

Example QA errors that triggered this fix:
ERROR: camxlib-kodiak-1.0.18-r0 do_package_qa: QA Issue:
File /usr/lib/camx/kodiak/libcamxhwlipe.a in package camxlib-kodiak-staticdev
contains reference to TMPDIR [buildpaths]

ERROR: camxlib-kodiak-1.0.18-r0 do_package_qa: QA Issue:
File /usr/lib/camx/kodiak/camera/components/.debug/com.qti.stats.aec.so.0.1.0
in package camxlib-kodiak-dbg contains reference to TMPDIR [buildpaths]
