### PR TITLE
iq-x7181-evk: add x1 el2 DTBO building and FIT DTB mapping

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -43,6 +43,8 @@ FIT_DTB_COMPATIBLE[qcom_sm8750-mtp] = "sm8750-mtp"
 # ---------- hamoa ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk] = \
     "hamoa-iot-evk hamoa-iot-evk-camera-imx577"
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-el2kvm] = \
+    "hamoa-iot-evk hamoa-iot-evk-camera-imx577 x1-el2"
 
 # ---------- purwa ----------
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-el2kvm] = "purwa-iot-evk x1-el2"

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -9,6 +9,7 @@ MACHINE_FEATURES += "efi pci tpm2"
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \
                       qcom/hamoa-iot-evk-camera-imx577.dtbo \
+                      qcom/x1-el2.dtbo \
                       "
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels


### PR DESCRIPTION
KVM support on IQ-X7181 Evaluation Kit requires applying the el2 DTBO at boot. Add FIT_DTB_COMPATIBLE entries to allow UEFI to correctly match and apply the `x1-el2.dtbo` overlay when booting with KVM.

Generated ITS file overview
```
$ cat build/tmp/deploy/images/iq-x7181-evk/qclinux-fit-image.its
/dts-v1/;

/ {
        description = "Kernel fitImage for Qualcomm Linux Reference Distro/7.0+git/iq-x7181-evk";
        #address-cells = <1>;
        images {
                fdt-qcom-metadata.dtb {
                        description = "Flattened Device Tree blob";
                        type = "qcom_metadata";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/hamoa_mainline/build/tmp/work/iq_x7181_evk-qcom-linux/linux-qcom-next/7.0+git/linux-qcom-next-7.0+git/arch/arm64/boot/dts/qcom/qcom-metadata.dtb");
                        arch = "arm64";
                };
                fdt-x1-el2.dtbo {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/hamoa_mainline/build/tmp/work/iq_x7181_evk-qcom-linux/linux-qcom-next/7.0+git/linux-qcom-next-7.0+git/arch/arm64/boot/dts/qcom/x1-el2.dtbo");
                        arch = "arm64";
                };
                fdt-hamoa-iot-evk.dtb {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/hamoa_mainline/build/tmp/work/iq_x7181_evk-qcom-linux/linux-qcom-next/7.0+git/linux-qcom-next-7.0+git/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dtb");
                        arch = "arm64";
                };
                fdt-hamoa-evk-camx.dtbo {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/hamoa_mainline/build/tmp/work/iq_x7181_evk-qcom-linux/linux-qcom-next/7.0+git/linux-qcom-next-7.0+git/arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
                        arch = "arm64";
                };
                fdt-hamoa-iot-evk-camera-imx577.dtbo {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/hamoa_mainline/build/tmp/work/iq_x7181_evk-qcom-linux/linux-qcom-next/7.0+git/linux-qcom-next-7.0+git/arch/arm64/boot/dts/qcom/hamoa-iot-evk-camera-imx577.dtbo");
                        arch = "arm64";
                };
        };
        configurations {
                conf-1 {
                        description = "FDT Blob";
                        fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-iot-evk-camera-imx577.dtbo";
                        compatible = "qcom,hamoa-evk";
                };
                conf-2 {
                        description = "FDT Blob";
                        fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-iot-evk-camera-imx577.dtbo", "fdt-x1-el2.dtbo";
                        compatible = "qcom,hamoa-evk-el2kvm";
                };
                conf-3 {
                        description = "FDT Blob";
                        fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-evk-camx.dtbo";
                        compatible = "qcom,hamoa-evk-camx";
                };
        };
};
```
**Related PR**: https://github.com/qualcomm-linux/qcom-dtb-metadata/pull/89

KVM Boot log:
```
root@iq-x7181-evk:~# dmesg | grep kvm
[    0.093554] kvm [1]: nv: 570 coarse grained trap handlers
[    0.093691] kvm [1]: nv: 710 fine grained trap handlers
[    0.093775] kvm [1]: IPA Size Limit: 44 bits
[    0.093785] kvm [1]: GICv4 support disabled
[    0.093786] kvm [1]: GICv3: no GICV resource entry
[    0.093786] kvm [1]: disabling GICv2 emulation
[    0.093801] kvm [1]: GIC system register CPU interface enabled
[    0.093807] kvm [1]: vgic interrupt IRQ9
[    0.093830] kvm [1]: Broken CNTVOFF_EL2, trapping virtual timer
[    0.093835] kvm [1]: VHE mode initialized successfully
root@iq-x7181-evk:~# ls -alh /dev/kvm
crw-rw-rw- 1 root kvm 10, 232 Mar 13 15:35 /dev/kvm
```