### PR TITLE
meta-qcom: add DTSO and fit compatible for rb3gen2 industrial mezzanine M.2 QCC2072 variant

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -84,6 +84,8 @@ FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype13] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine qcs6490-rb3gen2-industrial-mezzanine-m2-cologne"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -86,6 +86,8 @@ FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype13] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine qcs6490-rb3gen2-industrial-mezzanine-bt-uart"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -10,6 +10,7 @@ MACHINE_FEATURES += "efi m2connector pci tpm2 phone"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine.dtbo \
+                      qcom/qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo \
                       qcom/qcs6490-rb3gen2-vision-mezzanine.dtbo \
                       "
 

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -10,6 +10,7 @@ MACHINE_FEATURES += "efi m2connector pci tpm2 phone"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine.dtbo \
+                      qcom/qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtbo \
                       qcom/qcs6490-rb3gen2-vision-mezzanine.dtbo \
                       "
 


### PR DESCRIPTION
Add qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo to KERNEL_DEVICETREE for dtbo generation
Add qcs6490-iot-subtype13 compatible strings for M.2 QCC2072 on qcs6490-rb3gen2 industrial
mezzanine board to ensure the correct DTB is selected