### PR TITLE
[Backport wrynose] ci: enable DPDK support via kas fragment and CI job

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -294,6 +294,14 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: iq-9075-evk
+            distro:
+                name: qcom-distro-dpdk
+                yamlfile: ':ci/qcom-distro.yml:ci/dpdk.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: iq-8275-evk
             distro:
                 name: qcom-distro-kvm

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -20,3 +20,5 @@ overrides:
             commit: 7fbd0d7d73d4e252ee31e5260e547cbf17945a82
         meta-security:
             commit: 596b966a0d047c2f48cb768821558e918ae0c477
+        meta-dpdk:
+            commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257

--- a/ci/dpdk.yml
+++ b/ci/dpdk.yml
@@ -1,0 +1,7 @@
+header:
+  version: 14
+
+repos:
+  meta-dpdk:
+    branch: master
+    url: https://git.yoctoproject.org/meta-dpdk

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -51,3 +51,4 @@ target:
   - qcom-multimedia-image
   - qcom-multimedia-proprietary-image
   - qcom-container-orchestration-image
+  - qcom-networking-image


### PR DESCRIPTION
Backport of PR #1902 to wrynose.

Includes:
- ci/qcom-distro: Add the qcom-networking-image
- ci: lock meta-dpdk to latest stable revision
- ci: add kas fragment for dpdk
- ci: build qcom-networking-image with dpdk fragment for iq-9075-evk

(cherry picked from commit 5f14c8555f124821bfc86f42130c8337bcd52d16) (cherry picked from commit e52684148a010716fdf85c25a2b5954eed2c01e9) (cherry picked from commit d3be909c138f8d5896922f0b4323ee2352aceeed) (cherry picked from commit 69bf5d8894b0bcfa9cbdcd5556392c338a197af6)