### PR TITLE
[wrynose] ci: move meta-arm and meta-security to wrynose

### DIFF
--- a/ci/meta-arm.yml
+++ b/ci/meta-arm.yml
@@ -4,7 +4,7 @@ header:
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
-    branch: master
+    branch: wrynose
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -40,7 +40,6 @@ repos:
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
-    branch: master
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
Both layers now provide a wrynose branch containing the same hashes used by our current lock, so no functional changes.