### PR TITLE
linux-qcom-6.18: update to tag qcom-6.18.y-20260430

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260424
-SRCREV ?= "79ab61f25c649832e8005b1a3344d2b078ad0256"
+# tag:qcom-6.18.y-20260430
+SRCREV ?= "cdf31edb9e60f17ab886c1baf3406dc5d6a6571d"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest qcom-6.18 tag qcom-6.18.y-20260430

Changelog:
FROMLIST: arm64: dts: qcom: lemans: Enable audio over DisplayPort
QCLINUX: prune.config: Enable Realtek PHY config for Rb3Gen2 Industrial board
FROMLIST: ASoC: qcom: q6apm-lpass-dai: move graph start to trigger
FROMLIST: arm64: dts: qcom: Enable secondary mi2s
FROMLIST: arm64: dts: qcom: qcs6490: Enable DP audio
FROMLIST: ASoC: qcom: q6dsp-lpass-ports: Extend q6dsp-lpass-ports driver to support additional sampling rates
FROMLIST: ASoC: qcom: q6dsp-lpass-ports: Update constraints to support 32-bit PCM format
PENDING: arm64: dts: qcom: rb3gen2-industrial-mezzanine: add overlay for QPS615
PENDING: arm64: dts: qcom: monaco-evk: fix overlay stacking and PHY reset polarity
QCLINUX: arm64: configs: qcom.config: Enable CONNECTOR, PROC_EVENTS
Revert "FROMLIST: of: Respect #{iommu,msi}-cells in maps"
Revert "FROMLIST: of: Factor arguments passed to of_map_id() into a struct"
Revert "FROMLIST: of: Add convenience wrappers for of_map_id()"
FROMLIST: of: Add convenience wrappers for of_map_id()
FROMLIST: of: Factor arguments passed to of_map_id() into a struct
FROMLIST: of: Respect #{iommu,msi}-cells in maps
Revert "Revert "FROMLIST: PCI: dwc: Remove MSI/MSIX capability if iMSI-RX is used as MSI controller""
FROMLIST: PCI: qcom: Disable ASPM L0s for SA8775P