### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260505

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260430
-SRCREV ?= "cdf31edb9e60f17ab886c1baf3406dc5d6a6571d"
+# tag:qcom-6.18.y-20260505
+SRCREV ?= "7368c42b9ccaa0e2c2c537d2df814a6940af7372"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260505

Changelog:
FROMLIST: pci: quirks: Advertise D3cold capability for UPD720201
WORKAROUND: i2c: qcom-geni: Fix -EACCES error during system resume
FROMLIST: PCI: qcom: Add D3cold support
FROMLIST: PCI/pwrctrl: Do not try to power on/off devices that don't need pwrctrl
FROMLIST: soc: qcom: pd-mapper: Add support for SA8775P
FROMLIST: soc: qcom: pd-mapper: Add support for QCS8300