### PR TITLE
CI: bitbake buildstats refactor

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -64,8 +64,9 @@ runs:
         $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
         $KAS_CONTAINER shell ${KAS_YAMLS}:ci/world.yml \
           -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
-        ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
-        mv $KAS_WORK_DIR/build/buildchart.svg buildchart-world.svg
+        ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+        rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
+        mv $KAS_WORK_DIR/build/buildstats* .
 
     - name: Kas build images
       shell: bash
@@ -73,8 +74,8 @@ runs:
         $KAS_CONTAINER build ${KAS_YAMLS}
         $KAS_CONTAINER shell ${KAS_YAMLS} \
           -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
-        ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
-        mv $KAS_WORK_DIR/build/buildchart.svg .
+        ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+        mv $KAS_WORK_DIR/build/buildstats* .
 
         if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
           # SDK only with the default kernel and qcom-distro
@@ -84,16 +85,17 @@ runs:
               --target qcom-multimedia-proprietary-image
             $KAS_CONTAINER shell ${KAS_YAMLS} \
               -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
-            ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
-            mv $KAS_WORK_DIR/build/buildchart.svg buildchart-sdk.svg
+            ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+            rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
+            mv $KAS_WORK_DIR/build/buildstats* .
           fi
         fi
 
     - uses: actions/upload-artifact@v6
       with:
-        name: buildchart-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
+        name: buildstats-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
         path: |
-          buildchart*
+          buildstats*
 
     - uses: actions/upload-artifact@v6
       with:
@@ -114,7 +116,7 @@ runs:
         # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
         # Copy *.efi, *.efi and *.vfat as they are useful for debugging
         find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
-        cp buildchart.svg kas-build.yml $uploads_dir/
+        cp buildstats* kas-build.yml $uploads_dir/
         if [ -d $deploy_dir/../../sdk ]; then
           cp $deploy_dir/../../sdk/* $uploads_dir/
         fi

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -62,8 +62,6 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
-        $KAS_CONTAINER shell ${KAS_YAMLS}:ci/world.yml \
-          -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
         ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
         rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
         mv $KAS_WORK_DIR/build/buildstats* .
@@ -72,8 +70,6 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER build ${KAS_YAMLS}
-        $KAS_CONTAINER shell ${KAS_YAMLS} \
-          -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
         ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
         mv $KAS_WORK_DIR/build/buildstats* .
 
@@ -83,8 +79,6 @@ runs:
             $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
               --target qcom-multimedia-image \
               --target qcom-multimedia-proprietary-image
-            $KAS_CONTAINER shell ${KAS_YAMLS} \
-              -c "buildstats-summary --sort duration --highlight 0 --shortest 300"
             ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
             rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
             mv $KAS_WORK_DIR/build/buildstats* .

--- a/ci/yocto-buildstats.sh
+++ b/ci/yocto-buildstats.sh
@@ -43,3 +43,17 @@ CMD="$CMD $BUILDSTATS"
 
 echo $CMD
 eval $CMD
+
+# buildstats-summary tool
+CMD="buildstats-summary"
+# sort by task duration
+CMD="$CMD --sort duration"
+# disable highlight
+CMD="$CMD --highlight 0"
+# buildstats log folder
+CMD="$CMD $BUILDSTATS"
+# show and save it to
+CMD="$CMD | tee buildstats.log"
+
+echo $CMD
+eval $CMD

--- a/ci/yocto-buildstats.sh
+++ b/ci/yocto-buildstats.sh
@@ -37,8 +37,9 @@ CMD="$CMD --full-time"
 # image format (png, svg, pdf); default format png
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
-CMD="$CMD --output=buildchart"
+CMD="$CMD --output=buildstats"
 # buildstats log folder
 CMD="$CMD $BUILDSTATS"
 
-exec $CMD
+echo $CMD
+eval $CMD

--- a/ci/yocto-pybootchartgui.sh
+++ b/ci/yocto-pybootchartgui.sh
@@ -22,11 +22,14 @@ _is_dir "$REPO_DIR"
 _is_dir "$WORK_DIR"
 
 # latest buildstats folder
-BUILDSTATS="$WORK_DIR/build/tmp/buildstats"
+BUILDSTATS="$(bitbake-getvar --value TMPDIR)/buildstats"
 BUILDSTATS="$BUILDSTATS/$(ls $BUILDSTATS | tail -1)"
 
+# add pybootchartgui path
+PATH="$PATH:$WORK_DIR/oe-core/scripts/pybootchartgui"
+
 # pybootchartgui tool
-CMD="$CMD $WORK_DIR/oe-core/scripts/pybootchartgui/pybootchartgui.py"
+CMD="pybootchartgui.py"
 # display time in minutes instead of seconds
 CMD="$CMD --minutes"
 # display the full time regardless of which processes are currently shown
@@ -35,7 +38,7 @@ CMD="$CMD --full-time"
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
 CMD="$CMD --output=buildchart"
-# /path/to/tmp/buildstats/<recipe-machine>/<BUILDNAME>/
+# buildstats log folder
 CMD="$CMD $BUILDSTATS"
 
 exec $CMD


### PR DESCRIPTION
Refactoring of the bitbake buildstats artifcats:

1. Rename svg charts pattern from `buildchart*.svg` to `buildstats*.svg`.
2. Add `buildstats*.log` with the time of all bitbake tasks executed which is also visible in the general output log.
3. Rename CI deployed artifcats from `buildchart-*zip` to `buildstats-*zip`.
