### PR TITLE
Include qupv3fw for QCS615

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
@@ -15,6 +15,7 @@ RRECOMMENDS:${PN}-firmware = " \
     camxfirmware-talos \
     linux-firmware-qcom-qcs615-audio \
     linux-firmware-qcom-qcs615-compute \
+    linux-firmware-qcom-qcs615-qupv3fw \
     linux-firmware-qcom-venus-5.4 \
 "
 RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \

--- a/recipes-bsp/packagegroups/packagegroup-qcs615-ride.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcs615-ride.bb
@@ -13,6 +13,7 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
     linux-firmware-qcom-qcs615-audio \
     linux-firmware-qcom-qcs615-compute \
+    linux-firmware-qcom-qcs615-qupv3fw \
     linux-firmware-qcom-venus-5.4 \
 "
 RDEPENDS:${PN}-hexagon-dsp-binaries = " \


### PR DESCRIPTION
qupv3fw firmware is required for setting up Serial Engines in QUP hardware.