### PR TITLE
[Wrynose] Switch default kernel to linux-qcom-6.18

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -228,9 +228,9 @@ jobs:
           - type: default
             dirname: ""
             yamlfile: ""
-          - type: 6.18
-            dirname: "_linux-qcom-6.18"
-            yamlfile: ":ci/linux-qcom-6.18.yml"
+          - type: qcom-next
+            dirname: "_linux-qcom-next"
+            yamlfile: ":ci/linux-qcom-next.yml"
           - type: rt-6.18-distro-kvm
             dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
       distro_name: "nodistro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
-  test-qcom-distro:
+  test-qcom-distro_linux-qcom-next:
     needs: [prepare-env]
-    name: "Test qcom-distro"
+    name: "Test qcom-distro_linux-qcom-next"
     uses: ./.github/workflows/test-distro.yml
     secrets: inherit
     with:
@@ -51,11 +51,12 @@ jobs:
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
+      distro_suffix: "_linux-qcom-next"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
-  test-qcom-distro_linux-qcom-6-18:
+  test-qcom-distro:
     needs: [prepare-env]
-    name: "Test qcom-distro_linux-qcom-6.18"
+    name: "Test qcom-distro"
     uses: ./.github/workflows/test-distro.yml
     secrets: inherit
     with:
@@ -64,13 +65,12 @@ jobs:
       devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
-      distro_suffix: "_linux-qcom-6.18"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
 
   collect-ids:
     name: "Collect Summary artifact IDs"
-    needs: [test-nodistro, test-qcom-distro, test-qcom-distro_linux-qcom-6-18]
+    needs: [test-nodistro, test-qcom-distro, test-qcom-distro_linux-qcom-next]
     if: |
       always()
       && contains(needs.*.result, 'success')
@@ -85,4 +85,4 @@ jobs:
       - name: Summary IDs
         id: generate-summary
         run: |
-          echo "artifact_ids=${{ needs.test-nodistro.outputs.summary_id }},${{ needs.test-qcom-distro.outputs.summary_id }},${{ needs.test-qcom-distro_linux-qcom-6-18.outputs.summary_id }}" >> $GITHUB_OUTPUT
+          echo "artifact_ids=${{ needs.test-nodistro.outputs.summary_id }},${{ needs.test-qcom-distro.outputs.summary_id }},${{ needs.test-qcom-distro_linux-qcom-next.outputs.summary_id }}" >> $GITHUB_OUTPUT

--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -1,7 +1,7 @@
 # Common configurations and variables for Qualcomm platforms.
 
 # Provider for linux kernel
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-qcom-next"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-qcom"
 
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_ALT_IMAGETYPE ?= "vmlinux"


### PR DESCRIPTION
On QLI 2.0, linux-qcom-6.18 is the default kernel. Since the wrynose
 branch is available now for QLI 2.0 development, set linux-qcom-6.18
 as the default kernel for machines that were previously building
 against linux-qcom-next.