### PR TITLE
ci: base.lock.yml: update meta-oe to 335045d3fb

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -9,7 +9,7 @@ overrides:
         meta-arm:
             commit: d987a5945802dcbbc06be91a0d34f00431ea840e
         meta-openembedded:
-            commit: d2e6069771e435231a220a8ecac20c0e7ceff037
+            commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
         meta-virtualization:
             commit: 052241689a0c419d13e15e83e7ad65dd16fc8ffd
         meta-audioreach:


### PR DESCRIPTION
Updating to the commit before the updates to pipewire/wireplumber to better isolate possible regressions, as we are still a bit behind on master.

Relevant changes:
- 335045d3fb kernel-selftest: add missing sources if mm is enabled
- 06ddb535df kernel-selftest: fix mm selftests dependencies
- a407a3e533 kernel-selftest: drop libhugetlbfs
- fcae7611c1 kernel-selftest: rename vm selftests to mm
- 5305a97026 xrdp: upgrade 0.10.5 -> 0.10.6
- d696debe79 xdg-desktop-portal: upgrade 1.20.3 -> 1.20.4
- 9375394805 wolfssl: mark fixed CVEs as patched
- 1be9c09e23 python3-pillow: upgrade 12.1.1 -> 12.2.0
- 468ee626f8 python3-grpcio: ignore CVE-2026-33186
- aef8bc3422 protobuf, python3-protobuf: ignore CVE-2026-6409
- 09050325e6 openjpeg: patch CVE-2026-6192
- e88f57539e ngtcp2: upgrade 1.22.0 -> 1.22.1
- eb7dba674e minizip: backport fix for the missing header
- d31f07340f monkey: patch CVEs
- 22277ca3a3 monkey: upgrade 1.8.4 -> 1.8.7
- 799eb058e2 gimp: update 3.2.0 -> 3.2.4
- 4152a23426 pytesseract: replace deprecated md5sum with sha256sum
- 7f49deaf7e libraw: mark CVE-2026-20911 and CVE-2026-21413 patched
- de5f93f95d libgphoto2: patch CVE-2026-40341
- 420e5aec46 libgphoto2: patch CVE-2026-40340
- 2e3be1dddc libgphoto2: patch CVE-2026-40339
- f22e17508e libgphoto2: patch CVE-2026-40338
- 078f26b084 libgphoto2: patch CVE-2026-40336
- f735ea20b1 libgphoto2: patch CVE-2026-40335
- ce3fa8ad2a libgphoto2: patch CVE-2026-40334
- 754e02c668 libgphoto2: patch CVE-2026-40333
- 24d9844515 gphoto2: upgrade 2.5.28 -> 2.5.32
- f896922914 libcoap: upgrade 4.3.5a -> 4.3.5b
- c0a8cec24e lcms: patch CVE-2026-41254
- 2b1e34f0f5 jq: patch CVE-2026-39979
- 8d399af333 jq: patch CVE-2026-33948
- 525e18ce21 jq: patch CVE-2026-33947
- e94ab85126 jq: patch CVE-2026-32316
- 6fb954e736 fio: upgrade 3.41 -> 3.42
- 7bf89d06a4 libdvdread: use https for fetching code
- ae92a2993c libdvdcss: use https for fetching code
- b50fbdd66b libdvdnav: use https for fetching code
- 5f254f737c enca: disable C23 support to fix configure check
- b620c1f7a6 libkcapi: disable C23 support to fix configure check
- 7d0bd988bb highway: Update to latest tip of trunk
- 626ce67c53 dlt-daemon: fix sign-conversion warning in dlt_timer_conn_types array type
- 9707426b83 liboauth2: Add knob for code coverage
- ee394862b9 sdbus-c++-libsystemd: Upgrade to 259.5
- 2a1772dbc8 libcppconnman: Upgrade to 1.0.0
- 93286ad8b7 xfce4-screensaver: add dependencies libpam and systemd
- 70144adc98 drbd-utils: upgrade 9.30.0 -> 9.34.0
- 574aa17a02 libtoml11: Fix build with C23 and clang
- 3e04c621c4 magic-enum: Upgrade to latest
- c1765cd254 streamripper: disable C23 support to fix configure check
- 515a0ba30d composefs: Fix incompatible pointer type qualifier mismatches
- d4e052c45e poco: upgrade 1.15.1 -> 1.15.2
- a38bcc23f7 mpd: Fix systemd user unit installation
- 750982ed27 fswebcam: Add RRECOMMENDS ttf-dejavu-sans
- ee20c1a573 libraqm: New recipe for a library for complex text layout
- be9f029b6c gd: Support PACKAGECONFIG
- 2df018ea4b dlt-daemon: fix missing application description
- 2b16c16389 packagegroup-meta-python: Enable python3-pyatspi conditional upon GI data
- 268b24cf14 packagegroup-meta-oe: Make pcp and remmina depend upon x11 distro feature
- d7386465ee xrdp: Guard ptests with x11 distro feature
- 0c5517ff10 hiawatha: Upgrade to 12.1 release
- dd3221a5e7 taisei: Fix build with glibc 2.43 + c23
- ec5480d068 eog: Update to 49.3
- 975376f1c7 ruli: Delete -ansi and -pedantic from compiler commandline
- e1f95af4ba meta-oe/recipes: disable C23 support to fix configure check
- e488423e25 audiofile: disable C23 support to fix configure check
- 0581dcc49b sthttpd: disable C23 support to fix configure check
- 6b90623439 dante,openflow,linux-atm: disable C23 support to fix configure check
- 9954723208 ruli: disable C23 support to fix build
- 2571280d86 dhcp-relay: disable C23 support to fix configure check
- 930d936313 libvarlink: Fix build with C23 support in glibc
- 0d39d65c0e systemd-netlogd: Upgrade to 1.4.5 release
- 0556ca04c6 libcanberra: Upgrade to 0.30-20
- bf0e9419c5 cheese: Require x11 distro feature
- de9e6be749 xfdesktop: Add missing DEPENDS on libyaml
- 07a51dfa4e gedit: Use gitsm in SRC_URI for new gdlib submodule
- d09f50438f lshw: Fix binmerge
- f23c00b163 jsoncpp: add ptest support
- 2f1a9776c7 rocksdb: packageconfig knob for set static library option
- f34a878ee2 python3-moteus: Upgrade 0.3.99 -> 0.3.100
- 50d807b18b python3-soupsieve: Upgrade 2.8.2 -> 2.8.3
- b94206dc56 python3-huey: Upgrade 2.6.0 -> 3.0.0
- 18a7b38f73 python3-uvicorn: Upgrade 0.42.0 -> 0.44.0
- 85ed0b926c onboard: upgrade 1.4.3-9 -> 1.4.4-1
- 17a8c0d634 xdg-user-dirs: upgrade 0.19 -> 0.20
- 629cdd168e leancrypto: upgrade 1.7.1 -> 1.7.2
- d5bdddcd95 htop: upgrade 3.4.1 -> 3.5.0
- 29305b3295 python3-mlcommons-loadgen: upgrade 5.1.2 -> 6.0.14
- 7d34df5102 iperf3: upgrade 3.20 -> 3.21
- 0fecdd0b59 libhugetlbfs: add RISC-V to COMPATIBLE_HOSTS