### PR TITLE
workflows: update lava-test-plans to d0f755a

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -37,7 +37,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: 3ef1a0d87c7122590b58df1f37c65a95ed25b3b1
+          ref: d0f755a1cc8b66af6bc28e61fd4c7b40975194e0
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       distro_name: "qcom-distro"
   test-qcom-distro_linux-qcom-6-18:


### PR DESCRIPTION
Update ref to add glymur-crd to the general device pool and to meta-qcom project.

Merged PR: [PR#15](https://github.com/qualcomm-linux/lava-test-plans/pull/56)

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>