### PR TITLE
ci: workflows/push: drop run-name

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,4 @@
 name: Build on push
-run-name: "${{ github.ref_name }}: ${{ github.event.head_commit.message }}"
 
 on:
   push:


### PR DESCRIPTION
Run-name was added as a way to easily identify if the push job was done on master or wrynose, but github.event.head_commit.message is way too verbose since it includes the entire commit message, so remove it entirely as there is no way to use just the commit subject.