### PR TITLE
Workflows/lava test plans ref

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -21,6 +21,9 @@ inputs:
   project:
     description: "Project name to be used in lava-test-plans call"
     required: false
+  ref:
+    description: "Ref in the lava-test-plans repository. Can be a commit ID, branch or tag"
+    required: true
 
 outputs:
   jobmatrix:
@@ -37,7 +40,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: b9de72b563d8b361b39075c6070d76010040660e
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         description: "Suffix for the distro name"
+      lava_test_plans_ref:
+        type: string
+        description: "Ref in lava-test-plans repository: commit, tag or branch"
+        required: true
     outputs:
       summary_id:
         description: "ID of the test summary artifact"
@@ -53,6 +57,7 @@ jobs:
           prefix: boottest
           project: "meta-qcom"
           testplan: "${{ inputs.distro_name }}/boot"
+          ref: ${{ inputs.lava_test_plans_ref }}
 
       - name: Print output ID
         env:
@@ -176,6 +181,7 @@ jobs:
           prefix: premerge
           project: "meta-qcom"
           testplan: "${{ inputs.distro_name }}/pre-merge"
+          ref: ${{ inputs.lava_test_plans_ref }}
 
       - name: Print output ID
         env:

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -91,7 +91,7 @@ jobs:
         # of devices
         timeout-minutes: 120
         id: submit
-        uses: foundriesio/lava-action@v12
+        uses: foundriesio/lava-action@v13
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'
@@ -209,7 +209,7 @@ jobs:
         # It may spend some time in LAVA queue as there is a limited number
         # of devices
         timeout-minutes: 120
-        uses: foundriesio/lava-action@v12
+        uses: foundriesio/lava-action@v13
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -28,6 +28,10 @@ on:
         type: string
         description: "Ref in lava-test-plans repository: commit, tag or branch"
         required: true
+      project_name:
+        required: true
+        type: string
+        description: "Name of the project in lava-test-plans"
     outputs:
       summary_id:
         description: "ID of the test summary artifact"
@@ -55,7 +59,7 @@ jobs:
           build_id: ${{ inputs.build_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: boottest
-          project: "meta-qcom"
+          project: ${{ inputs.project_name }}
           testplan: "${{ inputs.distro_name }}/boot"
           ref: ${{ inputs.lava_test_plans_ref }}
 
@@ -179,7 +183,7 @@ jobs:
           build_id: ${{ inputs.build_id }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: premerge
-          project: "meta-qcom"
+          project: ${{ inputs.project_name }}
           testplan: "${{ inputs.distro_name }}/pre-merge"
           ref: ${{ inputs.lava_test_plans_ref }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,dragonboard-410c,dragonboard-820c,rb1-core-kit"
+      project_name: "meta-qcom"
       distro_name: "nodistro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
   test-qcom-distro:
@@ -44,6 +45,7 @@ jobs:
       build_id: "${{ inputs.build_id }}"
       devices: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      project_name: "meta-qcom"
       distro_name: "qcom-distro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
   test-qcom-distro_linux-qcom-6-18:
@@ -55,6 +57,7 @@ jobs:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      project_name: "meta-qcom"
       distro_name: "qcom-distro"
       distro_suffix: "_linux-qcom-6.18"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,23 @@ on:
       summary_ids:
         description: "IDs of the test summary artifact"
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
+env:
+  # git sha, tag or branch in lava-test-plans repository
+  LAVA_TEST_PLANS_REF: "b9de72b563d8b361b39075c6070d76010040660e"
 
 jobs:
+  prepare-env:
+    name: Prepare environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Print ref"
+        shell: bash
+        run: |
+          echo "lava-test-plans ref: ${{ env.LAVA_TEST_PLANS_REF }}"
+    outputs:
+      lava-test-plans-ref: "${{ env.LAVA_TEST_PLANS_REF }}"
   test-nodistro:
+    needs: [prepare-env]
     name: "Test nodistro"
     uses: ./.github/workflows/test-distro.yml
     secrets: inherit
@@ -20,7 +34,9 @@ jobs:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,dragonboard-410c,dragonboard-820c,rb1-core-kit"
       distro_name: "nodistro"
+      lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
   test-qcom-distro:
+    needs: [prepare-env]
     name: "Test qcom-distro"
     uses: ./.github/workflows/test-distro.yml
     secrets: inherit
@@ -29,7 +45,9 @@ jobs:
       devices: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       distro_name: "qcom-distro"
+      lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
   test-qcom-distro_linux-qcom-6-18:
+    needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-6.18"
     uses: ./.github/workflows/test-distro.yml
     secrets: inherit
@@ -39,6 +57,7 @@ jobs:
       devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       distro_name: "qcom-distro"
       distro_suffix: "_linux-qcom-6.18"
+      lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
 
   collect-ids:
     name: "Collect Summary artifact IDs"


### PR DESCRIPTION
Allow test-distro.yml workflow to be reusable in other projects
The workflow accepts parameters to be passed to lava-test-plans action and lava-action. This way it's possible to use the same workflow in multiple repositories (meta-qcom, meta-qcom-distro, etc.) Long term the workflow files should be hosted in a separate repository.