### PR TITLE
[backport wrynose] image_types_qcom: include *.img in qcomflash bundle whitelist

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -101,6 +101,7 @@ create_qcomflash_pkg() {
                 -name '*.mbn*' -o \
                 -name '*.melf*' -o \
                 -name '*.fv' -o \
+                -name '*.img' -o \
                 -name 'cdt_*.bin' -o \
                 -name 'logfs_*.bin' -o \
                 -name 'qsahara_*.xml' -o \


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2172