### PR TITLE
Enable KVM by default on Lemans and Monaco Platforms

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -303,14 +303,6 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
-          - machine: iq-8275-evk
-            distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
-            kernel:
-                type: default
-                dirname: ""
-                yamlfile: ""
           - machine: rb3gen2-core-kit
             distro:
                 name: qcom-distro-kvm

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -297,14 +297,6 @@ jobs:
                 yamlfile: ":ci/linux-qcom-next-rt.yml"
           - machine: iq-9075-evk
             distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
-            kernel:
-                type: default
-                dirname: ""
-                yamlfile: ""
-          - machine: iq-9075-evk
-            distro:
                 name: qcom-distro-dpdk
                 yamlfile: ':ci/qcom-distro.yml:ci/dpdk.yml'
             kernel:

--- a/ci/qcom-distro-kvm.yml
+++ b/ci/qcom-distro-kvm.yml
@@ -5,4 +5,6 @@ header:
   includes:
    - ci/qcom-distro.yml
 
-distro: qcom-distro-kvm
+local_conf_header:
+  kvm: |
+        MACHINE_FEATURES:append = " kvm"

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -112,18 +112,13 @@ create_qcomflash_pkg() {
         done
 
         # xbl_config
-        xbl_config="xbl_config.elf"
-        if ${@bb.utils.contains('DISTRO_FEATURES', 'kvm', 'true', 'false', d)}; then
-            xbl_config="xbl_config_kvm.elf"
-        fi
-
         # Prefer the OEM-cert-injected xbl_config deployed by the capsule recipe
         # when available.
         if [ -n "${QCOM_CAPSULE_FIRMWARE}" ] && \
                 [ -f "${DEPLOY_DIR_IMAGE}/xbl_config-with-oem-cert.elf" ]; then
             install -m 0644 "${DEPLOY_DIR_IMAGE}/xbl_config-with-oem-cert.elf" xbl_config.elf
-        elif [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" ]; then
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" xbl_config.elf
+        elif [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_XBL_CONFIG}" ]; then
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_XBL_CONFIG}" xbl_config.elf
         fi
 
         # bootloader selection

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -21,73 +21,73 @@ require conf/machine/include/fit-dtb-compatible.inc
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 
 # ---------- lemans ----------
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-staging] = \
     "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
     "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
     "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx] = \
     "lemans-evk lemans-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx-staging] = \
     "lemans-evk lemans-evk-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
     "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
     "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
     "lemans-evk lemans-evk-ifp-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
     "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging"
 
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh-staging] = \
     "qcs9100-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam] = \
     "qcs9100-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
     "qcs9100-ride lemans-el2 lemans-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
     "qcs9100-ride sa8775p-ride-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
     "qcs9100-ride sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2gh-staging] = \
     "qcs9100-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0] = \
     "qcs9100-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
     "qcs9100-ride-r3 lemans-el2 lemans-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
     "qcs9100-ride-r3 sa8775p-ride-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
     "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
 
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-staging] = \
     "sa8775p-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam] = \
     "sa8775p-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
     "sa8775p-ride lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-camx] = \
     "sa8775p-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2gh-staging] = \
     "sa8775p-ride sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
     "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
     "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-staging] = \
     "sa8775p-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0] = \
     "sa8775p-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
     "sa8775p-ride-r3 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx] = \
     "sa8775p-ride-r3 sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx-staging] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
 
 # ---------- monaco ----------

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -91,33 +91,33 @@ FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
 
 # ---------- monaco ----------
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
     "monaco-evk monaco-evk-camera-imx577 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
     "monaco-evk monaco-evk-camera-imx577 monaco-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
     "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = "monaco-evk monaco-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx] = "monaco-evk monaco-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging] = \
     "monaco-evk monaco-evk-camx monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = \
     "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
     "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
     "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"
 
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = "qcs8300-ride monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm] = "qcs8300-ride monaco-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = \
     "qcs8300-ride monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = "qcs8300-ride qcs8300-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx] = "qcs8300-ride qcs8300-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx-staging] = \
     "qcs8300-ride qcs8300-ride-camx monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = \
     "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
     "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
 
 # ---------- talos ----------

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -36,6 +36,9 @@ PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"
 IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 
+# XBL Config selection
+QCOM_XBL_CONFIG ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "xbl_config_kvm.elf", "xbl_config.elf", d)}"
+
 # Android boot image settings
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "4096"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs8300.inc
 
-MACHINE_FEATURES += "efi pci tpm2 phone"
+MACHINE_FEATURES += "efi kvm pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk.dtb \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi pci tpm2 phone"
+MACHINE_FEATURES += "efi kvm pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/lemans-evk.dtb \

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs8300.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi kvm pci"
 
 QCOM_DTB_DEFAULT ?= "qcs8300-ride"
 

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi kvm pci"
 
 QCOM_DTB_DEFAULT ?= "qcs9100-ride-r3"
 


### PR DESCRIPTION
All PILs are functioning correctly and KVM can be enabled by default on Lemans and Monaco platforms. 
Update FIT_DTB_COMPATIBLE entries and machine configurations to switch to default KVM for these boards.