### PR TITLE
ci/qcom-distro: set defaults branch

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -5,6 +5,10 @@ header:
 
 distro: qcom-distro
 
+defaults:
+  repos:
+    branch: master
+
 repos:
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
@@ -12,7 +16,6 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
-    branch: master
     layers:
       meta-filesystems:
       meta-gnome:
@@ -24,23 +27,18 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
-    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach
-    branch: master
 
   meta-selinux:
-    branch: master
     url: https://git.yoctoproject.org/meta-selinux
 
   meta-updater:
-    branch: master
     url: https://github.com/uptane/meta-updater
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
-    branch: master
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
We can simplify and define a default branch for all layers and specify only the branch for divergent cases.