### PR TITLE
debug.yml: enable FTrace settings in kernel cmdline

### DIFF
--- a/ci/debug.yml
+++ b/ci/debug.yml
@@ -6,3 +6,7 @@ local_conf_header:
     DEBUG_BUILD = "1"
     IMAGE_GEN_DEBUGFS = "1"
     IMAGE_FSTYPES_DEBUGFS = "tar.bz2"
+
+  cmdline: |
+    KERNEL_CMDLINE_EXTRA_FTRACE = "ftrace=tracing_on trace_buf_size=5M trace_event=timer:timer_expire_entry,timer:timer_expire_exit,timer:hrtimer_cancel,timer:hrtimer_expire_entry,timer:hrtimer_expire_exit,timer:hrtimer_init,timer:hrtimer_start,irq:*,workqueue:*,sched:sched_migrate_task,sched:sched_pi_setprio,sched:sched_switch,sched:sched_wakeup,sched:sched_wakeup_new,power:clock_set_rate,power:clock_enable,power:clock_disable,power:cpu_frequency,regulator:*,thermal:thermal_zone_trip,thermal:thermal_temperature,thermal:cdev_update,rpmh:rpmh_send_msg"
+    KERNEL_CMDLINE_EXTRA:append = " ${KERNEL_CMDLINE_EXTRA_FTRACE}"


### PR DESCRIPTION
  Add FTrace kernel cmdline options to ci/debug.yml for debug builds to enable tracing from early boot.

  ## Problem
  FTrace is off by default. On debug builds, timing-sensitive events (scheduler latency, IRQ storms, thermal throttling, clock/regulator transitions) happen during early init — before userspace can enable tracing — and are lost.

  ## Changes
  - Adds a cmdline section to local_conf_header in ci/debug.yml that appends FTrace options to KERNEL_CMDLINE_EXTRA for debug builds only.
  - The event list is stored in KERNEL_CMDLINE_EXTRA_FTRACE and referenced via ${KERNEL_CMDLINE_EXTRA_FTRACE} to keep the assignment readable.

  ## FTrace Options
  | Option | Reason |
  |---|---|
  | ftrace=tracing_on | Enables the tracer at boot so early-init events are not missed |
  | trace_event | Captures timer, IRQ, workqueue, scheduler, clock, CPU frequency, regulator, thermal, and RPMh events — the subsystems most relevant to platform debug |
  | trace_buf_size=5M | Increases per-CPU ring buffer from 1 MB to 5 MB to reduce data loss under high-frequency event bursts |