### PR TITLE
u-boot-qcom: bump SRCREV to 39a47cb4b336

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.04+2026.07-rc1+git"
 
-SRCREV = "a027d749f0ccc0559b3ebdaa22aca3833102c9e9"
+SRCREV = "39a47cb4b336cda637e802c03d84cdac19464728"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Update U-Boot source revision to latest qcom-next commit.

Adds support for exiting Gunyah hypervisor and switching to EL2 during early boot via TrustZone SMC. This enables U-Boot to run at EL2 on platforms booted in a guest environment, allowing use of hypervisors like KVM.

The feature is controlled by CONFIG_QCOM_EL2_GUNYAH_EXIT_SUPPORT and is enabled by default for KLT targets.