### PR TITLE
ci: base.lock: update layers to latest (all but meta-oe).

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,19 +3,19 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
+            commit: 3724b93538d3acbec9f48d4c524b51d166071708
         bitbake:
-            commit: cb28befc56d201cace72d70891e731b955fb567f
+            commit: 2b47c2fc40b753e260b63ec419edfd1f85adff90
         meta-arm:
-            commit: f3a2db0561d60aa0401beefe783ee91c8ebb3bcb
+            commit: 1843e9e2eb983cfda6a025e7435c0b855aa94eeb
         meta-openembedded:
             commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
         meta-virtualization:
-            commit: 4ba5825ee16fcded87f4d555b4ed7a7615dc67ac
+            commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: 4feaf103f9525e467fbefddbefd2e55465c88656
+            commit: 132bba376dbcc0caac4749d42437617f586936a1
         meta-selinux:
-            commit: f7306d7af4425553684a860df6f6d0ee66efba31
+            commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:
             commit: a8af24357121dc8614fd98f234b73d55005b0cc9
         meta-security:

--- a/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,4 @@
+# workaround due oe-core 5e97f3c1e2, to be fixed upstream via
+# https://lists.openembedded.org/g/openembedded-core/message/236619
+DEPENDS:append:class-native = " libyaml-native"
+DEPENDS:append:qcom = " libyaml-native"


### PR DESCRIPTION
Just holding meta-oe as there is a known test regression with the updated pipewire, as discussed at https://github.com/qualcomm-linux/meta-qcom/pull/2127.