### PR TITLE
ci: qcom-distro: remove branch settings for meta-virtualization

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -26,7 +26,6 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
-    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach


### PR DESCRIPTION
meta-virtualization now provides a wrynose branch, so remove the custom master branch settings for it and let it use the default wrynose branch name instead.