### PR TITLE
Switch debug and performance builds to catchall distro

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -223,9 +223,9 @@ jobs:
           - name: qcom-distro-catchall
             yamlfile: ':ci/qcom-distro-catchall.yml'
           - name: debug
-            yamlfile: ':ci/qcom-distro.yml:ci/debug.yml'
+            yamlfile: ':ci/qcom-distro-catchall.yml:ci/debug.yml'
           - name: performance
-            yamlfile: ':ci/qcom-distro.yml:ci/performance.yml'
+            yamlfile: ':ci/qcom-distro-catchall.yml:ci/performance.yml'
         kernel:
           - type: default
             dirname: ""


### PR DESCRIPTION
Update the build-yocto GitHub CI workflow to run debug and performance builds against qcom-distro-catchall instead of the default qcom-distro.

The catchall distro enables all Qualcomm-supported DISTRO_FEATURES and provides broader feature coverage, making it more suitable for debug and performance validations.