### PR TITLE
u-boot-qcom: update SRCREV to latest qcom-next commit

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.04+2026.07-rc1+git"
 
-SRCREV = "7a82a69bc2e56bdf0df04378b2b6902f995790a6"
+SRCREV = "a027d749f0ccc0559b3ebdaa22aca3833102c9e9"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Bump SRCREV from 7a82a69bc2e5 to a027d749f0cc to pick up the latest fixes and updates from the Qualcomm u-boot tree.

- Add Qualcomm SMEM support for early hardware detection, memory map
  parsing, and serial number reporting
- Enhance Snapdragon boot flow with FIT multi-DTB selection, overlays,
  and FAT loading fallback for EDK2 bootloaders
- Improve ARMv8 MMU region unmapping and fix reserved memory carve-out
  handling
- Fix DWC3 fastboot crash caused by incorrect device-managed memory
  freeing
- Add new Qualcomm platform support and defconfigs (Talos EVK,
  QCS6490 updates)
- Update environment storage, partition lookup (GUID-based), and
  fastboot configuration across Qualcomm boards