### PR TITLE
[Backport wrynose] iq-9075-evk: Add support for Open Boot firmware (TF-A, OP-TEE and U-Boot) build

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -358,6 +358,14 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: iq-9075-evk-open-fw
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: rb3gen2-core-kit
             distro:
                 name: nodistro

--- a/ci/iq-9075-evk-open-fw.yml
+++ b/ci/iq-9075-evk-open-fw.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+  - ci/meta-arm.yml
+
+machine: iq-9075-evk-open-fw

--- a/conf/machine/iq-9075-evk-open-fw.conf
+++ b/conf/machine/iq-9075-evk-open-fw.conf
@@ -1,0 +1,12 @@
+#@TYPE: Machine
+#@NAME: Qualcomm IQ-9075 Evaluation Kit (EVK) with open boot firmware support
+#@DESCRIPTION: Machine configuration for Qualcomm IQ-9075 Evaluation Kit (EVK)
+
+require conf/machine/iq-9075-evk.conf
+
+EXTRA_IMAGEDEPENDS += "trusted-firmware-a-qcom"
+
+MACHINE_FEATURES += "optee"
+MACHINE_EXTRA_RRECOMMENDS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-arm', 'packagegroup-optee', '', d)}"
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-qcom"

--- a/conf/machine/rb3gen2-core-kit-open-fw.conf
+++ b/conf/machine/rb3gen2-core-kit-open-fw.conf
@@ -9,4 +9,4 @@ EXTRA_IMAGEDEPENDS += "trusted-firmware-a-qcom"
 MACHINE_FEATURES += "optee"
 MACHINE_EXTRA_RRECOMMENDS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-arm', 'packagegroup-optee', '', d)}"
 
-UBOOT_CONFIG = "qcs6490-rb3gen2"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-qcom"

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -1,4 +1,4 @@
-DEPENDS += "qtestsign-native optee-os-qcom"
+DEPENDS += "qtestsign-native optee-os-qcom u-boot-qcom"
 
 SRC_URI += "git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc_blobs;subdir=qc_blobs;branch=main"
 SRCREV_qc_blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
@@ -9,17 +9,19 @@ LIC_FILES_CHKSUM:qcm6490 += "file://${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/LICEN
 COMPATIBLE_MACHINE:qcm6490 = "qcm6490"
 TFA_PLATFORM:qcm6490 = "rb3gen2"
 
-TFA_UBOOT ?= "1"
 TFA_BUILD_TARGET = "bl2 fip"
 TFA_SPD = "opteed"
 
 EXTRA_OEMAKE:append = " \
     BL32=${RECIPE_SYSROOT}/${nonarch_base_libdir}/firmware/tee-raw.bin \
+    BL33=${DEPLOY_DIR_IMAGE}/u-boot.bin \
    "
 
 EXTRA_OEMAKE:append:qcm6490 = " \
     QTISECLIB_PATH=${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/libqtisec.a \
    "
