### PR TITLE
ci: base.lock: pin meta-qcom-distro for 2.0 RC3

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -20,3 +20,5 @@ overrides:
             commit: d713c99a9ddace090c0efc0ed57022185daa6fb2
         meta-security:
             commit: 596b966a0d047c2f48cb768821558e918ae0c477
+        meta-qcom-distro:
+            commit: 51a70d3dad35d59230974534cd95edbf35b659e2


### PR DESCRIPTION
Pin the revision for meta-qcom-distro for the 2.0 RC3 release, to be reverted once it opens for development again.

Lock updated with: kas lock ci/base.yml:ci/qcom-distro.yml