### PR TITLE
workflows: enable glymur-crd premerge test and update ref to b9de72b

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -37,7 +37,7 @@ runs:
         with:
           repository: qualcomm-linux/lava-test-plans
           path: lava-test-plans
-          ref: d0f755a1cc8b66af6bc28e61fd4c7b40975194e0
+          ref: b9de72b563d8b361b39075c6070d76010040660e
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
-      devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       distro_name: "qcom-distro"
   test-qcom-distro_linux-qcom-6-18:
     name: "Test qcom-distro_linux-qcom-6.18"


### PR DESCRIPTION
Add glymur-crd to the devices_premerge list in test.yml for the qcom-distro job and update lava-test-plans ref to b9de72b to include premerge support for glymur-crd.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>