### PR TITLE
minkipc: Update tag to v1.2.5 to bring-in multiple fixes

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.5.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.5.bb
@@ -23,7 +23,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93 \
                     file://optee-client/optee_client/LICENSE;md5=69663ab153298557a59c67a60a743e5b \
                     file://optee-test/optee_test/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
-SRCREV_minkipc = "117484de484003637f27c41a9aa379f3b2faa476"
+SRCREV_minkipc = "51e8710144f0851bc59e51f3e32598e00d323eaa"
 SRCREV_opteec = "acb0885c117e73cb6c5c9b1dd9054cb3f93507ee"
 SRCREV_opteet = "1c3d6be5eaa6174e3dbabf60928d15628e39b994"
 


### PR DESCRIPTION
This release brings the following updates:
- Bug fix for libminkteec where memory wasn't being zero-initialized.
- Migrate to using standard libexec paths from GNUInstallDirs during build.
- Add support for PKCS#11 TAs for glymur, kaanapali, qcm2290, sm8750 and hamoa.
- Removing hard-checks for persist partition mounting for platforms like glymur and hamoa where the partition is not yet defined.