### PR TITLE
workflows: fix warnings about node20 in actions

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - id: app_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         if: always()
         with:
           app-id: 2291458

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -98,7 +98,7 @@ jobs:
           save_job_details: true
           result_file_name: "${{ matrix.target.result_file }}"
           test_job_file_name_prefix: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}-"
-      - uses: mwasilew/github-action-matrix-outputs-write@v2
+      - uses: qualcomm-linux/github-action-matrix-outputs-write@v3
         if: always()
         id: out
         with:


### PR DESCRIPTION
Upgrade actions to use node24 and eliminate all warnings about using node20.