### PR TITLE
qcom-partition-conf: build qcom-ptool natively

### DIFF
--- a/recipes-bsp/partition/qcom-partition-conf_git.bb
+++ b/recipes-bsp/partition/qcom-partition-conf_git.bb
@@ -1,19 +1,16 @@
 SUMMARY = "Partition configuration for Qualcomm devices"
 DESCRIPTION = "GPT partition binaries and QDL scripts for Qualcomm reference devices"
-LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
-SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "7b3365284e2c19f1457e335eb25d545e9a2c08a6"
+require qcom-ptool.inc
 
-INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "qcom-ptool-native"
 
 inherit deploy allarch
 
 do_install[noexec] = "1"
 
 do_deploy() {
-    cd platforms
+    cd ${S}/platforms
     for gpt in `find . -name gpt_main0.bin` ; do
         QCOM_PLATFORM_SUBDIR=${gpt%%/gpt_main0.bin}
         install -d ${DEPLOYDIR}/partitions/${QCOM_PLATFORM_SUBDIR}

--- a/recipes-bsp/partition/qcom-ptool-native.bb
+++ b/recipes-bsp/partition/qcom-ptool-native.bb
@@ -1,0 +1,6 @@
+SUMMARY = "Qualcomm partition tool (build-time CLI)"
+DESCRIPTION = "Python CLI used by qcom-partition-conf to generate per-platform GPT partition tables and QDL flashing scripts."
+
+require qcom-ptool.inc
+
+inherit python_setuptools_build_meta native

--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -1,0 +1,6 @@
+HOMEPAGE = "https://github.com/qualcomm-linux/qcom-ptool"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
+
+SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
+SRCREV = "0909c6ea6e143e94beb8780b64172643d093d3d4"


### PR DESCRIPTION
qcom-ptool's new layout exposes a single qcom-ptool CLI installed via pip, and the Makefile now invokes that CLI. Add a qcom-ptool-native recipe so the CLI lands on the recipe-sysroot-native PATH, DEPENDS on it from qcom-partition-conf (dropping INHIBIT_DEFAULT_DEPS), and switch do_deploy's `cd platforms` to absolute now that ${B} != ${S}. Bump SRCREV to pick that refactor up; the new tip also adds the qcs6490-thundercomm-rubikpi3 machine.

Note one deviation from the suggested wording in the review thread: used python_setuptools_build_meta rather than setuptools3, since setuptools3 still drives setup.py and this repo is pyproject-only.