### PR TITLE
[Backport wrynose] workflows: ensure build_successful checkrun runs only if all builds pass

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -435,17 +435,10 @@ jobs:
           key: build-success-${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.github-cache-check.outputs.run_hash }}
 
   build_successful:
-    if: |
-      always() && github.repository_owner == 'qualcomm-linux' &&
-      (needs.compile.result == 'success' ||
-       (inputs.skip_if_github_cached == true && needs.github-cache-check.outputs.cache_hit == 'true'))
-    needs: [github-cache-check, compile]
+    if: github.repository_owner == 'qualcomm-linux'
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully
         run: |
-          if [ "${{ needs.github-cache-check.outputs.cache_hit }}" = "true" ]; then
-            echo "Build skipped: Run cache recorded a previous successful build for the current input hash and workflow"
-          else
-            echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"
-          fi
+          echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"


### PR DESCRIPTION
The build_successful checkrun indicates to downstream automations that all builds passed and the build artifacts are uploaded to S3. At present, it reports success even if the builds didn't run because of caching. This reverts the change made to the build_successful checkrun in #2098 to fix this issue.

Observed this issue as part of the nightly workflow https://github.com/qualcomm-linux/meta-qcom/actions/runs/26008497553

(cherry picked from commit 662b8f05c869804d7b8a8f70b256472cfeb49fec)