### PR TITLE
ci: base.lock: update meta-openembedded to 39321ae90b

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -9,7 +9,7 @@ overrides:
         meta-arm:
             commit: 3c07303388bf1fa286bbb6f5b5b6189635787103
         meta-openembedded:
-            commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
+            commit: 39321ae90b64e8f2bd890a2957a5f80e74d4de30
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:


### PR DESCRIPTION
Relevant changes:
- 39321ae90b nginx: upgrade 1.30.1 -> 1.30.2
- 11b95aa5fd imagemagick: upgrade 7.1.2-22 -> 7.1.2-23
- 9666b61fbd python3-ldap: upgrade 3.4.5 -> 3.4.7
- 76bb679f42 procmail: Add -std=gnu17 to fix error of do_compile
- 99f4962fa3 tigervnc: Fix do_configure Error
- bfd1582c46 xdg-desktop-portal-gnome: remove gnome-shell runtime dependency
- 0ef03e2f75 libjcat: upgrade 0.2.3 -> 0.2.6
- c967ae5edc freerdp3: upgrade 3.25.0 -> 3.26.0
- a2b90ccd7b nginx: upgrade 1.30.0 -> 1.30.1
- 2f64c27b18 python3-django: upgrade 6.0.4 -> 6.0.5
- ef903fca83 python3-django: upgrade 5.2.13 -> 5.2.14
- 143d18269c nodejs: upgrade 22.22.3 -> 24.16.0 (LTS)
- 9f1a858701 nodejs-oe-cache-native: upgrade to version 24.16
- 72154f38fc kmscon: fix zlib cross-compiling errors
- c6abe6c8b0 python3-orjson: Upgrade to 3.11.9
- 83cad3966c postgresql: upgrade 17.8 -> 17.10
- c5e90eff6c lvm2: Do not install sbin/dmvdostats to sysroot
- f90ccad49a openjpeg: add ptest support
- 4009dea868 jemalloc: fix version string
- f2973002c9 xfsdump: upgrade 3.2.0 -> 3.3.0
- a0589ae5a4 uriparser: upgrade 1.0.1 -> 1.0.2
- a86ee0d4f6 swagger-ui: upgrade 5.32.5 -> 5.32.6
- 2413c8b267 python3-virtualenv: upgrade 21.3.1 -> 21.3.3
- 537a4c4484 python3-typeguard: upgrade 4.5.1 -> 4.5.2
- 8ae0b005d2 python3-twisted: upgrade 25.5.0 -> 26.4.0
- d2656956d9 python3-tox: upgrade 4.53.1 -> 4.54.0
- b71b3e83fd python3-tomlkit: upgrade 0.14.0 -> 0.15.0
- 3052c0a501 python3-thrift: upgrade 0.22.0 -> 0.23.0
- 157c5a9198 python3-sentry-sdk: upgrade 2.59.0 -> 2.60.0
- 7a655b30fe python3-rich-toolkit: upgrade 0.19.7 -> 0.19.9
- a8fa054d80 python3-reportlab: upgrade 4.5.0 -> 4.5.1
- 9221e2d306 python3-regex: upgrade 2026.4.4 -> 2026.5.9
- 0b6fa1f1c6 python3-python-multipart: upgrade 0.0.27 -> 0.0.28
- f4943b2efe python3-pytest-codspeed: upgrade 4.5.0 -> 5.0.2
- f8d7055b54 python3-paramiko: upgrade 4.0.0 -> 5.0.0
- 78ba07b0a3 python3-pandas: upgrade 3.0.2 -> 3.0.3
- edeaf33269 python3-myst-parser: upgrade 5.0.0 -> 5.1.0
- e0676322d0 python3-meh: upgrade 0.52 -> 0.53
- 7c6a0813e0 python3-mdit-py-plugins: upgrade 0.6.0 -> 0.6.1
- 63f8874f0e python3-inline-snapshot: upgrade 0.32.7 -> 0.33.0
- c14a56b358 python3-huey: upgrade 3.0.0 -> 3.0.1
- 9255649ec1 python3-flask-jwt-extended: upgrade 4.7.3 -> 4.7.4
- 4844eade22 python3-faker: upgrade 40.15.0 -> 40.18.0
- f514cde1a5 python3-coverage: upgrade 7.13.5 -> 7.14.0
- 74cd808dbd lldpd: upgrade 1.0.21 -> 1.0.22
- ff7bf096f5 libsdl3-mixer: upgrade 3.2.0 -> 3.2.2
- 9c56c3ed52 libsdl2-mixer: upgrade 2.8.1 -> 2.8.2
- 313c92cda8 libei: upgrade 1.5.0 -> 1.6.0
- b2ae1309c0 lcms: upgrade 2.19 -> 2.19.1
- 5063ac8e48 imagemagick: upgrade 7.1.2-21 -> 7.1.2-22
- 2b3c9da3f8 gnome-text-editor: upgrade 50.0 -> 50.1
- 0bcee676da fastfetch: upgrade 2.62.1 -> 2.63.1
- 05fe4e2bfc dovecot: upgrade 2.4.3 -> 2.4.4
- 45df5217fa ctags: upgrade 6.2.20260426.0 -> 6.2.20260510.0
- d490283916 catch2: upgrade 3.14.0 -> 3.15.0
- 84d4d96d9f bit7z: upgrade 4.0.11 -> 4.0.12
- c14ab2717b python3-pycurl: Use pep517-backend Fixes
- a07b2ddc51 layer.conf: remove dead BBFILES_DYNAMIC entry for clang-layer
- 44c8962f48 dnsmasq: fix https://github.com/advisories/GHSA-57vp-ffx7-7gm6
- b4c4853624 dnsmasq: fix https://github.com/advisories/GHSA-4rrv-pmrh-2vc4
- 21c3d7eb6f dnsmasq: fix https://github.com/advisories/GHSA-m62j-63mf-xr95
- a9de48a9fa dnsmasq: fix https://github.com/advisories/GHSA-2qp9-xr4x-2cr9
- 78162615f5 dnsmasq: fix https://github.com/advisories/GHSA-32px-jfgq-53xf
- a53328688a dnsmasq: fix https://github.com/advisories/GHSA-hjxh-hmm9-wcmc
- 47e9739586 plymouth: upgrade 24.004.60 -> 26.124.222
- babcd87414 pipewire: update 1.6.3 -> 1.6.5
- f8787b56f3 procmail: Upgrade to 3.24
- 428d146237 nautilus: update dependencies
- adf125bf64 gnome-system-monitor: remove obsolete dependencies
- 766e9e0518 file-roller: drop libhandy dependency
- 0f3868acc4 gnome-calendar: remove obsolete dependencies, clean up recipe
- 86c742e5f4 libhandy: add recipe (from oe-core)
- da0ce6c6c0 libdazzle: add recipe (from oe-core)
- 51ed0fcecd iwd: depend on the regulatory database
- 38c953d97c 7zip: do not provide p7zip
- 6133cecab2 pgpool2: 4.6.4 -> 4.6.6
- ad0f53d2bb postfix: upgrade 3.10.9 -> 3.11.2
- ad74dd5f1b python3-pychromecast: Fix build with wheel 0.47
- 4392c7d397 python3-cucumber-tag-expressions: Fix build with newer uv build
- 205defa2c4 python3-croniter: Fix build with newer trove and pathspec modules
- c6e778b387 magic-enum: upgrade 0.9.7 -> 0.9.8
- e3ffb17057 xfce4-appfinder: upgrade 4.21.0 -> 4.21.1
- ea56a5e3ae nodejs: upgrade 22.22.2 -> 22.22.3
- 9be9388574 jsoncpp: Fix C++11 ABI breakage when compiled with C++17
- 3608cfdc5b pkcs11-provider: fix build error on 32 bit systems
- 37408fe618 nftables: add systemd PACKAGECONFIG
- 125dbabef6 webmin: upgrade 2.630 -> 2.641
- 3bdbc82938 orage: upgrade 4.20.2 -> 4.20.3
- 8b4ce3276c znc: upgrade 1.10.1 -> 1.10.2
- ea33566f0c xterm: upgrade 409 -> 410
- 8c4ff33080 xfsprogs: upgrade 6.18.0 -> 7.0.0
- f61e7bea3f wireshark: upgrade 4.6.4 -> 4.6.5
- d47ea6487b valkey: upgrade 9.0.3 -> 9.0.4
- fd65c13ad9 unbound: upgrade 1.24.2 -> 1.25.0
- da3a09b3c5 rtorrent: upgrade 0.16.10 -> 0.16.11
- 8d66bc9c7b python3-wtforms: upgrade 3.2.1 -> 3.2.2
- 5879058ea3 python3-web3: upgrade 7.12.1 -> 7.16.0
- 253f6f1cdc python3-virtualenv: upgrade 21.3.0 -> 21.3.1
- 6887661fec python3-ujson: upgrade 5.12.0 -> 5.12.1
- a372745b14 python3-types-psutil: upgrade 7.2.2.20260408 -> 7.2.2.20260508
- 243aa508d2 python3-typer: upgrade 0.25.0 -> 0.25.1
- 61e1f28462 python3-traitlets: upgrade 5.14.3 -> 5.15.0
- 368e3e2b0e python3-tox: upgrade 4.53.0 -> 4.53.1
- a7f68b510d python3-sentry-sdk: upgrade 2.58.0 -> 2.59.0
- 4586283993 python3-rich-argparse: upgrade 1.7.2 -> 1.8.0
- f88b1dc36d python3-reportlab: upgrade 4.4.10 -> 4.5.0
- 53bd15697e python3-pytest-codspeed: upgrade 4.4.0 -> 4.5.0
- d8013dd69b python3-pymysql: upgrade 1.1.2 -> 1.1.3
- b0ad174507 python3-pymisp: upgrade 2.5.33.2 -> 2.5.34.1
- 47fa5ccb56 python3-pycurl: upgrade 7.45.7 -> 7.46.0
- e717c3840a python3-pika: upgrade 1.3.2 -> 1.4.0
- da8191b6e2 python3-parso: upgrade 0.8.6 -> 0.8.7
- 08a2ba9392 python3-parse: upgrade 1.21.1 -> 1.22.0
- 775fa37814 python3-mdit-py-plugins: upgrade 0.5.0 -> 0.6.0
- 4d65bb8dac python3-matplotlib-inline: upgrade 0.2.1 -> 0.2.2
- 1cf75e0645 python3-jedi: upgrade 0.19.2 -> 0.20.0
- 14e63df1b9 python3-gunicorn: upgrade 25.3.0 -> 26.0.0
- f038293ac0 python3-google-auth: upgrade 2.49.2 -> 2.52.0
- cb61ace3a4 python3-google-auth-oauthlib: upgrade 1.3.1 -> 1.4.0
- b052ea6761 python3-git-pw: upgrade 2.8.0 -> 2.8.1
- 1ba6bd5f5f python3-fsspec: upgrade 2026.3.0 -> 2026.4.0
- 7a1881d379 python3-flask-jwt-extended: upgrade 4.7.1 -> 4.7.3
- e3d55327f3 python3-drgn: upgrade 0.1.0 -> 0.2.0
- 76e632e2c9 pure-ftpd: upgrade 1.0.53 -> 1.0.54
- 3d65906189 libtorrent: upgrade 0.16.10 -> 0.16.11
- 390f294ff3 libtest-harness-perl: upgrade 3.50 -> 3.52
- ac45e26afc libsdl3: upgrade 3.4.4 -> 3.4.8
- de7b302aae libnet-dns-sec-perl: upgrade 1.26 -> 1.27
- 3839e31771 libnet-dns-perl: upgrade 1.53 -> 1.54
- 3567b3a761 libio-socket-ssl-perl: upgrade 2.096 -> 2.098
- d7c87a628c libgsf: upgrade 1.14.56 -> 1.14.58
- e1168b4f99 libdevmapper,lvm2: upgrade 2.03.39 -> 2.03.40,2.03.39 -> 2.03.40
- 5ce922aaea libcgi-perl: upgrade 4.71 -> 4.72
- bfd93bafbb libauthen-sasl-perl: upgrade 2.1800 -> 2.2000
- dad06c74bb hunspell: upgrade 1.7.2 -> 1.7.3
- 85b6f00b86 htop: upgrade 3.5.0 -> 3.5.1
- 63fa426735 hiawatha: upgrade 12.1 -> 12.2
- f6cb840125 fluentbit: upgrade 5.0.3 -> 5.0.5
- ff39e9c8bb feh: upgrade 3.12.1 -> 3.12.2
- 2a19e17aa8 exiftool: upgrade 13.57 -> 13.58
- 8c104eafe2 doxygen: upgrade 1.16.1 -> 1.17.0
- 2f44d17816 btop: upgrade 1.4.6 -> 1.4.7
- a457cb619c botan: upgrade 3.11.1 -> 3.12.0
- 4fe6bf337a thin-provisioning-tools: fix compile failure on 32bit BSPs
- 0a3798eaed bpftool-native: Fix -Wdiscarded-qualifiers errors for glibc 2.42+
- a3b407c982 nftables: improve reproducibility
- 46aaa5b623 haveged: upgrade 1.9.19 -> 1.9.20
- 7c6ce9d100 postfix: upgrade 3.10.8 -> 3.10.9
- fec614b8cb lvm2: move scripts to lvm2-scripts package
- 995f143cb9 openvpn: create an extra package for the dns-updown script
- ad3b5ba0b0 xarchiver: upgrade 0.5.4.21 -> 0.5.4.26
- a8ecd065cd libgpiod: clean-up sub-packages
- a34b94c7b0 dbus-cxx: 2.6.1 -> 2.6.2
- 4f276e4b8b glaze: 7.3.3 -> 7.6.0
- 3ec333fc06 apache2: upgrade 2.4.66 -> 2.4.67
- d98d888df6 nginx: upgrade 1.29.7 -> 1.30.0
- a1503aa0f2 postfix: make it can compile with linux 7.x
- 682856ec1f mdns: Update for mbedtls4, set daemon version
- 4310ecc78f php: upgrade 8.5.5 -> 8.5.6
- 8d6cbbc160 freerdp3: upgrade 3.24.2 -> 3.25.0
- ba9fd4e029 thrift: upgrade 0.22.0 -> 0.23.0
- a5e9c8141a cryptsetup: update udev package config
- 8b2c487173 libcamera: 0.7.0 -> 0.7.1
- 41ba8f83a4 libcamera: 0.6.0 -> 0.7.0
- a797983156 libcamera: change python config
- a9eece0195 libcamera: add new package for lc-compliance
- 5206553c8f libcamera: add configs pipelines for testing
- d5d6c6a064 libyuv: add recipe
- 63130ebd08 open62541: upgrade 1.4.16 -> 1.5.4
- 91e9560ad0 libavif: add PACKAGECONFIG for rav1e codec
- 90d7303e3e librav1e: add recipe
- fd70b478f3 svt-av1: add recipe
- b6a6d9fd86 python3-cyclonedx-python-lib: add recipe
- 13befbc001 python3-py-serializable: add recipe
- b71752fb55 python3-packageurl-python: add recipe
- 7381ae9d24 proftpd: upgrade 1.3.9 -> 1.3.9a
- 70d12c42dc dracut: upgrade 110 -> 111
- f36312669c kmscon: upgrade 9.3.3 -> 9.3.5
- 85ccc34c46 xterm: upgrade 408 -> 409
- 1463fc29ec xbitmaps: upgrade 1.1.3 -> 1.1.4
- 03255a83e3 uriparser: upgrade 1.0.0 -> 1.0.1
- 046d3adc9c ubi-utils-klibc: upgrade 2.3.0 -> 2.3.1
- a620499544 tinysparql: upgrade 3.11.0 -> 3.11.1
- 137e8d240e swagger-ui: upgrade 5.32.2 -> 5.32.5
- b05b177ae5 strongswan: upgrade 6.0.5 -> 6.0.6
- db7155a0c2 spectre-meltdown-checker: upgrade 26.26.0404682 -> 26.33.0420460
- 542072981a rtorrent: upgrade 0.16.9 -> 0.16.10
- 12d6ef482f python3-zopeinterface: upgrade 8.3 -> 8.4
- e0a8bb27fe python3-xxhash: upgrade 3.6.0 -> 3.7.0
- 3fa56fbd9d python3-virtualenv: upgrade 21.2.1 -> 21.3.0
- 6321202865 python3-tzdata: upgrade 2026.1 -> 2026.2
- 791da9289c python3-typer: upgrade 0.24.1 -> 0.25.0
- e746d2a644 python3-tox: upgrade 4.52.1 -> 4.53.0
- f7db694ca5 python3-simplejson: upgrade 3.20.2 -> 4.1.1
- 4b28593e9a python3-sentry-sdk: upgrade 2.57.0 -> 2.58.0
- 7841103fcb python3-python-multipart: upgrade 0.0.26 -> 0.0.27
- 40ea3157ef python3-pytest-codspeed: upgrade 4.3.0 -> 4.4.0
- f11c94d90e python3-pyroute2: upgrade 0.9.5 -> 0.9.6
- 7995c66f68 python3-pymongo: upgrade 4.16.0 -> 4.17.0
- ce66ccbde2 python3-pymisp: upgrade 2.5.33.1 -> 2.5.33.2
- b76b720d7b python3-pre-commit: upgrade 4.5.1 -> 4.6.0
- 73cfca3ddd python3-moteus: upgrade 0.3.100 -> 0.3.101
- 1e0639ffa3 python3-ipython: upgrade 9.12.0 -> 9.13.0
- fe086de31a python3-inline-snapshot: upgrade 0.32.6 -> 0.32.7
- de42f7888f python3-identify: upgrade 2.6.18 -> 2.6.19
- 8c5dd332cd python3-greenlet: upgrade 3.4.0 -> 3.5.0
- 344f4f0638 python3-flask-wtf: upgrade 1.2.2 -> 1.3.0
- a1ea487c50 python3-flask-marshmallow: upgrade 1.4.0 -> 1.5.0
- 6a7392f88f python3-filelock: upgrade 3.25.2 -> 3.29.0
- 1dc5309883 python3-fastapi: upgrade 0.135.3 -> 0.136.1
- d5ef0b6c8c python3-faker: upgrade 40.13.0 -> 40.15.0
- 2f18e97759 python3-cmd2: upgrade 3.4.0 -> 3.5.1
- e020150dd9 python3-cmake: upgrade 4.3.1 -> 4.3.2
- e454377810 python3-bumble: upgrade 0.0.226 -> 0.0.228
- 906979c699 python3-asyncinotify: upgrade 4.4.2 -> 4.4.4
- a213780f22 parallel: upgrade 20260322 -> 20260422
- 6cba4ed4d2 ntfs-3g-ntfsprogs: upgrade 2022.10.3 -> 2026.2.25
- 695729a1c1 nss: upgrade 3.122 -> 3.123.1
- 9222ec03c3 neatvnc: upgrade 0.9.5 -> 0.9.6
- 12e311c7e6 nbdkit: upgrade 1.47.7 -> 1.47.8
- 1f465d9d28 mdio-tools,mdio-netlink: upgrade 1.3.1 -> 1.3.2,1.3.1 -> 1.3.2
- 2b43bc24f6 md4c: upgrade 0.5.2 -> 0.5.3
- 5a08d78f85 localsearch: upgrade 3.11.0 -> 3.11.1
- 6d7794e799 libtsm: upgrade 4.4.3 -> 4.5.0
- ba505640b1 libtorrent: upgrade 0.16.9 -> 0.16.10
- 3b0564196f libfido2: upgrade 1.16.0 -> 1.17.0
- 8bfc883261 libblockdev: upgrade 3.4.0 -> 3.5.0
- 6fc78f37ee lcms: upgrade 2.18 -> 2.19
- e10b2658b2 jsoncons: upgrade 1.6.0 -> 1.7.0
- 08447ba871 jemalloc: upgrade 5.3.0 -> 5.3.1
- 5d2fd54d7d isocline: upgrade 1.0.9 -> 1.1.0
- 963f73979d imagemagick: upgrade 7.1.2-19 -> 7.1.2-21
- 9fa2334a45 iceauth: upgrade 1.0.10 -> 1.0.11
- b93e7beea0 highway: upgrade 1.3.0 -> 1.4.0
- e22ae5b251 fluentbit: upgrade 5.0.2 -> 5.0.3
- e61d33aa53 fastfetch: upgrade 2.61.0 -> 2.62.1
- e953ab856d dash: upgrade 0.5.13.2 -> 0.5.13.3
- 7bb3014384 ctags: upgrade 6.2.20260329.0 -> 6.2.20260426.0
- 8cb0926b53 bubblewrap: upgrade 0.11.1 -> 0.11.2
- c01d05c2f9 appstream-glib: upgrade 0.8.2 -> 0.8.3
- 506bd38398 7zip: upgrade 26.00 -> 26.01
- cde1c732e4 cloudflared: add initial recipe for 2026.3.0 version
- 23c9511b0a gnome-shell: upgrade 48.7 -> 48.8
- f50db12058 exiftool: upgrade 13.52 -> 13.57
- 1f2864a3d5 editorconfig-core-c: upgrade 0.12.9 -> 0.12.11
- 76b27162f9 eog: Add HOMEPAGE
- e265577249 webkitgtk3: fix build on riscv64
- ee2048e9df xfdesktop: upgrade 4.20.1 -> 4.20.2
- fbe399b230 vboxguestdrivers: Upgrade to 7.2.8
- 1785028847 python3-blivet: switch from setuptools3_legacy to python_setuptools_build_meta
- d389ed9e33 python3-aspectlib: Fix pytest compatibility
- 39e99ad532 libcoap: mark https://github.com/advisories/GHSA-4vrr-6f8v-98rf patched
- 420222862f networkmanager: re-implement the vala detection
- 05191ba25b memcached: drop libhugetlbfs
- 0af2c62a38 mdns: Upgrade 2881.80.4.0.1 -> 2881.100.56.0.1
- 62104ea1db fftw_3.3.11.bb: Update version.
- 15d5785d28 tbb: add ptest support
- ecaeb93da3 frr: fix mgmtd crash on ARM32
- 41a7fe71a7 frr: upgrade 10.5.3 -> 10.6.1
- b5a792e209 jemalloc: fix always_inline build failure
- 8c9adcfadb xfce4-screensaver: Make libpam and systemd dependencies conditional
- 88c22e566d ebtables: Fix update-alternatives by setting ALTERNATIVE_TARGET
- 6a14b73000 canopenterm: update to version 2.02+git
- 36d46e1871 python3-pyfuse3: Move to meta-python
- 3283baa0a4 framebuffer-vncserver: New recipe for VNC server for framebuffer
- 76700b6eaf gphoto2: Fix build with clang-22
- ef548c3982 networkmanager: DISTRO_FEATURES_BACKFILL_CONSIDERED -> DISTRO_FEATURES_OPTED_OUT
- fa612d7971 libspdm: update SRCREV to final 3.8.2 release
- 0c9cb5fb09 opensc: ship missed installed file
- f2d723ce08 python3-pyfuse3: new recipe
- 07d6722816 libsoup-2.4: fix several CVEs
- 740f9f71dd webkitgtk3 update 2.50.5 -> 2.50.6
- 44d5012a7c ceres-solver: Improve the build configuration
- cc814c9fd1 wireplumber: update 0.5.13 -> 0.5.14
- be77fde6f6 pipewire: update 1.6.2 -> 1.6.3