### PR TITLE
ci: convert compile action in reusable workflow

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -159,6 +159,17 @@ jobs:
         run: |
           ci/kas-container-shell-helper.sh ci/oe-selftest.sh
 
+  compile-env:
+    if: github.repository_owner == 'qualcomm-linux'
+    runs-on: ubuntu-latest
+    outputs:
+      CACHE_DIR: ${{ steps.compile_env.outputs.CACHE_DIR }}
+    steps:
+      - name: Setup compile variables
+        id: compile_env
+        run: |
+          echo "CACHE_DIR=${{env.CACHE_DIR}}" >> $GITHUB_OUTPUT
+
   compile_warm_up:
     needs: [kas-setup, github-cache-check]
     if: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -171,11 +171,10 @@ jobs:
           echo "CACHE_DIR=${{env.CACHE_DIR}}" >> $GITHUB_OUTPUT
 
   compile_warm_up:
-    needs: [kas-setup, github-cache-check]
+    needs: [kas-setup, github-cache-check, compile-env]
     if: |
       github.repository_owner == 'qualcomm-linux' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
-    runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:
       fail-fast: true
       matrix:
@@ -192,28 +191,20 @@ jobs:
           - type: default
             dirname: ""
             yamlfile: ""
-    name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Run kas build
-        uses: ./.github/actions/compile
-        with:
-          machine: ${{matrix.machine}}
-          distro_yaml: ${{matrix.distro.yamlfile}}
-          distro_name: ${{matrix.distro.name}}
-          kernel_yaml: ${{matrix.kernel.yamlfile}}
-          kernel_dirname: ${{matrix.kernel.dirname}}
-          cache_dir: ${{env.CACHE_DIR}}
+    uses: ./.github/workflows/compile.yml
+    with:
+      machine: ${{matrix.machine}}
+      distro_yaml: ${{matrix.distro.yamlfile}}
+      distro_name: ${{matrix.distro.name}}
+      kernel_yaml: ${{matrix.kernel.yamlfile}}
+      kernel_dirname: ${{matrix.kernel.dirname}}
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
 
   compile:
-    needs: [github-cache-check, compile_warm_up]
+    needs: [github-cache-check, compile_warm_up, compile-env]
     if: |
       github.repository_owner == 'qualcomm-linux' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
-    runs-on: [self-hosted, qcom-u2404, amd64]
     strategy:
       fail-fast: false
       matrix:
@@ -416,25 +407,15 @@ jobs:
                 type: capsule
                 dirname: "_capsule"
                 yamlfile: ""
-    name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
-    steps:
-      - name: checkout
-        if: inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Run kas build
-        if: inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')
-        uses: ./.github/actions/compile
-        id: compile_kas
-        with:
-          machine: ${{matrix.machine}}
-          distro_yaml: ${{matrix.distro.yamlfile}}
-          distro_name: ${{matrix.distro.name}}
-          kernel_yaml: ${{matrix.kernel.yamlfile}}
-          kernel_dirname: ${{matrix.kernel.dirname}}
-          cache_dir: ${{env.CACHE_DIR}}
+    uses: ./.github/workflows/compile.yml
+    with:
+      enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
+      machine: ${{matrix.machine}}
+      distro_yaml: ${{matrix.distro.yamlfile}}
+      distro_name: ${{matrix.distro.name}}
+      kernel_yaml: ${{matrix.kernel.yamlfile}}
+      kernel_dirname: ${{matrix.kernel.dirname}}
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
 
   publish_summary:
     needs: [github-cache-check, compile]

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+env:
+  KAS_CLONE_DEPTH: 1
+
 jobs:
   reusable_compile_job:
     runs-on: [self-hosted, qcom-u2404, amd64]

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      enabled:
+        required: false
+        type: boolean
+        default: true
       machine:
         required: true
         type: string
@@ -25,6 +29,7 @@ env:
 
 jobs:
   reusable_compile_job:
+    if: inputs.enabled
     runs-on: [self-hosted, qcom-u2404, amd64]
     name: ${{ inputs.machine }}/${{ inputs.distro_name }}${{ inputs.kernel_dirname }}
     steps:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,20 +1,34 @@
