### PR TITLE
[backport wrynose] ci: build-yocto: always run kas lock and include meta-arm by default

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -39,7 +39,6 @@ jobs:
           persist-credentials: false
 
       - name: Run kas lock
-        if: ${{ hashFiles('ci/base.lock.yml') == '' }}
         run: |
           ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
 

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run kas lock
         run: |
-          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
+          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml:ci/meta-arm.yml
 
       - name: Upload kas lockfile
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run kas lock
         if: ${{ hashFiles('ci/base.lock.yml') == '' }}
         run: |
-          ${KAS_CONTAINER} lock --update ci/base.yml:ci/qcom-distro.yml
+          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
 
       - name: Upload kas lockfile
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2112