### PR TITLE
tqftpserv: upgrade 1.1.1 -> 1.2

### DIFF
--- a/recipes-support/tqftpserv/tqftpserv_1.2.bb
+++ b/recipes-support/tqftpserv/tqftpserv_1.2.bb
@@ -9,7 +9,7 @@ DEPENDS = "qrtr zstd"
 
 inherit systemd meson pkgconfig
 
-SRCREV = "443c82aadae2862dc7c12af48ac0b900f4bb0fe7"
+SRCREV = "b6bb92d40cfffe28621abcf7bfaa6d99beea46cb"
 SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https;tag=v${PV} \
 "
 


### PR DESCRIPTION
Protocol-related fixes and improved translation paths for compatibility with broader set of platforms and modems.

- Sanity checks and cleanups
- tftp: ACK short DATA packets in WRQ window mode
- Fix build for Android
- translate: add persistent path for read-write and fix read-only search path
- translate: verify asprintf return value
- translate: support /readonly/vendor/firmware/ paths
- fix: add path validation in tqftpserv.c