-  name: Run kas for a specific build configuration
-  inputs:
-    machine:
-      required: true
-    distro_yaml:
-      required: true
-    distro_name:
-      required: true
-    kernel_yaml:
-      required: true
-    kernel_dirname:
-      required: true
-    cache_dir:
-      required: true
-  runs:
-    using: "composite"
+on:
+  workflow_call:
+    inputs:
+      machine:
+        required: true
+        type: string
+      distro_yaml:
+        required: true
+        type: string
+      distro_name:
+        required: true
+        type: string
+      kernel_yaml:
+        required: true
+        type: string
+      kernel_dirname:
+        required: true
+        type: string
+      cache_dir:
+        required: true
+        type: string
+
+jobs:
+  reusable_compile_job:
+    runs-on: [self-hosted, qcom-u2404, amd64]
+    name: ${{ inputs.machine }}/${{ inputs.distro_name }}${{ inputs.kernel_dirname }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
         with:
@@ -58,7 +72,7 @@
           mkdir $KAS_WORK_DIR
           $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
 
-      - name: Kas qcom world build
+      - name: Kas build world
         shell: bash
         run: |
           $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -87,6 +87,9 @@ jobs:
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           mv $KAS_WORK_DIR/build/buildstats* .
 
+      - name: Kas build SDK
+        shell: bash
+        run: |
           if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
             # SDK only with the default kernel and qcom-distro
             if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,149 @@
+  name: Run kas for a specific build configuration
+  inputs:
+    machine:
+      required: true
+    distro_yaml:
+      required: true
+    distro_name:
+      required: true
+    kernel_yaml:
+      required: true
+    kernel_dirname:
+      required: true
+    cache_dir:
+      required: true
+  runs:
+    using: "composite"
+    steps:
+      - name: Download kas lockfile
+        uses: actions/download-artifact@v7
+        with:
+          name: kas-lockfile
+          path: ci/
+
+      - name: Download kas-container
+        uses: actions/download-artifact@v7
+        with:
+          name: kas-container
+          path: ${{runner.temp}}
+
+      - name: Setting up kas-container
+        shell: bash
+        run: |
+          KAS_CONTAINER=$RUNNER_TEMP/kas-container
+          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
+          chmod +x $KAS_CONTAINER
+
+      - name: Setup build variables
+        shell: bash
+        run: |
+          # use a monthly sstate cache folder
+          echo "DL_DIR=${INPUTS_CACHE_DIR}/downloads" >> $GITHUB_ENV
+          echo "SSTATE_DIR=${INPUTS_CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
+          echo "KAS_WORK_DIR=${PWD}/../kas" >> $GITHUB_ENV
+          echo "KAS_YAMLS=ci/ci.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}" >> $GITHUB_ENV
+          echo "INPUTS_CACHE_DIR=${INPUTS_CACHE_DIR}" >> $GITHUB_ENV
+          echo "INPUTS_MACHINE=${INPUTS_MACHINE}" >> $GITHUB_ENV
+          echo "INPUTS_DISTRO_YAML=${INPUTS_DISTRO_YAML}" >> $GITHUB_ENV
+          echo "INPUTS_KERNEL_YAML=${INPUTS_KERNEL_YAML}" >> $GITHUB_ENV
+        env:
+          INPUTS_CACHE_DIR: ${{inputs.cache_dir}}
+          INPUTS_MACHINE: ${{ inputs.machine }}
+          INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+          INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
+
+      - name: Dump kas-build yaml
+        shell: bash
+        run: |
+          mkdir $KAS_WORK_DIR
+          $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
+
+      - name: Kas qcom world build
+        shell: bash
+        run: |
+          $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
+          ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+          rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
+          mv $KAS_WORK_DIR/build/buildstats* .
+
+      - name: Kas build images
+        shell: bash
+        run: |
+          $KAS_CONTAINER build ${KAS_YAMLS}
+          ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+          mv $KAS_WORK_DIR/build/buildstats* .
+
+          if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
+            # SDK only with the default kernel and qcom-distro
+            if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then
+              $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
+                --target qcom-multimedia-image \
+                --target qcom-multimedia-proprietary-image
+              ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+              rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
+              mv $KAS_WORK_DIR/build/buildstats* .
+            fi
+          fi
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: buildstats-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
+          path: |
+            buildstats*
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: kas-build-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
+          path: kas-build.yml
+
+      - name: Stage build artifacts for publishing
+        shell: bash
+        run: |
+          # The upload-private-artifact-action runs from a container that
+          # expects file to be relative to our PWD. deploy_dir is outside
+          # that, so we move things around:
+          deploy_dir=../kas/build/tmp/deploy/images/${INPUTS_MACHINE}
+          uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
+          mkdir -p $uploads_dir
+          # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
+          find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
+          # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
+          # Copy *.efi, *.efi and *.vfat as they are useful for debugging
+          find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
+          cp buildstats* kas-build.yml $uploads_dir/
+          if [ -d $deploy_dir/../../sdk ]; then
+            cp $deploy_dir/../../sdk/* $uploads_dir/
+          fi
+        env:
+          INPUTS_MACHINE: ${{ inputs.machine }}
+          INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+          INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
+
+      - name: Upload artifacts to S3 bucket
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        id: upload_s3_artifacts
+        with:
+          path: ./uploads
+          destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
+          s3_bucket: qcom-prd-gh-artifacts
+
+      - name: "Print output"
+        shell: bash
+        id: print-output
+        run: |
+          KERNEL_DIRNAME="${INPUTS_KERNEL_DIRNAME}"
+          BUILDNAME="${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${KERNEL_DIRNAME}"
+          FILENAME="build-url_${BUILDNAME}"
+          echo "${{ steps.upload_s3_artifacts.outputs.url }}" > "${FILENAME}"
+          echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
+        env:
+          INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
+          INPUTS_MACHINE: ${{ inputs.machine }}
+          INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+      - name: Upload build URL
+        uses: actions/upload-artifact@v6
+        with:
+          overwrite: true
+          name: ${{ steps.print-output.outputs.filename }}
+          path: ${{ steps.print-output.outputs.filename }}
+


### PR DESCRIPTION
The actions is composed by several named steps but it appears as a single step in the ci output log and because of this, interpreting the different steps is very difficult.

This will allow all the steps to be displayed in the ci output logs.