### PR TITLE
ci: pin qcom-linux-testkit to a tagged revision for traceability

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -24,6 +24,10 @@ inputs:
   ref:
     description: "Ref in the lava-test-plans repository. Can be a commit ID, branch or tag"
     required: true
+  testkit_ref:
+    description: "Ref in qcom-linux-testkit repository. Can be a CalVer tag (testkit-YYYY.MM.DD) or commit SHA"
+    required: false
+    default: ""
 
 outputs:
   jobmatrix:
@@ -63,6 +67,7 @@ runs:
           INPUTS_KERNEL: ${{ inputs.kernel }}
           INPUTS_TESTPLAN: ${{ inputs.testplan }}
           INPUTS_PREFIX: ${{ inputs.prefix }}
+          INPUTS_TESTKIT_REF: ${{ inputs.testkit_ref }}
         run: |
           set -euo pipefail
           cd lava-test-plans && pip install .
@@ -89,6 +94,9 @@ runs:
           echo "AUTH_HEADER_NAME=Authorization" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "AUTH_HEADER_TOKEN=Q_S3_TOKEN" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          if [ -n "${INPUTS_TESTKIT_REF}" ]; then
+            echo "TEST_DEFINITIONS_REVISION=${INPUTS_TESTKIT_REF}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          fi
           IMAGE_TYPE="core-image-base"
           case "${INPUTS_DISTRO_NAME}" in
             "qcom-distro"*)

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -28,6 +28,10 @@ on:
         type: string
         description: "Ref in lava-test-plans repository: commit, tag or branch"
         required: true
+      testkit_ref:
+        type: string
+        description: "Ref in qcom-linux-testkit repository: CalVer tag or commit SHA"
+        required: true
       project_name:
         required: true
         type: string
@@ -62,6 +66,7 @@ jobs:
           project: ${{ inputs.project_name }}
           testplan: "${{ inputs.distro_name }}/boot"
           ref: ${{ inputs.lava_test_plans_ref }}
+          testkit_ref: ${{ inputs.testkit_ref }}
 
       - name: Print output ID
         env:
@@ -186,6 +191,7 @@ jobs:
           project: ${{ inputs.project_name }}
           testplan: "${{ inputs.distro_name }}/pre-merge"
           ref: ${{ inputs.lava_test_plans_ref }}
+          testkit_ref: ${{ inputs.testkit_ref }}
 
       - name: Print output ID
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ on:
 env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "b9de72b563d8b361b39075c6070d76010040660e"
+  # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
+  TESTKIT_REF: "testkit-2026.05.11"
 
 jobs:
   prepare-env:
@@ -25,6 +27,7 @@ jobs:
           echo "lava-test-plans ref: ${{ env.LAVA_TEST_PLANS_REF }}"
     outputs:
       lava-test-plans-ref: "${{ env.LAVA_TEST_PLANS_REF }}"
+      testkit-ref: "${{ env.TESTKIT_REF }}"
   test-nodistro:
     needs: [prepare-env]
     name: "Test nodistro"
@@ -36,6 +39,7 @@ jobs:
       project_name: "meta-qcom"
       distro_name: "nodistro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
+      testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
   test-qcom-distro:
     needs: [prepare-env]
     name: "Test qcom-distro"
@@ -48,6 +52,7 @@ jobs:
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
+      testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
   test-qcom-distro_linux-qcom-6-18:
     needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-6.18"
@@ -61,6 +66,7 @@ jobs:
       distro_name: "qcom-distro"
       distro_suffix: "_linux-qcom-6.18"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
+      testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
 
   collect-ids:
     name: "Collect Summary artifact IDs"


### PR DESCRIPTION
LAVA jobs were cloning qcom-linux-testkit at tip of tree, making it impossible to reproduce a test run or know exactly which test scripts produced a given result.

Introduce TESTKIT_REF in test.yml as the single place to record the pinned CalVer tag (testkit-YYYY.MM.DD). Thread it through test-distro.yml and the lava-test-plans composite action so it lands in TEST_DEFINITIONS_REVISION inside gh-variables.ini, which the lava-test-plans Jinja2 templates already consume to emit a revision: field on every test definition in the rendered LAVA job YAML.

Set to testkit-2026.05.11 as the initial pinned tag.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>