### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260513

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260511
-SRCREV ?= "b822a3cc2f27c8a8b35b580e063ce5e618d3c9bd"
+# tag:qcom-6.18.y-20260513
+SRCREV ?= "c9092c6055905903be100bb9e46483d9c523c51b"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260513

Changelog:
FROMLIST: phy: qcom: edp: Initialize swing_pre_emph_cfg for sc7280
FROMLIST: dt-bindings: i2c: qcom,i2c-geni: Document multi-owner controller support
FROMLIST: dmaengine: qcom: gpi: Add lock/unlock TREs for multi-owner I2C transfers
FROMLIST: soc: qcom: geni-se: Keep pinctrl active for multi-owner controllers
FROMLIST: i2c: qcom-geni: Support multi-owner controllers in GPI mode
QCLINUX: arm64: dts: qcom: Add kodiak lite camx overlay dts
PENDING: arm64: dts: qcom: Add EL2 support for Iris for kodiak Add support for IRIS on kodiak when Linux host running at EL2.
QCLINUX: arm64: dts: qcom: Add kodiak lite camx overlay dts
QCLINUX: arm64: dts: qcom: Add kodiak lite camx overlay dts
QCLINUX: qcom-dcc: add lemans register list and move config to header
QCLINUX: qcom-dcc: move talos config to qcom-dcc-talos-config.h
QCLINUX: qcom-dcc: group lemans and monaco SoC IDs with comments
QCLINUX: qcom-dcc: add kodiak register list and move config to header
QCLINUX: qcom-dcc: add pakala register list and move config to header
QCLINUX: qcom.config: enable CONFIG_CMA for qcom chipsets
BACKPORT: drm/msm: use drm_crtc_vblank_waitqueue()
BACKPORT: soc: qcom: ubwc: Add configuration Glymur platform
BACKPORT: soc: qcom: ubwc: Add config for Kaanapali
BACKPORT: drm/msm/dpu: Remove dead-code in dpu_encoder_helper_reset_mixers()
BACKPORT: drm/msm/dpu: fix mixer number counter on allocation
BACKPORT: drm/msm/dpu: bind correct pingpong for quad pipe
BACKPORT: drm/msm/dpu: Add pipe as trace argument
BACKPORT: drm/msm/dpu: handle pipes as array
BACKPORT: drm/msm/dpu: split PIPES_PER_STAGE definition per plane and mixer
BACKPORT: drm/msm/dpu: Use dedicated WB number definition
BACKPORT: drm/msm/dpu: blend pipes per mixer pairs config
BACKPORT: drm/msm/dpu: support SSPP assignment for quad-pipe case
BACKPORT: drm/msm/dpu: support plane splitting in quad-pipe case
BACKPORT: drm/msm/dpu: Enable quad-pipe for DSC and dual-DSI case
BACKPORT: drm/msm/dpu: Add support for Glymur
BACKPORT: drm/msm/dp: Add support for Glymur
BACKPORT: drm/msm/disp: fix kernel-doc warnings
BACKPORT: drm/msm: Switch to use %ptSp
BACKPORT: drm/msm/disp: mdp_format: fix all kernel-doc warnings
BACKPORT: drm/msm/dp: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_cdm.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_ctl.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_cwb.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_dsc.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_dspp.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_intf.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_lm.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_merge3d.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_pingpong.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_sspp.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_top.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_vbif.h: fix all kernel-doc warnings
BACKPORT: drm/msm/dpu: dpu_hw_wb.h: fix all kernel-doc warnings
BACKPORT: Revert "drm/msm/dpu: support plane splitting in quad-pipe case"
BACKPORT: Revert "drm/msm/dpu: Enable quad-pipe for DSC and dual-DSI case"
BACKPORT: drm/msm/dp: Enable support for eDP v1.4+ link rates table
BACKPORT: drm/msm/disp: set num_planes and fetch_mode in INTERLEAVED_RGB_FMT
BACKPORT: drm/msm/disp: set num_planes, fetch_mode and tile_height in INTERLEAVED_RGB_FMT_TILED
BACKPORT: drm/msm/disp: simplify RGB{,A,X} formats definitions
BACKPORT: drm/msm/disp: simplify tiled RGB{,A,X} formats definitions
BACKPORT: drm/msm/disp: pull in common YUV format parameters
BACKPORT: drm/msm/disp: pull in common tiled YUV format parameters
BACKPORT: drm/msm/disp: drop PSEUDO_YUV_FMT_LOOSE_TILED
BACKPORT: drm/msm/dpu: simplify _dpu_format_populate_plane_sizes_*
BACKPORT: drm/msm/dpu: drop redundant num_planes assignment in _dpu_format_populate_plane_sizes*()
BACKPORT: drm/msm/dpu: rewrite _dpu_format_populate_plane_sizes_ubwc()
BACKPORT: drm/msm/dpu: use standard functions in _dpu_format_populate_plane_sizes_ubwc()
BACKPORT: drm/msm/dpu: drop intr_start from DPU 3.x catalog files
BACKPORT: drm/msm/dpu: fix SSPP_UBWC_STATIC_CTRL programming on UBWC 5.x+
BACKPORT: drm/msm/dsi/phy: Add support for Kaanapali
BACKPORT: drm/msm/dsi: Add support for Kaanapali
BACKPORT: drm/msm/dpu: Add interrupt registers for DPU 13.0.0
BACKPORT: drm/msm/dpu: Refactor SSPP to compatible DPU 13.0.0
BACKPORT: drm/msm/dpu: Add Kaanapali SSPP sub-block support
BACKPORT: drm/msm/dpu: Add Kaanapali WB support
BACKPORT: drm/msm/dpu: Add support for Kaanapali DPU
BACKPORT: drm/msm/dpu: correct error messages in RM
BACKPORT: drm/msm/dpu: try reserving the DSPP-less LM first
BACKPORT: drm/msm/dpu: Add DSPP GC driver to provide GAMMA_LUT DRM property
BACKPORT: drm/msm/dpu: Fix smatch warnings about variable dereferenced before check
BACKPORT: Revert "drm/msm/dpu: try reserving the DSPP-less LM first"
BACKPORT: drm/msm/dpu: Don't use %pK through printk (again)
BACKPORT: drm/msm/dpu: simplify bg_alpha selection
BACKPORT: drm/msm/dpu: use full scale alpha in _dpu_crtc_setup_blend_cfg()
BACKPORT: drm/msm: add missing MODULE_DEVICE_ID definitions
BACKPORT: drm/msm/dpu: fix mismatch between power and frequency
BACKPORT: drm/msm/dpu: fix vblank IRQ registration before atomic_mode_set
BACKPORT: drm/msm/dpu: correct DP MST interface configuration
FROMLIST: drm/msm/dp: fix HPD state status bit shift value
FROMLIST:drm/msm/dp: Fix the ISR_* enum values
FROMLIST:drm/msm/dp: Read DPCD and sink count in bridge detect()
FROMLIST:drm/msm/dp: Move link training to atomic_enable()
FROMLIST:drm/msm/dp: Drop EV_USER_NOTIFICATION
FROMLIST:drm/msm/dp: drop event data
FROMLIST:drm/msm/dp: rework HPD handling
FROMLIST:drm/msm/dp: Add sink_count to debug logs
FROMLIST:drm/msm/dp: turn link_ready into plugged
FROMLIST:drm/msm/dp: clear EDID on display unplug
FROMLIST: drm/msm/dp: remove cached drm_edid from panel
FROMLIST: drm/msm/dp: drop deprecated .mode_set() and use .atomic_enable
FROMLIST: drm/msm/dp: break up dp_display_enable into two parts
FROMLIST: drm/msm/dp: re-arrange dp_display_disable() into functional parts
FROMLIST: drm/msm/dp: splite msm_dp_ctrl_config_ctrl() into link parts and stream parts
FROMLIST: drm/msm/dp: extract MISC1_MISC0 configuration into a separate function
FROMLIST: drm/msm/dp: split link setup from source params
FROMLIST: drm/msm/dp: allow dp_ctrl stream APIs to use any panel passed to it
FROMLIST: drm/msm/dp: move the pixel clock control to its own API
FROMLIST: drm/msm/dp: split dp_ctrl_off() into stream and link parts
FROMLIST: drm/msm/dp: make bridge helpers use dp_display to allow re-use
FROMLIST: drm/msm/dp: separate dp_display_prepare() into its own API
FROMLIST: drm/msm/dp: introduce stream_id for each DP panel
FROMLIST: drm/msm/dp: introduce max_streams for DP controller MST support
FROMLIST: drm/msm/dp: Add support for programming p1/p2/p3 register blocks
FROMLIST: drm/msm/dp: use stream_id to change offsets in dp_catalog
FROMLIST: drm/msm/dp: Add catalog support for 3rd/4th stream MST
FROMLIST: drm/msm/dp: add support to send ACT packets for MST
FROMLIST: drm/msm/dp: Add support to enable MST in mainlink control
FROMLIST: drm/msm/dp: no need to update tu calculation for mst
FROMLIST: drm/msm/dp: Add support for MST channel slot allocation
FROMLIST: drm/msm/dp: Add support for sending VCPF packets in DP controller
FROMLIST: drm/msm/dp: Always program MST_FIFO_CONSTANT_FILL for MST use cases
FROMLIST: drm/msm/dp: simplify link and clock disable sequence
FROMLIST: drm/msm/dp: pass panel to display enable/disable helpers
FROMLIST: drm/msm/dp: abstract out the dp_display stream helpers to accept a panel
FROMLIST: drm/msm/dp: replace power_on with active_stream_cnt for dp_display
FROMLIST: drm/msm/dp: Mark the SST bridge disconnected when mst is active
FROMLIST: drm/msm/dp: add an API to initialize MST on sink side
FROMLIST: drm/msm/dp: add dp_display_get_panel() to initialize DP panel
FROMLIST: drm/msm/dp: add prepared to manage link-level operations
FROMLIST: drm/msm/dpu: initialize encoders per stream for DP MST
FROMLIST: drm/msm/dp: initialize dp_mst module for each DP MST controller
FROMLIST: drm/msm/dp: add dp_mst_drm to manage DP MST bridge operations
FROMLIST: drm/msm/dp: wire MST helpers into atomic check and commit paths
FROMLIST: drm/msm/dp: add connector abstraction for DP MST
FROMLIST: drm/msm/dp: add HPD callback for dp MST
FROMLIST: drm/msm/dpu: use msm_dp_get_mst_intf_id() to get the intf id
FROMLIST: drm/msm/dp: Add MST stream support for SA8775P DP controller 0 and 1