### PR TITLE
iq-x5121-evk: add x1 el2 DTBO building and FIT DTB mapping

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -44,6 +44,9 @@ FIT_DTB_COMPATIBLE[qcom_sm8750-mtp] = "sm8750-mtp"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk] = \
     "hamoa-iot-evk hamoa-iot-evk-camera-imx577"
 
+# ---------- purwa ----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-el2kvm] = "purwa-iot-evk x1-el2"
+
 # ---------- lemans ----------
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
     "lemans-evk lemans-evk-camera-csi1-imx577"

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -8,6 +8,7 @@ MACHINE_FEATURES += "efi pci"
 
 KERNEL_DEVICETREE ?= " \
     qcom/purwa-iot-evk.dtb \
+    qcom/x1-el2.dtbo \
     "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
KVM support on IQ-X5121 Evaluation Kit requires applying the el2 DTBO at boot. Add FIT_DTB_COMPATIBLE entries to allow UEFI to correctly match and apply the x1-el2.dtbo(shared the same one with IQ-X7181 #2234 ) overlay when booting with KVM.

Generated ITS file overview
```
$ cat build/tmp/deploy/images/iq-x5121-evk/qclinux-fit-image.its
/dts-v1/;

/ {
        description = "Kernel fitImage for Qualcomm Linux Reference Distro/7.0+git/iq-x5121-evk";
        #address-cells = <1>;
        images {
                fdt-qcom-metadata.dtb {
                        description = "Flattened Device Tree blob";
                        type = "qcom_metadata";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/purwa-mainline/build/tmp/work/iq_x5121_evk-qcom-linux/linux-qcom-next/7.0+git/build/arch/arm64/boot/dts/qcom/qcom-metadata.dtb");
                        arch = "arm64";
                };
                fdt-x1-el2.dtbo {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/purwa-mainline/build/tmp/work/iq_x5121_evk-qcom-linux/linux-qcom-next/7.0+git/build/arch/arm64/boot/dts/qcom/x1-el2.dtbo");
                        arch = "arm64";
                };
                fdt-purwa-iot-evk.dtb {
                        description = "Flattened Device Tree blob";
                        type = "flat_dt";
                        compression = "none";
                        data = /incbin/("/local/mnt/workspace/xinlon/work/purwa-mainline/build/tmp/work/iq_x5121_evk-qcom-linux/linux-qcom-next/7.0+git/build/arch/arm64/boot/dts/qcom/purwa-iot-evk.dtb");
                        arch = "arm64";
                };
        };
        configurations {
                conf-1 {
                        description = "FDT Blob";
                        fdt = "fdt-purwa-iot-evk.dtb";
                        compatible = "qcom,purwa-evk";
                };
                conf-2 {
                        description = "FDT Blob";
                        fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo";
                        compatible = "qcom,purwa-evk-el2kvm";
                };
        };
};
```

KVM Boot log:
```
root@iq-x5121-evk:~# dmesg | grep kvm
[    0.092851] kvm [1]: nv: 570 coarse grained trap handlers
[    0.092985] kvm [1]: nv: 710 fine grained trap handlers
[    0.093060] kvm [1]: IPA Size Limit: 44 bits
[    0.093071] kvm [1]: GICv4 support disabled
[    0.093072] kvm [1]: GICv3: no GICV resource entry
[    0.093073] kvm [1]: disabling GICv2 emulation
[    0.093088] kvm [1]: GIC system register CPU interface enabled
[    0.093100] kvm [1]: vgic interrupt IRQ9
[    0.093119] kvm [1]: Broken CNTVOFF_EL2, trapping virtual timer
[    0.093123] kvm [1]: VHE mode initialized successfully
root@iq-x5121-evk:~# ls -alh /dev/kvm
crw-rw-rw- 1 root kvm 10, 232 Mar 13 15:35 /dev/kvm
```

Pending by issue: https://github.com/qualcomm-linux/meta-qcom/issues/1962