### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260515 v6.18.25

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.21"
+LINUX_VERSION ?= "6.18.25"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260513
-SRCREV ?= "c9092c6055905903be100bb9e46483d9c523c51b"
+# tag:qcom-6.18.y-20260515
+SRCREV ?= "9a4537ba60cc7332c642471323e32f85df771053"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260515

Changelog:
Merge tag 'v6.18.25' into qcom-6.18.y
Revert "FROMLIST: arm64: dts: qcom: x1e80100-lenovo-yoga-slim7x: Add pm8010 camera PMIC with voltage levels for IR and RGB camera"
Revert "FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add on ov02c10 RGB sensor on CSIPHY4"
Revert "FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add pm8010 camera PMIC with voltage levels for IR and RGB camera"
Revert "FROMLIST: arm64: dts: qcom: x1e80100-crd: Add ov08x40 RGB sensor on CSIPHY4"
Revert "FROMLIST: arm64: dts: qcom: x1e80100-crd: Add pm8010 CRD pmic,id=m regulators"
Revert "FROMLIST: arm64: dts: qcom: x1e80100: Add CAMSS block definition"
Revert "FROMLIST: arm64: dts: qcom: x1e80100: Add MIPI CSI PHY nodes"
Revert "FROMLIST: arm64: dts: qcom: x1e80100: Add CCI definitions"
Revert "FROMLIST: arm64: dts: qcom: x1e80100: Add CAMCC block definition"
Revert "FROMLIST: media: qcom: camss: Drop legacy PHY descriptions from x1e"
Revert "FROMLIST: media: qcom: camss: Add support for PHY API devices"
Revert "FROMLIST: media: qcom: camss: Add legacy_phy flag to SoC definition structures"
Revert "FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Allow CSIPHY supplies to be optional"
Revert "FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add iommus minItems: 5"
Revert "FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add support for combo-mode endpoints"
Revert "FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add optional PHY handle definitions"
Revert "FROMLIST: phy: qcom-mipi-csi2: Add a CSI2 MIPI DPHY driver"
Revert "FROMLIST: dt-bindings: phy: qcom: Add CSI2 C-PHY/DPHY schema"
FROMLIST: phy: dphy: Add lane_positions to DPHY config struct
FROMLIST: phy: dphy: Add lane_polarities to DPHY config struct
FROMLIST: phy: dphy: Add clock_lane_position to DPHY config struct
FROMLIST: phy: dphy: Add clock_lane_polarity to DPHY config struct
FROMLIST: dt-bindings: phy: qcom: Add CSI2 C-PHY/DPHY schema
FROMLIST: phy: qcom-mipi-csi2: Add a CSI2 MIPI DPHY driver
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add optional PHY handle definitions
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Add support for combo-mode endpoints
FROMLIST: dt-bindings: media: qcom,x1e80100-camss: Describe iommu entries
FROMLIST: media: qcom: camss: Add support to populate sub-devices
FROMLIST: media: qcom: camss: Add legacy_phy flag to SoC definition structures
FROMLIST: media: qcom: camss: Add support for PHY API devices
FROMLIST: media: qcom: camss: Drop legacy PHY descriptions from x1e
FROMLIST: media: qcom: camss: Add common TPG support
FROMLIST: media: qcom: camss: Add link support for TPG
FROMLIST: media: qcom: camss: tpg: Add TPG support for multiple targets
FROMLIST: dt-bindings: media: Add bindings for qcom,x1p42100-camss
FROMLIST: media: qcom: camss: add support for X1P42100 camss
FROMLIST: arm64: dts: qcom: x1e80100: Add CAMCC block definition
FROMLIST: arm64: dts: qcom: x1e80100: Add CCI definitions
FROMLIST: arm64: dts: qcom: x1e80100: Add CAMSS block definition
FROMLIST: arm64: dts: qcom: x1e80100-crd: Add pm8010 CRD pmic,id=m regulators
FROMLIST: arm64: dts: qcom: x1e80100-crd: Add ov08x40 RGB sensor on CSIPHY4
FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add pm8010 camera PMIC with voltage levels for IR and RGB camera
FROMLIST: arm64: dts: qcom: x1e80100-t14s: Add on ov02c10 RGB sensor on CSIPHY4
FROMLIST: arm64: dts: qcom: x1e80100-lenovo-yoga-slim7x: Add pm8010 camera PMIC with voltage levels for IR and RGB camera
FROMLIST: arm64: dts: qcom: x1e80100-lenovo-yoga-slim7x: Add l7b_2p8 voltage regulator for RGB camera
FROMLIST: arm64: dts: qcom: x1e80100-lenovo-yoga-slim7x: Add ov02c10 RGB sensor on CSIPHY4
FROMLIST: arm64: dts: qcom: x1e80100-dell-inspiron14-7441: Switch on CAMSS RGB sensor
FROMLIST: arm64: dts: qcom: purwa: Add camss node
FROMLIST: arm64: dts: qcom: purwa-iot-evk: Add camss node
FROMLIST: arm64: dts: qcom: monaco-evk: Extract common EVK hardware into shared dtsi
FROMLIST: dt-bindings: arm: qcom: Add monaco-ac-evk support
FROMLIST: arm64: dts: qcom: monaco: Add monaco-ac EVK board
FROMLIST: arm64: dts: qcom: monaco-ac-evk: Add IFP mezzanine
FROMLIST: arm64: dts: qcom: monaco-evk: Enable primary USB controller in host mode
WORKAROUND: arm64: dts: qcom: monaco-evk: Enable Bluetooth support
WORKAROUND: arm64: dts: qcom: Add qref supply for Monaco
FROMLIST: dt-bindings: soc: qcom: eud: Add per-path child nodes for UTMI routing
FROMLIST: usb: misc: qcom_eud: add sysfs attribute for port selection
FROMLIST: usb: misc: qcom_eud: add per-path High-Speed PHY control
FROMLIST: usb: misc: qcom_eud: add per-path role switch support
FROMLIST: usb: misc: qcom_eud: improve enable_store API
FROMLIST: usb: misc: qcom_eud: add host mode coordination
FROMLIST: usb: misc: qcom_eud: fix virtual attach/detach event handling
FROMLIST: arm64: dts: qcom: kodiak: Describe EUD UTMI path using child node
FROMLIST: arm64: dts: qcom: Map USB connector to EUD on Kodiak boards
FROMLIST: wifi: ath12k: fix TLV32 length mask
FROMLIST: wifi: ath12k: refactor HAL TLV32/64 decode helpers
FROMLIST: wifi: ath12k: add HAL ops for monitor TLV header decode and alignment
FROMLIST: wifi: ath12k: add dp_mon support 32-bit TLV headers
FROMLIST: wifi: ath12k: tighten RX monitor TLV bounds check
FROMLIST: wifi: ath12k: allow peer_id 0 in dp peer lookup
FROMLIST: dt-bindings: media: qcom,sm8550-iris: Add X1P42100 compatible
FROMLIST: media: iris: Add hardware power on/off ops for X1P42100
FROMLIST: media: iris: Add platform data for X1P42100
FROMLIST: arm64: dts: qcom: purwa: Override Iris clocks and operating points
FROMLIST: arm64: dts: qcom: purwa-iot-som: enable video
FROMLIST: wifi: ath12k: fix inconsistent arvif state in vdev_create error paths
FROMLIST: wifi: ath12k: fix NULL deref in change_sta_links for unready link
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable 4-lane DisplayPort Alt Mode
FROMGIT: arm64: dts: qcom: hamoa: Fix incomplete Root Port property migration
FROMLIST: dt-bindings: embedded-controller: Add Qualcomm reference device EC description
FROMLIST: platform: arm64: Add driver for EC found on Qualcomm reference devices
FROMLIST: arm64: dts: qcom: x1-crd: Add Embedded controller node
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: Add Embedded controller node
FROMLIST: arm64: defconfig: Enable Qualcomm reference device EC driver
WORKAROUND: arm64: dts: qcom: purwa-iot-evk: support Bluetooth over both USB and UART
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable 4-lane DisplayPort Alt Mode
QCLINUX: arm64: dts: qcom: add CAMX overlay DTS for Purwa