### PR TITLE
Enable KVM builds for rb3gen2-core-kit and iq-615-evk

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -302,6 +302,22 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: rb3gen2-core-kit
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: iq-615-evk
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: qcom-armv7a
             distro:
                 name: nodistro


### PR DESCRIPTION
The RB3Gen2 Core Kit and IQ-615-EVK platforms are now ready for KVM testing. 
Update the CI build matrix to enable qcom-distro-kvm builds for these machines 
to provide regular CI coverage with KVM.