### PR TITLE
ci: base.lock: update meta-arm, meta-security, meta-updater and meta-virt layers

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -7,16 +7,16 @@ overrides:
         bitbake:
             commit: cb28befc56d201cace72d70891e731b955fb567f
         meta-arm:
-            commit: d987a5945802dcbbc06be91a0d34f00431ea840e
+            commit: f3a2db0561d60aa0401beefe783ee91c8ebb3bcb
         meta-openembedded:
             commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
         meta-virtualization:
-            commit: 052241689a0c419d13e15e83e7ad65dd16fc8ffd
+            commit: 4ba5825ee16fcded87f4d555b4ed7a7615dc67ac
         meta-audioreach:
             commit: 4feaf103f9525e467fbefddbefd2e55465c88656
         meta-selinux:
             commit: f7306d7af4425553684a860df6f6d0ee66efba31
         meta-updater:
-            commit: 7fbd0d7d73d4e252ee31e5260e547cbf17945a82
+            commit: a8af24357121dc8614fd98f234b73d55005b0cc9
         meta-security:
-            commit: bd6927e1dfc19b2b9619da85e03fb06b6fb6dc03
+            commit: 9265f142f3890df2d00d71d13b19e95a082707ed


### PR DESCRIPTION
Relevant changes for meta-arm:
- f3a2db05 arm-bsp/u-boot: Update fvp-base, juno, corstone1000 patches
- 3aa08556 arm-bsp/docs:corstone1000: Reduce sudo dependency in OOB tests
- 85bd24f7 arm-bsp/docs:corstone1000: Fix secure boot script path
- eb9b2aff arm-bsp/u-boot: corstone1000: disable EFI debug support
- 325134ea arm-bsp/u-boot: fix Corstone1000 FVP detection in patch set
- 78354ba2 arm-bsp/trusted-firmware-m:cs1k: Use new GPT duplicate functionality
- 1eaa431f arm-bsp/trusted-firmware-m:cs1k: Add extra GPT library operations
- 9af92ed0 arm-bsp/trusted-firmware-m:cs1k: Add fixes for GPT library
- 45266372 scripts/runfvp: fix exception handling
- 9aedfffc scripts/runfvp: add Screen support
- 2b0fbab1 scripts/runfvp: check available terminal types
- 9d1070b4 arm-bsp/packagegroup-core-boot:cs1k: Remove GRUB from initramfs
- 8eb10af8 scripts/runfvp: fix silent failure when FVP is missing
- 6e1cea02 arm/generate_capsule_json_multiple: Fix --selected_components default behavior
- 3b7f4ccf CI: remove meta-virtualization references
- 5ad64ce7 CI: remove Xen jobs
- 01abd473 arm-bsp/docs: corstone1000: Drop A320 reboot workaround note
- 23189561 arm-bsp/trusted-firmware-m: corstone1000: Drive NPU reset via ext sys ctrl

Relevant changes for meta-security:
- 9265f14 README: update CI links
- 5bcd679 packagegroup-core-security: remove python3-privacyidea
- 5a333f4 packagegroup-core-security: Add missing packages
- 0743981 ncrack: Update
- ffdbb6d libmhash: Remove
- 203087e aide: Upgrade to 0.19.3
- 9004924 clamav: Upgrade to 1.4.4
- d0386f2 libmspack: Remove
- 8e4092a opendnssec: Upgrade to 2.1.14
- 1792ae2 aircrack-ng: Upgrade to 1.7
- cd05fe6 crowdsec: Upgrade to v1.7.7
- 1dcf90f suricata: update 7.0.13 -> 8.0.4
- 731c5fc krill: fix missing dollar sign in FILES

Relevant changes for meta-updater:
- a8af243 refpolicy-targeted: fix ostree deployment path regex and add missing rules

Relevant changes for meta-virtualization:
- 4ba5825e vcontainer: add --config / VDKR_CONFIG for docker/podman auth credentials
- 002f915a tests: add vcontainer --config / VDKR_CONFIG auth plumbing tests
- e1beca39 python3-dotenv: Fix CVE-2026-28684
- f262327c vcontainer-common: fix vstorage commands with --state-dir
- 3106e77f podman: fix CNI build tag for non-netavark networking configurations
- 751b99dc vcontainer-tarball: add CI-safe environment script for autobuilder
- cd15723c oe-go-mod-fetcher: add license scanning for Go module dependencies
- a66c8df6 cosign: switch to go-mod-vcs generated license scanning
- 3b721edc cosign: convert to go-mod-vcs hybrid fetch
- 88ae1ba5 oe-go-mod-fetcher: improve error messages with recipe-ready fix snippets
- eae6e33f cosign: add recipe for container signing tool v3.0.6
- ad63ebe6 vcontainer-initramfs-create: fix kernel deploy dependency via do_build

Updating all but oe-core and meta-oe as I want those to be updated separately as the changes are more intrusive, at least until we're in sync with latest.