### PR TITLE
image_types_qcom: include *.img in qcomflash bundle whitelist

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -101,6 +101,7 @@ create_qcomflash_pkg() {
                 -name '*.mbn*' -o \
                 -name '*.melf*' -o \
                 -name '*.fv' -o \
+                -name '*.img' -o \
                 -name 'cdt_*.bin' -o \
                 -name 'logfs_*.bin' -o \
                 -name 'qsahara_*.xml' -o \


### PR DESCRIPTION
## Summary

The boot-firmware deploy loop in `create_qcomflash_pkg`
(`classes-recipe/image_types_qcom.bbclass`) globs `QCOM_BOOT_FILES_SUBDIR`
for a fixed set of file patterns (`*.elf`, `*.mbn*`, `*.melf*`, `*.fv`,
named `*.bin` families, etc.) and copies the matches into the qcomflash
tarball. Boards whose LUN payloads are deployed as raw `*.img` files
are therefore silently dropped from the bundle, even though the
firmware recipe correctly deploys them into `QCOM_BOOT_FILES_SUBDIR`.

This trips up the Thundercomm RUBIK Pi 3 in particular, where LUN 6
holds `rubikpi_config.img`, `devcfg_full.img`, `rubikpi_dtso.img` and
`splash.img`. Future boards that ship raw image partitions will hit
the same gap.

Add `-o -name '*.img'` to the `find` expression, at the same precedence
as the other plain extension globs. The `\( -name '*.elf' ! -name
'abl2esp*.elf' ... \)` group with its exclusions is untouched.

The change is purely additive. Targets that do not deploy any `*.img`
files into `QCOM_BOOT_FILES_SUBDIR` see no behavioural change, no
existing pattern is removed, and no existing file is newly excluded.

This addresses review feedback on
qualcomm-linux/meta-qcom-3rdparty#41
(https://github.com/qualcomm-linux/meta-qcom-3rdparty/pull/41#discussion_r3230762891)
requesting that the fix land here in `meta-qcom` rather than as a
downstream `core-image-base` bbappend.