### PR TITLE
qps615-dlkm: fall back to random MAC address when none is predefined

### DIFF
--- a/recipes-kernel/qps615-module/qps615-dlkm/0002-net-ethernet-tc956x-read-MAC-address-from-DT-NVMEM-o.patch
+++ b/recipes-kernel/qps615-module/qps615-dlkm/0002-net-ethernet-tc956x-read-MAC-address-from-DT-NVMEM-o.patch
@@ -1,7 +1,7 @@
-From 1d10902d43db9320fa51dfeef24ab0672950c56f Mon Sep 17 00:00:00 2001
+From 585d7632a2a72d16264a71e240d552e0bf167de9 Mon Sep 17 00:00:00 2001
 From: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
 Date: Mon, 30 Mar 2026 01:24:43 +0530
-Subject: [PATCH 02/12] net: ethernet: tc956x: read MAC address from DT/NVMEM
+Subject: [PATCH 02/13] net: ethernet: tc956x: read MAC address from DT/NVMEM
  on platform
 
 Attempt to read the MAC address from the device tree or NVMEM via
@@ -12,14 +12,17 @@ This allows platform DTS nodes to supply the MAC address through the
 standard 'mac-address' / 'local-mac-address' properties or a linked
 NVMEM cell without requiring a config.ini file.
 
+Also, in case there's no predefined MAC address available, set a random
+one so that userland can handle it properly.
+
 Upstream-Status: Submitted [https://github.com/TC956X/TC9564_Host_Driver/pull/3]
 Signed-off-by: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
 ---
- drivers/net/ethernet/toshiba/tc956x/tc956xmac_main.c | 10 +++++++---
- 1 file changed, 7 insertions(+), 3 deletions(-)
+ .../ethernet/toshiba/tc956x/tc956xmac_main.c  | 23 +++++++++++++------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/net/ethernet/toshiba/tc956x/tc956xmac_main.c b/drivers/net/ethernet/toshiba/tc956x/tc956xmac_main.c
-index a4d8ca8..30031a9 100644
+index a4d8ca8..dffabcc 100644
 --- a/drivers/net/ethernet/toshiba/tc956x/tc956xmac_main.c
 +++ b/drivers/net/ethernet/toshiba/tc956x/tc956xmac_main.c
 @@ -223,6 +223,7 @@
@@ -30,9 +33,38 @@ index a4d8ca8..30031a9 100644
  #include <linux/version.h>
  #include <linux/ctype.h>
  #include "dwxgmac2.h"
-@@ -15732,10 +15733,13 @@ int tc956xmac_vf_dvr_probe(struct device *device,
+@@ -15288,8 +15289,9 @@ static bool lookfor_macid(char *file_buf, uint8_t port_id, uint8_t dev_id)
+  * \return None
+  *
+  */
+-static void parse_config_file(uint8_t port_id, uint8_t dev_id)
++static void parse_config_file(struct net_device *dev, uint8_t port_id, uint8_t dev_id)
+ {
++	struct tc956xmac_priv *priv = netdev_priv(dev);
+ 	void *data = NULL;
+ 	char *cdata;
+ 	int ret, i;
+@@ -15302,8 +15304,12 @@ static void parse_config_file(uint8_t port_id, uint8_t dev_id)
+ 	ret = kernel_read_file_from_path("config.ini", &data, &size, 3000, READING_POLICY);
+ #endif
+ 	if (ret < 0) {
+-		KPRINT_ERR("Mac configuration file not found\n");
+-		KPRINT_INFO("Using Default MAC Address\n");
++		/* There's no predefined MAC address so let's set a random
++		 * address and let userland take care of handling it.
++		 */
++		KPRINT_INFO("Falling back to random MAC address since there's no predefined address found");
++		eth_random_addr(dev_addr[priv->probe_seq_no]);
++		dev->addr_assign_type = NET_ADDR_RANDOM;
+ 		return;
+ 	} else {
+ 
+@@ -15730,12 +15736,15 @@ int tc956xmac_vf_dvr_probe(struct device *device,
+ #else
+ #ifdef TC956X_SRIOV_VF
  	/* To be enabled for config.ini parsing */
- 	parse_config_file(priv->port_num, priv->plat->vf_id);
+-	parse_config_file(priv->port_num, priv->plat->vf_id);
++	parse_config_file(priv->dev, priv->port_num, priv->plat->vf_id);
  #else
 -	/* To be enabled for config.ini parsing */
 -	parse_config_file(priv->port_num, 0);
@@ -41,7 +73,7 @@ index a4d8ca8..30031a9 100644
 +		return dev_err_probe(priv->device, ret,
 +				     "Deferring probe for MAC address from DTB/NVMEM\n");
 +	if (ret)
-+		parse_config_file(priv->port_num, 0);
++		parse_config_file(priv->dev, priv->port_num, 0);
  #endif
 -
  #endif /* EEPROM_MAC_ADDR */


### PR DESCRIPTION
Rb3Gen2 lacks an EEPROM chip and the bootloader does not append a MAC address into the DTB. As a result, all boards running QLI 2.0 end up with the same static fallback MAC addresses on both ports, which can cause DHCP lease conflicts across the network.

Fix this by assigning a random MAC address (with NET_ADDR_RANDOM) when both of_get_mac_address() and parse_config_file() fail to provide one. This allows a userspace network manager (e.g. NetworkManager) to detect the DEV_ADDR_RANDOM flag and persist a stable, board-unique address for subsequent boots.