### PR TITLE
[Backport wrynose] ci: github: drop leftovers

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -12,10 +12,6 @@ inputs:
     required: true
   cache_dir:
     required: true
-outputs:
-  url:
-    description: Location of the published binaries
-    value: ${{ steps.upload_artifacts.outputs.url }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -50,13 +50,11 @@ runs:
         echo "INPUTS_MACHINE=${INPUTS_MACHINE}" >> $GITHUB_ENV
         echo "INPUTS_DISTRO_YAML=${INPUTS_DISTRO_YAML}" >> $GITHUB_ENV
         echo "INPUTS_KERNEL_YAML=${INPUTS_KERNEL_YAML}" >> $GITHUB_ENV
-        echo "INPUTS_SDK=${INPUTS_SDK}" >> $GITHUB_ENV
       env:
         INPUTS_CACHE_DIR: ${{inputs.cache_dir}}
         INPUTS_MACHINE: ${{ inputs.machine }}
         INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
         INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
-        INPUTS_SDK: ${{ inputs.sdk }}
 
     - name: Dump kas-build yaml
       shell: bash

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -194,8 +194,6 @@ jobs:
       github.repository_owner == 'qualcomm-linux' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: [self-hosted, qcom-u2404, amd64]
-    outputs:
-      url: ${{ steps.compile_kas.outputs.url }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2191 to wrynose.
