### PR TITLE
linux-qcom-next: update to tag qcom-next-7.0-20260504

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,12 +8,12 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.19+7.0-rc7"
+LINUX_VERSION ?= "7.0"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.0-rc7-20260420
-SRCREV ?= "bc7c0351d6a12f6e2f67299ed7ce8c9f12225d65"
+# tag: qcom-next-7.0-20260504
+SRCREV ?= "0f9957102cc3756c05cd52145aaff7c5cbeaf155"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.0-20260504, 
which corresponds to kernel version v7.0

Changelog :
1. Fixes for connectivity issues on sm8750, Kaanapali and Glymur
2. Display fixes for sm8750 and Kaanapali
3. EL2 overlay dtso change for Kodiak
