### PR TITLE
CAMX: revision update for Lemans, Talos,Kodiak

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.21.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.21.bb
@@ -1,0 +1,121 @@
+SUMMARY = "CamX camera module with core interface utilities, extended image processing libraries, and CHI developer kit including sensor, tuning binaries"
+DESCRIPTION = "This recipe introduces Qualcomm CamX camera module which creates three components.\
+   camxlib: Includes common utilities, image processing algorithms and hardware support libraries extending CamX functionality for platform-specific enhancements. \
+   camx: Core CamX engine that manages camera pipelines, mediates between camera clients and hardware, and exposes structured interfaces to higher-level frameworks. \
+   chicdk: Camera hardware interface development kit delivering a configurable mechanism for use case selection and camera pipeline topology creation. \
+   Includes configurable sensor and tuning binaries, which are essential for enabling full camera functionality."
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
+                    file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
+
+PBT_BUILD_DATE = "260512.2"
+SRC_URI = " \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
+   "
+SRC_URI[camxlib.sha256sum] = "2edfdff2ff6ee08d2c1ff5f7b807235ec4916091337f1467cb40e61337d22017"
+SRC_URI[camx.sha256sum] = "04de35828b2d151564df1088c4a6f60b221620dc1b6439776d1eaae2cc44a773"
+SRC_URI[chicdk.sha256sum] = "0650383e28123b51aea279a8dc84d5f09dd9c1be0aef6032820536315041eb6e"
+
+S = "${UNPACKDIR}"
+
+DEPENDS += "glib-2.0 fastrpc protobuf-camx libxml2 virtual/egl virtual/libgles2 qmi-framework sensinghub qcom-sensors-binaries \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+# Use do_install:append to preserve cmake_do_install
+do_install:append() {
+    install -d ${D}${libdir}
+    install -d ${D}${datadir}/doc/${BPN}
+    install -d ${D}${datadir}/doc/camx-kodiak
+    install -d ${D}${datadir}/doc/chicdk-kodiak
+
+    cp -r ${S}/usr/lib/* ${D}${libdir}
+
+    # Install bin files only if /usr/bin exists in ${S}
+    if [ -d "${S}${bindir}" ]; then
+        install -d ${D}${bindir}
+        cp -r ${S}/usr/bin/* ${D}${bindir}
+    fi
+
+    # Remove unnecessary development symlinks (.so) from the staged image
+    rm -f ${D}${libdir}/camx/kodiak/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/camera/components/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/hw/*${SOLIBSDEV}
+    rm -f ${D}${libdir}/camx/kodiak/camera/*${SOLIBSDEV}
+
+    install -m 0644 ${S}/usr/share/doc/${BPN}/NOTICE ${D}${datadir}/doc/${BPN}
+    install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/${BPN}
+
+    # install camx docs only if /usr/share/doc/camx-kodiak exists in ${S}
+    if [ -d "${S}/usr/share/doc/camx-kodiak" ]; then
+        install -m 0644 ${S}/usr/share/doc/camx-kodiak/NOTICE ${D}${datadir}/doc/camx-kodiak
+        install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/camx-kodiak
+    fi
+
+    # install chicdk docs only if /usr/share/doc/chicdk-kodiak exists in ${S}
+    if [ -d "${S}/usr/share/doc/chicdk-kodiak" ]; then
+        install -m 0644 ${S}/usr/share/doc/chicdk-kodiak/NOTICE ${D}${datadir}/doc/chicdk-kodiak
+        install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/chicdk-kodiak
+    fi
+}
+
+PACKAGE_BEFORE_PN += "camx-kodiak chicdk-kodiak"
+RDEPENDS:${PN} += "chicdk-kodiak"
+RDEPENDS:${PN}-dev += "camxcommon-headers-dev"
+RRECOMMENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual-opencl-icd', '', d)} sensinghub qcom-sensors-binaries"
+
+FILES:camx-kodiak = "\
+    ${libdir}/libcamera_hardware_kodiak*${SOLIBS} \
+    ${libdir}/libcamxexternalformatutils_kodiak*${SOLIBS} \
+    ${libdir}/camx/kodiak/libchilog*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node.eisv*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node.swregistration*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/camera.qcom*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcamera_hardware*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcamxexternalformatutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcom.qti.camx.chiiqutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcom.qti.node.eisv*${SOLIBS} \
+    "
+FILES:chicdk-kodiak = "\
+    ${libdir}/camx/kodiak/com.qti.feature2*${SOLIBS} \
+    ${libdir}/camx/kodiak/libchimldw*${SOLIBS} \
+    ${libdir}/camx/kodiak/com.qualcomm*${SOLIBS} \
+    ${libdir}/camx/kodiak/chiofflinepostproclib*${SOLIBS} \
+    ${libdir}/camx/kodiak/libcommonchiutils*${SOLIBS} \
+    ${libdir}/camx/kodiak/libiccprofile*${SOLIBS} \
+    ${libdir}/camx/kodiak/com.qti.chiusecaseselector*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.node*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/com.qti.sensormodule*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/libshdr3*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/libbanding_correction*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/com.qti.stats.hafoverride*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/*.bin \
+    ${libdir}/camx/kodiak/camera/com.qti.sensor*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/com.qti.chi.*${SOLIBS} \
+    ${bindir}/ \
+    "
+FILES:${PN} = "\
+    ${libdir}/libcamera_metadata_kodiak*${SOLIBS} \
+    ${libdir}/camx/kodiak/*${SOLIBS} \
+    ${libdir}/camx/kodiak/hw/*${SOLIBS} \
+    ${libdir}/camx/kodiak/camera/components/*${SOLIBS} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${libdir}/camx/kodiak/*.cl', '', d)} \
+    "
+FILES:${PN}-dev = "\
+    ${libdir}/*${SOLIBSDEV} \
+    "
+FILES:${PN}-staticdev = "${libdir}/camx/kodiak/*.a"
+
+# Preserve ${PN} naming to avoid ambiguity in package identification.
+DEBIAN_NOAUTONAME:${PN} = "1"
+
+# Algo librarires are pre-compiled, pre-stripped.
+# Skipping QA checks: 'already-stripped' because:
+# - Library files are Pre-stripped  (already-stripped)
+INSANE_SKIP:${PN} = "already-stripped"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.23.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.23.bb
@@ -1,0 +1,30 @@
+PLATFORM = "lemans"
+PBT_BUILD_DATE = "260512.2"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "6b3543e5234205174434ee9db42d7d7fc55958a8ca0f006cce0d2d00a0a96806"
+SRC_URI[camx.sha256sum] = "663fcc6e18e6a7d0bcff67546b0e3805c30c1dd969429b31a3623e733370fac3"
+SRC_URI[chicdk.sha256sum] = "07044c75046a0caf9c16193411748d6d8eae0faf2d8668e321e74cca0279f806"
+SRC_URI[camxcommon.sha256sum] = "b3419ffac8927f1252cd50a15183d93de6ee2ed7a58641f408b7002491ee4369"
+
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
+
+do_install:append() {
+    # Copy json only when /etc folder exists in ${S}
+    if [ -d "${S}/etc" ]; then
+        install -d ${D}${sysconfdir}/camera/test/NHX/
+        cp -r ${S}/etc/camera/test/NHX/*.json ${D}${sysconfdir}/camera/test/NHX/
+    fi
+}
+
+RPROVIDES:${PN} = "camxlib-monaco"
+PACKAGE_BEFORE_PN += "camx-nhx"
+RRECOMMENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual-opencl-icd', '', d)}"
+
+FILES:camx-nhx = "\
+    ${bindir}/nhx.sh \
+    ${sysconfdir}/camera/test/NHX/ \
+"
+
+FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${libdir}/camx/${PLATFORM}/*.cl ${libdir}/camx/${PLATFORM}/libmctf_cl_program.bin', '', d)}"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260512.2"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "becf80216e5655eb0b3927ca9597df8ac0afc38abf55fe7bd166c1cf9a65e503"
+SRC_URI[camx.sha256sum] = "162e480fb2128fa0e8d775f8f84b355147402f2604f058da68f80d3052a60cd9"
+SRC_URI[chicdk.sha256sum] = "9ac9f0131c0ba9d6b9994ea28be1f8966eda91f08986876a296f902df455b28a"
+SRC_URI[camxcommon.sha256sum] = "3e0fd7c97e921bea885c73e8ff17992bd2fbe55297b2d523488fd7a6a9c37078"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.8.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.8.bb
@@ -1,0 +1,30 @@
+SUMMARY = "CamX common headers"
+
+DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
+
+LICENSE = "LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
+
+PBT_BUILD_DATE = "260512.2"
+SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
+SRC_URI[sha256sum] = "186203a3e9d3497b04c00bf8e55a1f368f206ec1bfb94a7a59581e897d0f47dd"
+
+S = "${UNPACKDIR}"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+# Disable configure and compile steps since this recipe uses prebuilt binaries.
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${includedir}/camx/kodiak
+    install -d ${D}${datadir}/doc/${BPN}
+
+    cp -r ${S}/usr/include/*  ${D}${includedir}/
+
+    install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.QCOM-2.txt ${D}${datadir}/doc/${BPN}
+}


### PR DESCRIPTION
camxlib-kodiak: Update to the 1.0.21 revision
- Fix YUV SHDR node buffer negotiation
- Use deep copy to fix localized flicker issue
- Disabling preprocml, postprocml and mlinference nodes.

camxlib-lemans: Update to the 1.0.23 revision
- Added NcLib changes to support LRME.
- Added Non-Bayer sensor support.

camxlib-talos: Update to the 1.0.23 revision
- Adding default tuning binary for Talos target.
- Enable imx577 MIPI 2-Lane sensor support on CSI1 for QCS615

camxcommon-headers: Update to the 1.0.8 revision
Source/header mismatch causes CamX compilation failure. Update the headers tar to align with the sources.