+
+do_compile[depends] += " u-boot-qcom:do_deploy"
 
 do_install:append:qcm6490() {
     export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -6,8 +6,9 @@ SRCREV_qc_blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
 LICENSE += "& LICENSE.qcom"
 LIC_FILES_CHKSUM:qcm6490 += "file://${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/LICENSE;md5=fa83f30385e617b56ef0934f13645621"
 
-COMPATIBLE_MACHINE:qcm6490 = "qcm6490"
+COMPATIBLE_MACHINE = "qcm6490|qcs9100"
 TFA_PLATFORM:qcm6490 = "rb3gen2"
+TFA_PLATFORM:qcs9100 = "lemans_evk"
 
 TFA_BUILD_TARGET = "bl2 fip"
 TFA_SPD = "opteed"
@@ -23,11 +24,14 @@ EXTRA_OEMAKE:append:qcm6490 = " \
 
 do_compile[depends] += " u-boot-qcom:do_deploy"
 
-do_install:append:qcm6490() {
+FIP_ELF_ADDR:qcm6490 = "0x9fc00000"
+FIP_ELF_ADDR:qcs9100 = "0xaf000000"
+
+do_install:append() {
     export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
 
     ${OBJCOPY} -I binary -B aarch64 -O elf64-littleaarch64 ${D}${FIRMWARE_DIR}/fip.bin ${D}${FIRMWARE_DIR}/fip.o
-    ${LD} ${D}${FIRMWARE_DIR}/fip.o -o ${D}${FIRMWARE_DIR}/fip_unsigned.elf -EL -T ${S}/tools/qti/fip-elf.lds --defsym=ELFENTRY=0x9fc00000 -Ttext=0x9fc00000
+    ${LD} ${D}${FIRMWARE_DIR}/fip.o -o ${D}${FIRMWARE_DIR}/fip_unsigned.elf -EL -T ${S}/tools/qti/fip-elf.lds --defsym=ELFENTRY=${FIP_ELF_ADDR} -Ttext=${FIP_ELF_ADDR}
     rm -f ${D}${FIRMWARE_DIR}/fip.o
 
     qtestsign -v6 aboot -o ${D}${FIRMWARE_DIR}/fip.elf ${D}${FIRMWARE_DIR}/fip_unsigned.elf

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
@@ -2,8 +2,10 @@ require recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
 
 PV = "2.14.0-qcom+git"
 
-SRC_TAG = "tag=qcom-next-2.14-20260220"
+SRC_TAG = "tag=qcom-next-2.14-20260507"
 SRC_URI = "git://github.com/qualcomm-linux/trusted-firmware-a.git;protocol=https;name=tfa;nobranch=1;${SRC_TAG}"
-SRCREV_tfa = "78d883ea408d58786287102bc704a5bfce2cbd90"
+SRCREV_tfa = "7336923157d8e55ec6e1111b111d6c1befdb1054"
+
+LIC_FILES_CHKSUM += "file://docs/license.rst;md5=6ed7bace7b0bc63021c6eba7b524039e"
 
 require trusted-firmware-a-qcom.inc

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
@@ -1,9 +1,9 @@
 require recipes-security/optee/optee-os.inc
 
-PV = "4.9.0-qcom+git"
+PV = "4.10.0-qcom+git"
 
-SRC_TAG = "tag=4.9.0"
+SRC_TAG = "tag=qcom-next-4.10-20260507"
 SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;nobranch=1;${SRC_TAG}"
-SRCREV_optee = "c2b0684fcd89929976a8726e6e3af922b48dd2c7"
+SRCREV_optee = "3ea006809a3ef569db4da775600cd2a46206120b"
 
 require optee-qcom.inc

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit-qcom_git.bb
@@ -1,0 +1,25 @@
+require optee-os-qcom_git.bb
+
+SUMMARY = "OP-TEE Trusted OS TA devkit"
+DESCRIPTION = "OP-TEE TA devkit for build TAs"
+HOMEPAGE = "https://www.op-tee.org/"
+
+DEPENDS += "python3-pycryptodome-native"
+DEPENDS:append:toolchain-clang = " lld-native"
+
+do_install() {
+    #install TA devkit
+    install -d ${D}${includedir}/optee/export-user_ta/
+    for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
+        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+    done
+}
+
+do_deploy() {
+        echo "Do not inherit do_deploy from optee-os."
+}
+
+FILES:${PN} = "${includedir}/optee/"
+
+# Build paths are currently embedded
+INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-tadevkit_%.bbappend
@@ -1,4 +1,0 @@
-MACHINE_OPTEE_REQUIRE ?= ""
-MACHINE_OPTEE_REQUIRE:qcom = "optee-qcom.inc"
-
-require ${MACHINE_OPTEE_REQUIRE}

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-qcom.inc
@@ -1,2 +1,3 @@
-COMPATIBLE_MACHINE:qcm6490 = "qcm6490"
+COMPATIBLE_MACHINE = "qcm6490|qcs9100"
 OPTEEMACHINE:qcm6490 = "qcom-kodiak"
+OPTEEMACHINE:qcs9100 = "qcom-lemans"

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-test_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-test_%.bbappend
@@ -1,4 +1,5 @@
-# Machine specific configurations
+DEPENDS:remove:qcom = "optee-os-tadevkit"
+DEPENDS:append:qcom = " optee-os-tadevkit-qcom"
 
 MACHINE_OPTEE_REQUIRE ?= ""
 MACHINE_OPTEE_REQUIRE:qcom = "optee-qcom.inc"

--- a/dynamic-layers/meta-arm/recipes-security/packagegroups/packagegroup-optee.bb
+++ b/dynamic-layers/meta-arm/recipes-security/packagegroups/packagegroup-optee.bb
@@ -3,5 +3,5 @@ SUMMARY = "Packages for the OP-TEE support"
 inherit packagegroup
 
 RRECOMMENDS:${PN} = " \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os-tadevkit optee-client optee-test', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-os-tadevkit-qcom optee-client optee-test', '', d)} \
 "

--- a/recipes-bsp/u-boot/files/tfa-optee.cfg
+++ b/recipes-bsp/u-boot/files/tfa-optee.cfg
@@ -1,0 +1,4 @@
+# Enables support for TF-A based OP-TEE as the open
+# source TrustZone stack on Qcom platforms
+CONFIG_TEE=y
+CONFIG_OPTEE=y

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -11,7 +11,10 @@ SRCREV = "a027d749f0ccc0559b3ebdaa22aca3833102c9e9"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"
-SRC_URI += "file://disable-eficapsule-tool.cfg"
+SRC_URI += " \
+    file://disable-eficapsule-tool.cfg \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'file://tfa-optee.cfg', '', d)} \
+"
 
 python __anonymous() {
     ubootconfig = (d.getVar('UBOOT_CONFIG') or "").split()


### PR DESCRIPTION
Backport PR: https://github.com/qualcomm-linux/meta-qcom/pull/2145 for wrynose