### PR TITLE
TEMP: NO MERGE: linux-firmware: install Cologne firmware path

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-9075-evk.bb
@@ -9,7 +9,7 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a663 linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sa8775p-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850 linux-firmware-ath12k-qcc2072', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066 linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn685x linux-firmware-qca-wcn7850 linux-firmware-qca-qcc2072', '', d)} \
     camxfirmware-lemans \
     linux-firmware-qcom-sa8775p-audio \

--- a/recipes-kernel/linux-firmware/linux-firmware-ath12k-qcc2072.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-ath12k-qcc2072.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Create ath12k QCC2072 firmware directory"
+LICENSE = "CLOSED"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/firmware/ath12k/QCC2072/hw1.0
+}
+
+FILES:${PN} += " \
+    ${nonarch_base_libdir}/firmware/ath12k \
+    ${nonarch_base_libdir}/firmware/ath12k/QCC2072 \
+    ${nonarch_base_libdir}/firmware/ath12k/QCC2072/hw1.0 \
+"
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -14,3 +14,8 @@ inherit_defer ${ALTERNATIVES_CLASS}
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin${@fw_compr_file_suffix(d)}"
+
+do_install:append:rb3gen2-core-kit() {
+    install -d ${D}${nonarch_base_libdir}/firmware/ath12k/QCC2072/hw1.0
+}
+FILES:${PN}:append:rb3gen2-core-kit = " ${nonarch_base_libdir}/firmware/ath12k/QCC2072/"


### PR DESCRIPTION
Install /lib/firmware/ath12k/QCC2072/hw1.0 for engineering META to include firmware builds.