### PR TITLE
ci: build-yocto: always run kas lock and include meta-arm by default

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run kas lock
         run: |
-          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
+          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml:ci/meta-arm.yml
 
       - name: Upload kas lockfile
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run kas lock
         if: ${{ hashFiles('ci/base.lock.yml') == '' }}
         run: |
-          ${KAS_CONTAINER} lock --update ci/base.yml:ci/qcom-distro.yml
+          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
 
       - name: Upload kas lockfile
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -44,7 +44,6 @@ jobs:
           ref: ${{ inputs.git_ref }}
 
       - name: Run kas lock
-        if: ${{ hashFiles('ci/base.lock.yml') == '' }}
         run: |
           ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
 


### PR DESCRIPTION
Having base.lock.yml present is not sufficient to guarantee that all
repositories are pinned (for example, meta-qcom-distro may be missing).
Always run 'kas lock', even when a lock file already exists, so missing
repositories are populated while existing pins are preserved. This also
behaves correctly when no lock file is present, equivalent to generating
a new lock.

Also include meta-arm.yml by default when generating the lock file as it
currently not included by base or qcom-distro.