### PR TITLE
ci: base.lock.yml: update bitbake

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -5,7 +5,7 @@ overrides:
         oe-core:
             commit: 8c008f36d7af1e63cb3f4a2ba763efd1f1e5fe4d
         bitbake:
-            commit: 5d722b5d65e4eef7befe6376983385421e993f86
+            commit: cb28befc56d201cace72d70891e731b955fb567f
         meta-arm:
             commit: d987a5945802dcbbc06be91a0d34f00431ea840e
         meta-openembedded:


### PR DESCRIPTION
Update the BitBake revision in base.lock.yml to include fix for fetcher failures observed when accessing crates.io.

Relevant change:
f39046348 fetch2/crate: use CDN for fetching crates

Other changes:
4af5f6a65 fetch/wget: in upstream version checks, match versioned directories exactly
0223ec6f6 Drop git-make-shallow
a7acbfd45 doc: Fix description of git shallow mirror tarball creation
8a15f29f7 contrib/vim: remove
941cfe74c bitbake: Update version to 2.19.0 for development series
33581c84f bitbake: Update version to 2.18.0
b508e646b utils: Add filter_string function
cfd3af465 default-registry: Add wrynose
6acd48497 bitbake-setup: Add the conditional script stanza
1557c502a taskdata: add_tasks: use sets to dedup from debug output
3c20c0a4d utils: goh1_file: deal with false positives from is_zipfile
23a91cb15 fetch2/git: fix HEAD and branch ref when subpath is used
1ffccdeaa runqueue: Fix comment typos
de7c87ae8 doc: set_versions.py: change strategy for the default page