### PR TITLE
uboot: support for the iq-9075-evk platform in the Yocto build environment.

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -277,6 +277,14 @@ jobs:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+          - machine: iq-9075-evk
+            distro:
+                name: nodistro
+                yamlfile: ''
+            kernel:
+                type: u-boot-qcom-6.18
+                dirname: "_linux-qcom-6.18_u-boot-qcom"
+                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit-open-fw
             distro:
                 name: qcom-distro-kvm

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -40,3 +40,8 @@ QCOM_IRQAFF        = "0-6"
 QCOM_RCU_NOCBS     = "7"
 QCOM_RCU_EXPEDITED = "1"
 QCOM_CPUIDLE_OFF   = "1"
+
+UBOOT_CONFIG_DEFAULT = "iq-9075-evk"
+UBOOT_CONFIG = "iq-9075-evk"
+UBOOT_CONFIG[iq-9075-evk] = "qcom_lemans_defconfig"
+BOARD_MBN_HEADER[iq-9075-evk] = "v6"


### PR DESCRIPTION

It introduces U-Boot configuration support for the iq-9075-evk machine by
enabling UBOOT_CONFIG and selecting qcom_lemans_defconfig for platform-
specific initialization.

Additionally, the GitHub CI workflow is extended to build U-Boot variants
for iq-9075-evk alongside the linux-qcom-6.18 kernel, ensuring continuous
integration coverage for the platform.
