### PR TITLE
Enable Kodiak el2 DTBO compilation and FIT DTB support

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -69,6 +69,10 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
     qcom,qcs5430-iot \
     qcom,qcs6490-iot \
 "
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+kodiak-el2] = " \
+    qcom,qcs5430-iot-el2kvm \
+    qcom,qcs6490-iot-el2kvm \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-staging] = " \
     qcom,qcs5430-iot-staging \
     qcom,qcs6490-iot-staging \
@@ -77,6 +81,10 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
     qcom,qcs5430-iot-subtype9 \
     qcom,qcs6490-iot-subtype9 \
 "
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+kodiak-el2] = " \
+    qcom,qcs5430-iot-subtype9-el2kvm \
+    qcom,qcs6490-iot-subtype9-el2kvm \
+"
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+qcs6490-rb3gen2-industrial-mezzanine-staging] = " \
     qcom,qcs5430-iot-subtype9-staging \
     qcom,qcs6490-iot-subtype9-staging \
@@ -84,6 +92,10 @@ FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+qcs6490-
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
     qcom,qcs5430-iot-subtype2 \
     qcom,qcs6490-iot-subtype2 \
+"
+FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine+kodiak-el2] = " \
+    qcom,qcs5430-iot-subtype2-el2kvm \
+    qcom,qcs6490-iot-subtype2-el2kvm \
 "
 FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
     qcom,qcs5430-iot-camx \

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -48,6 +48,9 @@ FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subt
 FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine+monaco-evk-staging] = "qcom,qcs8275-iot-subtype3-staging"
 FIT_DTB_COMPATIBLE[purwa-iot-evk] = "qcom,purwa-evk"
 FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"
+FIT_DTB_COMPATIBLE[qcm6490-idp+kodiak-el2] = " \
+    qcom,qcm6490-idp-el2kvm \
+"
 FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo] = "qcom,apq8064"
 FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410] = "qcom,apq8064-ifc6410"
 FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard] = "qcom,apq8074-dragonboard"

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -11,6 +11,7 @@ KERNEL_DEVICETREE ?= " \
                       "
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+                      qcom/kodiak-el2.dtbo \
                       qcom/kodiak-staging.dtbo \
                       "
 

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-vision-mezzanine-camx.dtbo \
                       qcom/qcs6490-rb3gen2-staging.dtbo \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine-staging.dtbo \
+                      qcom/kodiak-el2.dtbo \
                       qcom/kodiak-staging.dtbo \
                       "
 


### PR DESCRIPTION
KVM support on Kodiak Platforms requires applying `kodiak-el2.dtbo` at boot.
Generate this DTBO and add FIT_DTB_COMPATIBLE entries to allow UEFI to correctly
match and apply this overlay when booting with KVM.