### PR TITLE
ci: u-boot: enable qcom-distro for U-Boot builds

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -353,32 +353,32 @@ jobs:
                 yamlfile: ""
           - machine: qcs615-ride
             distro:
-                name: nodistro
-                yamlfile: ''
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
             kernel:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit
             distro:
-                name: nodistro
-                yamlfile: ''
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
             kernel:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: iq-9075-evk
             distro:
-                name: nodistro
-                yamlfile: ''
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
             kernel:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: iq-615-evk
             distro:
-                name: nodistro
-                yamlfile: ''
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
             kernel:
                 type: u-boot-qcom-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom"


### PR DESCRIPTION
U-Boot nightly builds currently use the 'nodistro' configuration.
However, 'nodistro' does not support generating the qcom-multimedia
image, which is required for validating multimedia features.

Multimedia testing is performed using the qcom-multimedia image,
which is based on the 'qcom-distro' environment. This creates a
mismatch between CI build configuration and the actual test setup.

Switch CI builds to 'qcom-distro' for supported QCOM machines to
enable qcom-multimedia image generation and align CI builds with
multimedia validation requirements.