### PR TITLE
weston-init: Enable early Weston startup using DRM device trigger

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -5,6 +5,7 @@ DEFAULTBACKEND:qcom ?= "drm"
 SRC_URI:append:qcom = " \
     file://additional-devices.conf \
     file://weston-start.sh \
+    file://0001-weston-init-Enable-early-Weston-startup-using-DRM-de.patch \
 "
 
 do_install:append:qcom() {


### PR DESCRIPTION
Modify weston.service to start Weston earlier in boot by removing default system dependencies and triggering startup based on /dev/dri/card0 availability.

Changes:
- Drop systemd-user-sessions, DBus, and graphical.target dependencies
- Disable DefaultDependencies to avoid sysinit delay
- Start Weston after dev-dri-card0.device
- Move ordering to Before=multi-user.target
- Run Weston as root to remove dependency on user sessions
- Set XDG_RUNTIME_DIR explicitly for root execution
- Create /tmp/.X11-unix with proper permissions via ExecStartPre

Motivation:
Waiting for sysinit.target and user-session dependencies delays Weston startup significantly. Starting Weston based on DRM device readiness enables earlier display bring-up and improves boot KPIs.

Impact:
- Reduces display start latency
- Enables early compositor availability
- Removes unnecessary runtime dependencies

Tested:
- Verified Weston starts immediately after /dev/dri/card0 creation
- Confirmed display availability earlier in boot timeline
- No dependency failures observed during startup