### PR TITLE
packagegroup-hamoa-iot-evk:Include camxfirmware in firmware packagegroup

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-hamoa-iot-evk.bb
@@ -11,6 +11,7 @@ RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-g705 linux-firmware-qcom-x1e80100-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca61x4-usb linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855 linux-firmware-ath12k-wcn7850', '', d)} \
+    camxfirmware-hamoa \
     linux-firmware-qcom-x1e80100-audio \
     linux-firmware-qcom-x1e80100-compute \
     linux-firmware-qcom-vpu \


### PR DESCRIPTION
Add camxfirmware-hamoa, firmware required to support Qualcomm Camera X (CamX) on the board.