### PR TITLE
CAMX: revision update for Lemans, Talos

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.21.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.21.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260416"
+PBT_BUILD_DATE = "260428.2"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum]     = "13039dd2d9d31bc9e21d55bb8165920aa367da90a0604c95f0459c8902a33da8"
-SRC_URI[camx.sha256sum]        = "70e9a815f7a1e83bb5d9ee0ff18c1b79a0ccc6b0ec9758c4f39d82c6c259e698"
-SRC_URI[chicdk.sha256sum]      = "5922944716bc3949a93984e29ec00b1d2076efec0c8da7cecb3713ff52879a92"
-SRC_URI[camxcommon.sha256sum]  = "7ee0f8cd78e42237058d3a3d7df8a70c0be7bd2316642f17e3bcf4b6e6637934"
+SRC_URI[camxlib.sha256sum]     = "fcd93e8015461e71098017cfe157bf5c3c5183912bdd42906eeac253783e9a38"
+SRC_URI[camx.sha256sum]        = "de99e8e74fb4d5d396d66a4000e369c5751bc76d6fbb3979e3a9efa6b32fbd73"
+SRC_URI[chicdk.sha256sum]      = "1769d0f4954962c337de8d117ae74c31f571960f3574b34256192e53cfbd871d"
+SRC_URI[camxcommon.sha256sum]  = "bf5255e784f222573f7fdfb14ea979b329e23ea5b54d204ac5fedb6bcaa4fe88"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.20.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.20.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260426"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "8f406d7d8613bb193a042426bb4c72f5917fea0b0fd0e0b42b1925f7b0deaa47"
-SRC_URI[camx.sha256sum]        = "733d26978dc436e89ec3f79f224537c530164d4410a68105f7c1a9d021e5797c"
-SRC_URI[chicdk.sha256sum]      = "0194a1d990e5873a5fc670de0535e03b8b225b388c9ca8dd08a8b0be7b64c1d0"
-SRC_URI[camxcommon.sha256sum]  = "6b050cc0aed123128fbe431bde1b7b0839d0ec2f5d955cbb269a26396c17a07d"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.21.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.21.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260428.2"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum]     = "401e9e2443a2704b9e8e9d9a0fbac823c3df39b70757f6d3abc278fe36ad246b"
+SRC_URI[camx.sha256sum]        = "199cc07a6349d820cac766a7fc26cd977cc003c6a68b51bf79a7c8a836d08e91"
+SRC_URI[chicdk.sha256sum]      = "97f0f28506883510cb69d7c7390dc64507c4647c55f7cd52ca1fec46958d725d"
+SRC_URI[camxcommon.sha256sum]  = "cbd294a2cad1ac576061f13f0805ce58476943d2ac6066ae464ecd42f004b7a9"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.7.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.7.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260420"
+PBT_BUILD_DATE = "260428.2"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "b99d2630d4cc083e8cf9eca4d851eaaea639bcc909be6ebe4056b7ced6d39030"
+SRC_URI[sha256sum] = "68f08592e3aa60d0510194d4346d941074634371c46c44866c37ede53310ea8d"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Yocto QA buildpaths checks were failing because multiple generated libraries were embedding absolute build-time TMPDIR paths. The issue affected libraries, leading to QA failures during packaging.

Fix:
    The source base directory is now resolved to an absolute path and mapped out at compile time using -ffile-prefix-map.
    This change resolves the buildpaths QA failures.

Example QA errors that triggered this fix:
   

     ERROR: camxlib-talos-1.0.20-r0 do_package_qa: QA Issue:
    File /usr/lib/camx/talos/libcamxhwlipe.a in package camxlib-talos-staticdev contains reference to TMPDIR [buildpaths]
    
    ERROR: camxlib-talos-1.0.20-r0 do_package_qa: QA Issue:
    File /usr/lib/camx/talos/camera/components/.debug/com.qti.stats.aec.so.0.1.0 in package camxlib-talos-dbg contains reference to TMPDIR [buildpaths]

