### PR TITLE
CAMX: revision update for Lemans, Talos,Kodiak

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.22.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.22.bb
@@ -8,15 +8,15 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260512.2"
+PBT_BUILD_DATE = "260515"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
    "
-SRC_URI[camxlib.sha256sum] = "2edfdff2ff6ee08d2c1ff5f7b807235ec4916091337f1467cb40e61337d22017"
-SRC_URI[camx.sha256sum] = "04de35828b2d151564df1088c4a6f60b221620dc1b6439776d1eaae2cc44a773"
-SRC_URI[chicdk.sha256sum] = "0650383e28123b51aea279a8dc84d5f09dd9c1be0aef6032820536315041eb6e"
+SRC_URI[camxlib.sha256sum] = "51cc525d7cf9572b890ea9576fcb1a97fb3d7670f1ff4db368c365fa07dcde60"
+SRC_URI[camx.sha256sum] = "2477d93fc5da81806086d252624787b5d6c330cfbfcdcf9373330381179005a0"
+SRC_URI[chicdk.sha256sum] = "d328d0889417c28bc2ff88a20a7ddf020e0123db1a05399a977a8490798c9256"
 
 S = "${UNPACKDIR}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.24.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.24.bb
@@ -1,12 +1,12 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260512.2"
+PBT_BUILD_DATE = "260515"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum] = "6b3543e5234205174434ee9db42d7d7fc55958a8ca0f006cce0d2d00a0a96806"
-SRC_URI[camx.sha256sum] = "663fcc6e18e6a7d0bcff67546b0e3805c30c1dd969429b31a3623e733370fac3"
-SRC_URI[chicdk.sha256sum] = "07044c75046a0caf9c16193411748d6d8eae0faf2d8668e321e74cca0279f806"
-SRC_URI[camxcommon.sha256sum] = "b3419ffac8927f1252cd50a15183d93de6ee2ed7a58641f408b7002491ee4369"
+SRC_URI[camxlib.sha256sum] = "15a96f7e3074a937f218d409ad068dba693eebc9ce518bf867399e6faf454e34"
+SRC_URI[camx.sha256sum] = "2c8d668138e2c81fee8179e3f71fc35c244f5b353bb83386bc3e5f3523263b9e"
+SRC_URI[chicdk.sha256sum] = "2770e377c159f25fb1bd656754987920f9439efb2233ad49135077808e073e4f"
+SRC_URI[camxcommon.sha256sum] = "ec9910a6b243af5518e748cb93b525bed9072a124d2cb87abfc1f61566a34b28"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.23.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260512.2"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum] = "becf80216e5655eb0b3927ca9597df8ac0afc38abf55fe7bd166c1cf9a65e503"
-SRC_URI[camx.sha256sum] = "162e480fb2128fa0e8d775f8f84b355147402f2604f058da68f80d3052a60cd9"
-SRC_URI[chicdk.sha256sum] = "9ac9f0131c0ba9d6b9994ea28be1f8966eda91f08986876a296f902df455b28a"
-SRC_URI[camxcommon.sha256sum] = "3e0fd7c97e921bea885c73e8ff17992bd2fbe55297b2d523488fd7a6a9c37078"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.24.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.24.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260515"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "5ef124eeb3b3eae5ca54651820ba00e004aca6b6aa860fb37d86485ed6489b10"
+SRC_URI[camx.sha256sum] = "9bd108e58fc128c76d429c75907c765f5fdf23d1f467c5398b31dd70b10d963e"
+SRC_URI[chicdk.sha256sum] = "41f783d9614177bc61c0b8f95f8ff347af348d867fb708c670bc84473cb8dea8"
+SRC_URI[camxcommon.sha256sum] = "5b0aefeb4737474f23bf3fa1168ad4da33f528cace047ea82aac79931657a24c"

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.9.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.9.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260512.2"
+PBT_BUILD_DATE = "260515"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "186203a3e9d3497b04c00bf8e55a1f368f206ec1bfb94a7a59581e897d0f47dd"
+SRC_URI[sha256sum] = "4b7f8da6a991ca6c1ca127838fe9a713dd9bdfcae8d848d97b44caf8fa51dfec"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
camxlib-kodiak: Update to the 1.0.22 revision
- Avoid unnecessary packaging of static libraries to reduce tarball size.

camxlib-talos/lemans: Update to the 1.0.24 revision
- Avoid unnecessary packaging of static libraries to reduce tarball
  size.
- Enable MFNR pipeline (segment XML restructuring, TF activation, IPE
  offset handling, registrationalgo integration).
- Fix BPS metadata posting, input propagation, RDI dimensions, and
  anchor selection.
- Simplify HFR pipeline topology for better support.

camxcommon-headers: Update to the 1.0.9 revision
- Source/header mismatch causes CamX compilation failure. Update the headers tar to align with the sources.