### PR TITLE
debug.yml: enable debug symbols

### DIFF
--- a/ci/debug.yml
+++ b/ci/debug.yml
@@ -4,3 +4,5 @@ header:
 local_conf_header:
   debug-build: |
     DEBUG_BUILD = "1"
+    IMAGE_GEN_DEBUGFS = "1"
+    IMAGE_FSTYPES_DEBUGFS = "tar.bz2"


### PR DESCRIPTION
Currently config options in debug.yml does not
produce the debugfs. The lack of debug symbols
does not enable remote gdb based debugging workflows.
The changes enables debug symbols to be produced as part
of the build but not published to artifactory.

Link: https://docs.yoctoproject.org/next/dev-manual/debugging.html#debugging-with-the-gnu-project-debugger-gdb-remotely