### PR TITLE
ci: set console TERM via kernel cmdline to avoid boot delay

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -3,4 +3,4 @@ header:
 
 local_conf_header:
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " quiet"
+    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"


### PR DESCRIPTION
By default, systemd attempts to auto-detect the terminal type of /dev/console in order to set the TERM variable appropriately.

On IQ-9075, the terminal capability query for /dev/console blocks for ~0.5s and eventually fails with "Operation not supported". This introduces unnecessary delay in the boot path.

Setting "systemd.tty.term.console=linux" kernel command line parameter avoids the probing step and ensures a deterministic TERM configuration, improving boot time.

On IQ-9075, this reduces console detection latency by ~0.5s per boot.