### PR TITLE
camx-dlkm: Update camx driver to v1.0.2

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.2.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.2.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
 "
 
-SRCREV = "3dac889d25682686d5d6990b0a62e4cd699c8cd9"
+SRCREV = "60755e6a8d744d5629d1b4d07237179a238b6778"
 
 inherit module
 


### PR DESCRIPTION
This tag v1.0.2 brings a below updates:

- Fix gpio_request_one EBUSY on kernel 7.1 shared GPIO

Tag v1.0.1 brings a below updates:

- Add cpas support for v695_100.
- Fix dma_fence lock access for kernel 7.1-rc2.
- Fix of_get_named_gpio for kernel 7.1-rc2.
 