### PR TITLE
workflows: trigger nightly on wrynose via dispatch

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,10 +7,6 @@ on:
         required: false
         type: string
         default: "full" # values: pr | full
-      git_ref:
-        required: false
-        type: string
-        default: ""
     outputs:
       artifacts_url:
         description: "URL to retrieve build artifacts"
@@ -41,7 +37,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ inputs.git_ref }}
 
       - name: Run kas lock
         if: ${{ hashFiles('ci/base.lock.yml') == '' }}
@@ -68,7 +63,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ inputs.git_ref }}
 
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
@@ -121,7 +115,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ inputs.git_ref }}
 
       - name: Run kas build
         uses: ./.github/actions/compile
@@ -308,7 +301,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ inputs.git_ref }}
 
       - name: Run kas build
         if: inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')
@@ -330,7 +322,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/print-build-output
         with:

--- a/.github/workflows/nightly-build-wrynose.yml
+++ b/.github/workflows/nightly-build-wrynose.yml
@@ -1,4 +1,4 @@
-name: Nightly Build (wrynose)
+name: Nightly Build Dispatcher (wrynose)
 
 on:
   schedule:
@@ -12,43 +12,14 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  actions: write
 
 jobs:
-  # Resolve wrynose to a single SHA so all downstream jobs build the same commit,
-  # and so test results are attributed to the correct wrynose commit (not master's
-  # github.sha, which is what scheduled workflows expose by default).
-  resolve-ref:
+  trigger-build:
     runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.get-sha.outputs.sha }}
     steps:
-      - name: Resolve wrynose SHA
-        id: get-sha
+      - name: Trigger Nightly Build
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/wrynose --jq '.object.sha')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-
-  build-nightly:
-    needs: resolve-ref
-    uses: ./.github/workflows/build-yocto.yml
-    with:
-      git_ref: ${{ needs.resolve-ref.outputs.sha }}
-
-  test-nightly:
-    uses: ./.github/workflows/test.yml
-    needs: [resolve-ref, build-nightly]
-    secrets: inherit
-    with:
-      build_id: ${{ github.run_id }}
-
-  publish-test-results:
-    uses: ./.github/workflows/publish-results.yml
-    needs: [resolve-ref, test-nightly]
-    secrets: inherit
-    with:
-      workflow_id: ${{ github.run_id }}
-      event_name: ${{ github.event_name }}
-      event_file: ${{ github.event_path }}
-      commit: ${{ needs.resolve-ref.outputs.sha }}
+          gh workflow run --repo ${{ github.repository }} --ref wrynose nightly-build.yml

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,5 @@
-name: Nightly Build (master)
+name: Nightly Build
+run-name: "Nightly Build (${{ github.ref_name }})"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,6 +1,7 @@
 name: Nightly Build (master)
 
 on:
+  workflow_dispatch:
   schedule:
   # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
   # so that build notification emails will be sent out properly.


### PR DESCRIPTION
 The current nightly workflow for wrynose dynamically calculates the tree to check out at runtime. However, the GitHub Actions metadata still shows the workflow as being triggered from a commit on the master branch.

This prevents any per-branch customization of the nightly build workflow and disrupts downstream automations that depend on GitHub actions metadata to derive the correct workflow context.

To address this, trigger the workflow via a dispatch explicitly passing the wrynose ref.