### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260519 v6.18.25

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -14,8 +14,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260515
-SRCREV ?= "9a4537ba60cc7332c642471323e32f85df771053"
+# tag:qcom-6.18.y-20260519
+SRCREV ?= "6964936c9bfc3337aa8ba8a0fb25021d06e5ce04"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260519

Changelog:
FROMLIST: wifi: ath12k: fix memory leak in ath12k_wifi7_dp_rx_h_verify_tkip_mic()
FROMLIST: wifi: ath11k: fix invalid data access in ath11k_dp_rx_h_undecap_nwifi
FROMLIST: wifi: ath11k: add MSDU length validation for TKIP MIC error
Revert "FROMLIST: coresight-tgu: add reset node to initialize"
Revert "FROMLIST: coresight-tgu: add timer/counter functionality for TGU"
Revert "FROMLIST: coresight-tgu: add support to configure next action"
Revert "FROMLIST: coresight-tgu: Add TGU decode support"
Revert "FROMLIST: coresight-tgu: Add signal priority support"
Revert "FROMLIST: coresight: Add coresight TGU driver"
Revert "FROMLIST: dt-bindings: arm: Add support for Coresight TGU trace"
FROMLIST: dt-bindings: arm: Add support for Qualcomm TGU trace
FROMLIST: qcom-tgu: Add TGU driver
FROMLIST: qcom-tgu: Add signal priority support
FROMLIST: qcom-tgu: Add TGU decode support
FROMLIST: qcom-tgu: Add support to configure next action
FROMLIST: qcom-tgu: Add timer/counter functionality for TGU
FROMLIST: qcom-tgu: Add reset node to initialize
QCLINUX: qcom.config: Rename CONFIG_CORESIGHT_TGU to CONFIG_QCOM_TGU
FROMLIST: arm64: dts: qcom: purwa: Add EL2 overlay for purwa-iot-evk
PENDING: dt-bindings: media: qcom: venus: add iommu-map support
PENDING: media: qcom: venus: support PAS boot and flexible IOMMU handling
PENDING: arm64: dts: qcom: talos: enable video codec on Talos
