### PR TITLE
ci: workflows/monthly: update runner to qcom-sm-u2404

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sstate-cache-cleanup:
     if: github.repository_owner == 'qualcomm-linux'
-    runs-on: [self-hosted, gen-qlnx-prd-u2404-x64-sm-od-ephem]
+    runs-on: [self-hosted, qcom-sm-u2404, sm-amd64]
     timeout-minutes: 720
     steps:
       - name: Clean up the persistant sstate-cache dir


### PR DESCRIPTION
Change the runner for the monthly sstate clean-up job to use qcom-sm-u2404, as recommended by IT.