### PR TITLE
workflows: ensure build_successful checkrun runs if all builds pass

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -448,9 +448,9 @@ jobs:
   build_successful:
     if: |
       always() && github.repository_owner == 'qualcomm-linux' &&
-      (needs.compile.result == 'success' ||
+      ((needs.compile.result == 'success' && needs.compile_warm_up.result == 'success') ||
        (inputs.skip_if_github_cached == true && needs.github-cache-check.outputs.cache_hit == 'true'))
-    needs: [github-cache-check, compile]
+    needs: [github-cache-check, compile_warm_up, compile]
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully


### PR DESCRIPTION
build_successful checkrun indicates to downstream automations that all builds passed and the build artifacts are uploaded to S3. The current criteria for evaluating this condition doesn't hold up if fail-fast is disabled and jobs fail in the compile_warm_up step.


Observed Axiom trigger failures as part of https://github.com/qualcomm-linux/meta-qcom/pull/1900/ since `fail-fast` was disabled for the compile_warm_up step.