### PR TITLE
CI: Switch upstream repos to wrynose branch

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -5,7 +5,7 @@ overrides:
         oe-core:
             commit: 8c008f36d7af1e63cb3f4a2ba763efd1f1e5fe4d
         bitbake:
-            commit: 5d722b5d65e4eef7befe6376983385421e993f86
+            commit: a2dd9be788274d9c7280be5b1be5eb5c3990cf54
         meta-arm:
             commit: d987a5945802dcbbc06be91a0d34f00431ea840e
         meta-openembedded:

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -7,7 +7,7 @@ distro: nodistro
 
 defaults:
   repos:
-    branch: master
+    branch: wrynose
 
 repos:
   meta-qcom:
@@ -19,6 +19,7 @@ repos:
 
   bitbake:
     url: https://github.com/openembedded/bitbake
+    branch: "2.18"
     layers:
       .: disabled
 

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -7,12 +7,11 @@ distro: qcom-distro
 
 defaults:
   repos:
-    branch: master
+    branch: wrynose
 
 repos:
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
-    branch: main
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
@@ -27,9 +26,11 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
+    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach
+    branch: master
 
   meta-selinux:
     url: https://git.yoctoproject.org/meta-selinux
@@ -39,6 +40,7 @@ repos:
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
+    branch: master
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
Update the default branch used for upstream repos in the CI to track
the Yocto wrynose release. Since the bitbake repo don't create a branch
with name `wrynose` set it to `2.18` to match the release requirements.

meta-arm, meta-virtualization, meta-audioreach, and meta-security layers 
will be switched to wrynose once they start publishing corresponding branches.
