### PR TITLE
recipes-connectivity: Update sigma-dut revision

### DIFF
--- a/recipes-connectivity/sigma-dut/sigma-dut_git.bb
+++ b/recipes-connectivity/sigma-dut/sigma-dut_git.bb
@@ -1,12 +1,12 @@
 SUMMARY = "WFA certification testing tool for QCA devices."
 HOMEPAGE = "https://github.com/qualcomm/sigma-dut"
 LICENSE = "BSD-3-Clause-Clear"
-LIC_FILES_CHKSUM = "file://README;md5=edb3527809487b74b4d4a7e02b05acf0"
+LIC_FILES_CHKSUM = "file://README;md5=e877b35748195c6ab87bf2d1ebed9a89"
 
 SRC_URI = "git://github.com/qualcomm/sigma-dut.git;branch=master;protocol=https"
 
 PV = "1.11+git"
-SRCREV = "21f3bb1c426367d9f480acb4f5f011dd0aa17875"
+SRCREV = "0f1913a10a122188984e1b18c0ff3aa0733df7ab"
 
 DEPENDS = "libnl"
 


### PR DESCRIPTION
Adds various mac80211 STA/AP, HE/MBO, EHT/MLO, P2P, and TWT fixes and feature updates, plus header sync and minor parameter cleanups.

Also adds support for using the ip command as a replacement for ifconfig.

Update LIC_FILES_CHKSUM due to changes in README reflecting updated
copyright statements.

Please refer to https://github.com/qualcomm-linux/meta-qcom/pull/1439 for more details.

CRs-Fixed: 4540875