### PR TITLE
kgsl-dlkm: Update to v1.0.2

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.2.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.2.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "885d476b899441cd56ee40e1d51dbd1ae4530e0d"
+SRCREV = "9ab5c108257cf64fe6628c0144765e98f489036f"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.2 brings below fixes:

- Add support for Gen7_15_0 GPU with standard DT bindings.