### PR TITLE
sensors: upgrade 1.2.0 -> 1.2.1

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.2.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_1.2.1.bb
@@ -5,9 +5,9 @@ validate sensor services functionality through the Sensinghub Interface."
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom-2;md5=f33ba334514c4dfabc6ab7377babb377"
 
-PBT_BUILD_DATE = "260407"
+PBT_BUILD_DATE = "260514.1"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "8d3b87e74895a569af835d4071b497934ab613e0e3d35cf41367df249d0a57d0"
+SRC_URI[sha256sum] = "507652592b326bfeb1b31c4c37f61a5173439bd3dffa7ded72b675f834ea11bb"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Upgraded sensor binaries from 1.2.0 to 1.2.1. Disabled sensors service on iq8275 and iq9075 builds since sensors are not supported on those two targets.