### PR TITLE
ci: backport: add missing capture group

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Create backport pull requests
         uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # 4.5.0
         with:
-          label_pattern: "^backport wrynose$"
+          label_pattern: "^backport (wrynose)$"


### PR DESCRIPTION
Action uses a matching capture group to define the target branch to use, so make sure wrynose is inside a group in order to make it work for wrynose labels.