### PR TITLE
CAMX: revision update for Lemans, Talos,Kodiak

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.21.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.21.bb
@@ -8,15 +8,15 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260502"
+PBT_BUILD_DATE = "260512.2"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
    "
-SRC_URI[camxlib.sha256sum] = "18fca4e8ea638eff0de96fddcc1461d82f77f90124e00d6dd5e972d3450d6688"
-SRC_URI[camx.sha256sum] = "46155ae50ebcfc8fc86f904c3e68a1e125db397c51d092519dc4612a64d3ba8b"
-SRC_URI[chicdk.sha256sum] = "a1925d6aad4c1e4c912a90f3a5d4a3948377c0e13866dd33254f553b4ec1c39d"
+SRC_URI[camxlib.sha256sum] = "2edfdff2ff6ee08d2c1ff5f7b807235ec4916091337f1467cb40e61337d22017"
+SRC_URI[camx.sha256sum] = "04de35828b2d151564df1088c4a6f60b221620dc1b6439776d1eaae2cc44a773"
+SRC_URI[chicdk.sha256sum] = "0650383e28123b51aea279a8dc84d5f09dd9c1be0aef6032820536315041eb6e"
 
 S = "${UNPACKDIR}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.23.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.23.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260502"
+PBT_BUILD_DATE = "260512.2"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum]     = "43119d312121b4e4b5588326df6568bf487aa530c6cc26409eefb5a53d1e04ff"
-SRC_URI[camx.sha256sum]        = "07107a3275df5cd6077cecdf2116598181d2d63934c9ecb4191ad20377caabd6"
-SRC_URI[chicdk.sha256sum]      = "7daaaf8601355137ec0323948710ec962fb4d8e5ffe73393971628d5ebf3b966"
-SRC_URI[camxcommon.sha256sum]  = "ed04306b348d141b4c02038860d908eadf6fa4fdf2776f572ec776357ac115ff"
+SRC_URI[camxlib.sha256sum] = "6b3543e5234205174434ee9db42d7d7fc55958a8ca0f006cce0d2d00a0a96806"
+SRC_URI[camx.sha256sum] = "663fcc6e18e6a7d0bcff67546b0e3805c30c1dd969429b31a3623e733370fac3"
+SRC_URI[chicdk.sha256sum] = "07044c75046a0caf9c16193411748d6d8eae0faf2d8668e321e74cca0279f806"
+SRC_URI[camxcommon.sha256sum] = "b3419ffac8927f1252cd50a15183d93de6ee2ed7a58641f408b7002491ee4369"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.22.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.22.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260502"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum]     = "6e1c7895f93c812a55416601415f9c5a255ef7dd62bbefc6587fab905b9aa9d1"
-SRC_URI[camx.sha256sum]        = "cd4b4408b904b633d9d3220887abac5f2bde9556553531de57e622b177d661b9"
-SRC_URI[chicdk.sha256sum]      = "dfc7b4e4baa556720c47b162d392a9662ec929400101c643d3a35dad4408d256"
-SRC_URI[camxcommon.sha256sum]  = "a6071ab6907fb29e469391aa23e3629a73d407d59513d18cb00c60c1d871f497"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260512.2"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "becf80216e5655eb0b3927ca9597df8ac0afc38abf55fe7bd166c1cf9a65e503"
+SRC_URI[camx.sha256sum] = "162e480fb2128fa0e8d775f8f84b355147402f2604f058da68f80d3052a60cd9"
+SRC_URI[chicdk.sha256sum] = "9ac9f0131c0ba9d6b9994ea28be1f8966eda91f08986876a296f902df455b28a"
+SRC_URI[camxcommon.sha256sum] = "3e0fd7c97e921bea885c73e8ff17992bd2fbe55297b2d523488fd7a6a9c37078"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.8.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.8.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260428.2"
+PBT_BUILD_DATE = "260512.2"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "68f08592e3aa60d0510194d4346d941074634371c46c44866c37ede53310ea8d"
+SRC_URI[sha256sum] = "186203a3e9d3497b04c00bf8e55a1f368f206ec1bfb94a7a59581e897d0f47dd"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
camxlib-kodiak: Update to the 1.0.21 revision

Fix YUV SHDR node buffer negotiation
Use deep copy to fix localized flicker issue
Disabling preprocml, postprocml and mlinference nodes.
camxlib-lemans: Update to the 1.0.23 revision

Added NcLib changes to support LRME.
Added Non-Bayer sensor support.
camxlib-talos: Update to the 1.0.23 revision

Adding default tuning binary for Talos target.
Enable imx577 MIPI 2-Lane sensor support on CSI1 for QCS615
camxcommon-headers: Update to the 1.0.8 revision
Source/header mismatch causes CamX compilation failure. Update the headers tar to align with the sources.