### PR TITLE
ci: skip nightly builds when inputs are unchanged

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,10 +7,18 @@ on:
         required: false
         type: string
         default: "full" # values: pr | full
+      skip_if_github_cached:
+        required: false
+        type: boolean
+        default: false
+        description: "Skip the build matrix if the github actions cache already records a previously-successful run for the same inputs"
     outputs:
       artifacts_url:
         description: "URL to retrieve build artifacts"
         value: ${{ jobs.create-output.outputs.url }}
+      build_skipped:
+        description: "True when the compile matrix was skipped because the github cache recorded a previously-successful build for the same inputs"
+        value: ${{ jobs.github-cache-check.outputs.cache_hit }}
 
 # Concurrency is used to prevent multiple workflows from running for the same PR
 concurrency:
@@ -54,9 +62,62 @@ jobs:
           name: kas-container
           path: ${{ env.KAS_CONTAINER }}
 
-  yocto-run-checks:
+  github-cache-check:
     needs: kas-setup
     if: github.repository_owner == 'qualcomm-linux'
+    runs-on: ubuntu-latest
+    outputs:
+      cache_hit: ${{ steps.restore.outputs.cache-hit == 'true' }}
+      run_hash: ${{ steps.hash.outputs.run_hash }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.git_ref }}
+
+      - name: Download kas lockfile
+        uses: actions/download-artifact@v7
+        with:
+          name: kas-lockfile
+          path: ci
+
+      - name: Compute build input hash
+        id: hash
+        run: |
+          # Hash inputs that fully determine the build:
+          # - the resolved base.lock.yml produced by `kas lock` (pins every layer)
+          # - the meta-qcom revision being built
+          LOCK_HASH=$(sha256sum ci/base.lock.yml | cut -d' ' -f1)
+          SRC_HASH=$(git rev-parse HEAD)
+          RUN_HASH=$(printf '%s\n%s' "$LOCK_HASH" "$SRC_HASH" | sha256sum | cut -d' ' -f1)
+          echo "base.lock.yml hash: $LOCK_HASH"
+          echo "meta-qcom HEAD: $SRC_HASH"
+          echo "Combined run hash: $RUN_HASH"
+          echo "run_hash=$RUN_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Look up previous successful build marker in github cache
+        id: restore
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/build-success-marker
+          key: build-success-${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ steps.hash.outputs.run_hash }}
+          lookup-only: true
+
+      - name: Report github-cache-check decision
+        run: |
+          if [ "${{ inputs.skip_if_github_cached }}" != "true" ]; then
+            echo "skip_if_github_cached not set; build will run"
+          elif [ "${{ steps.restore.outputs.cache-hit }}" = "true" ]; then
+            echo "Run cache hit on key build-success, hash ${{ steps.hash.outputs.run_hash }}: skipping build matrix"
+          else
+            echo "No previous successful build run recorded in github cache for this hash: build will run"
+          fi
+
+  yocto-run-checks:
+    needs: [kas-setup, github-cache-check]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
       - uses: actions/checkout@v6
@@ -90,8 +151,10 @@ jobs:
           ci/kas-container-shell-helper.sh ci/yocto-check-layer.sh
 
   compile_warm_up:
-    needs: kas-setup
-    if: github.repository_owner == 'qualcomm-linux'
+    needs: [kas-setup, github-cache-check]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:
       fail-fast: true
@@ -126,8 +189,10 @@ jobs:
           cache_dir: ${{env.CACHE_DIR}}
 
   compile:
-    needs: compile_warm_up
-    if: github.repository_owner == 'qualcomm-linux'
+    needs: [github-cache-check, compile_warm_up]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: [self-hosted, qcom-u2404, amd64]
     outputs:
       url: ${{ steps.compile_kas.outputs.url }}
@@ -314,8 +379,10 @@ jobs:
           cache_dir: ${{env.CACHE_DIR}}
 
   publish_summary:
-    needs: compile
-    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
+    needs: [github-cache-check, compile]
+    if: |
+      always() && github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -327,10 +394,36 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: build-url*
 
+  github-cache-save:
+    needs: [github-cache-check, compile]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      inputs.skip_if_github_cached == true &&
+      needs.github-cache-check.outputs.cache_hit != 'true' &&
+      needs.compile.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create build success marker
+        run: date -u +%FT%TZ > /tmp/build-success-marker
+
+      - name: Save successful build marker to github cache
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/build-success-marker
+          key: build-success-${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.github-cache-check.outputs.run_hash }}
+
   build_successful:
-    if: github.repository_owner == 'qualcomm-linux'
-    needs: compile
+    if: |
+      always() && github.repository_owner == 'qualcomm-linux' &&
+      (needs.compile.result == 'success' ||
+       (inputs.skip_if_github_cached == true && needs.github-cache-check.outputs.cache_hit == 'true'))
+    needs: [github-cache-check, compile]
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully
-        run: echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"
+        run: |
+          if [ "${{ needs.github-cache-check.outputs.cache_hit }}" = "true" ]; then
+            echo "Build skipped: Run cache recorded a previous successful build for the current input hash and workflow"
+          else
+            echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"
+          fi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -18,15 +18,20 @@ permissions:
 jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml
+    with:
+      skip_if_github_cached: true
+    secrets: inherit
   test-nightly:
+    if: needs.build-nightly.outputs.build_skipped != 'true'
     uses: ./.github/workflows/test.yml
     needs: build-nightly
     secrets: inherit
     with:
       build_id: ${{ github.run_id }}
   publish-test-results:
+    if: needs.build-nightly.outputs.build_skipped != 'true'
     uses: ./.github/workflows/publish-results.yml
-    needs: test-nightly
+    needs: [build-nightly, test-nightly]
     secrets: inherit
     with:
       workflow_id: ${{ github.run_id }}


### PR DESCRIPTION
Limit nightly CI runs to cases where effective build inputs change, avoiding duplicate runs with identical results.

Trigger the nightly build only when one or more of the following changes:
- the meta-qcom layer itself
- updated ci/base.lock.yml (based on kas-setup)

Use the content of base.lock.yml to detect changes in pinned dependencies.

Derive and store a combined hash from:
- updated base.lock.yml
- meta-qcom tree state

Compare this hash against the previous nightly run to determine whether to execute the build, test, and publish stages.

Fixes: https://github.com/qualcomm-linux/meta-qcom/issues/1662