### PR TITLE
ci: base.lock: update meta-audioreach to 4feaf10

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -13,7 +13,7 @@ overrides:
         meta-virtualization:
             commit: 052241689a0c419d13e15e83e7ad65dd16fc8ffd
         meta-audioreach:
-            commit: 75402c8d1ea1203dcf3a63792161f7d5d93946bb
+            commit: 4feaf103f9525e467fbefddbefd2e55465c88656
         meta-selinux:
             commit: f7306d7af4425553684a860df6f6d0ee66efba31
         meta-updater:


### PR DESCRIPTION
Relevant changes:
- 4feaf10 Merge pull request #86 from Sandhya1236/Align-stale-workflow-with-OSSOps-recommendations
- a7492fd Create stale-issues.yaml
- 612362c Merge pull request #108 from mohsRafi/Fix_the_SSR_issue
- 8e39167 audioreach-kernel: srcrev bump 6d3d0f0..bf478f8
- 0c8b40f audioreach-kernel: blacklist glymur ASoC machine driver
- 7e88f2b Merge pull request #109 from qti-sbojja/master
- 4bf2ea1 Revert "ci/qcom-distro: fix meta-security wic"
- 3f20e8c Merge pull request #105 from QTI-Quill/master
- 4645605 audioreach-kernel: srcrev bump bcf17af..6d3d0f
- 4a289a7 Merge pull request #103 from qti-sbojja/rev_update_pal_conf
- e8db8e8 audioreach-conf: srcrev bump 4ff045a..cb9e696
- 7551254 audioreach-pal: srcrev bump 9c39264..db8e497
- 0d70550 Merge pull request #104 from qti-sbojja/compilation_fix
- 266e322 ci/qcom-distro: fix meta-security wic