### PR TITLE
add phone capability via MACHINE_FEATURES for iq-x7181-evk and iq-x5121-evk

### DIFF
--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-purwa.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci phone"
 
 QCOM_DTB_DEFAULT ?= "purwa-iot-evk"
 

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-hamoa.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \


### PR DESCRIPTION
This change adds the 'phone' capability to MACHINE_FEATURES for the
iq-x7181-evk and iq-x5121-evk machines having external M.2 attach modems.

The intent is to advertise telephony support at the machine level,
allowing higher layers to conditionally enable cellular-related components based on MACHINE_FEATURES.