### PR TITLE
qcom-common: allow overriding EFI_PROVIDER

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -57,7 +57,7 @@ INITRAMFS_MAXSIZE = "655360"
 INITRAMFS_MAXSIZE:pn-initramfs-kerneltest-full-image = "983040"
 
 # Use systemd-boot as the EFI bootloader
-EFI_PROVIDER = "systemd-boot"
+EFI_PROVIDER ?= "systemd-boot"
 
 # Unified Kernel Image (UKI) name
 EFI_LINUX_IMG ?= "linux-${MACHINE}.efi"


### PR DESCRIPTION
Use a weak assignment for EFI_PROVIDER so downstream configs can select a different EFI bootloader when needed (e.g. grub-efi or simply no provider) instead of being forced to use systemd-boot.