### PR TITLE
uboot: support for the iq-615-evk platform in the Yocto build environment.

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -285,6 +285,14 @@ jobs:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+          - machine: iq-615-evk
+            distro:
+                name: nodistro
+                yamlfile: ''
+            kernel:
+                type: u-boot-qcom-6.18
+                dirname: "_linux-qcom-6.18_u-boot-qcom"
+                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit-open-fw
             distro:
                 name: qcom-distro-kvm

--- a/conf/machine/include/qcom-u-boot-common.inc
+++ b/conf/machine/include/qcom-u-boot-common.inc
@@ -9,12 +9,14 @@ UBOOT_CONFIG_DEFAULT ?= "${UBOOT_CONFIG}"
 UBOOT_INITIAL_ENV = ""
 
 # Don't forget to add config to qcom-armv8a.conf when adding it here
+UBOOT_CONFIG[iq-615-evk] = "qcom_qcs615_defconfig"
 UBOOT_CONFIG[iq-9075-evk] = "qcom_lemans_defconfig"
 UBOOT_CONFIG[qcs615-ride] = "qcom_qcs615_defconfig"
 UBOOT_CONFIG[qcs6490-rb3gen2] = "qcm6490_defconfig"
 UBOOT_CONFIG[qrb2210-rb1] = "qcom_defconfig"
 UBOOT_CONFIG[sdm845-db845c] = "qcom_defconfig"
 
+BOARD_MBN_HEADER[iq-615-evk] = "v6"
 BOARD_MBN_HEADER[iq-9075-evk] = "v6"
 BOARD_MBN_HEADER[qcs615-ride] = "v6"
 BOARD_MBN_HEADER[qcs6490-rb3gen2] = "v6"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -34,3 +34,5 @@ QCOM_IRQAFF        = "0-6"
 QCOM_RCU_NOCBS     = "7"
 QCOM_RCU_EXPEDITED = "1"
 QCOM_CPUIDLE_OFF   = "1"
+
+UBOOT_CONFIG = "iq-615-evk"

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -7,6 +7,7 @@ MACHINE_FEATURES += "screen ext2 efi"
 EXTRA_IMAGECMD:ext4 += " -b 4096 "
 
 UBOOT_CONFIG ??= " \
+    iq-615-evk \
     iq-9075-evk \
     qcs615-ride \
     qcs6490-rb3gen2 \


### PR DESCRIPTION
It introduces U-Boot configuration support for the iq-615-evk machine by
enabling UBOOT_CONFIG and selecting qcom_qcs615_defconfig for platform-
specific initialization.

Additionally, the GitHub CI workflow is extended to build U-Boot variants
for iq-615-evk alongside the linux-qcom-6.18 kernel, ensuring continuous
integration coverage for the platform.