### PR TITLE
ci/qcom-distro: fix building MariaDB for Glymur

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -16,6 +16,10 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    patches:
+      plain:
+        repo: meta-qcom
+        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-filesystems:
       meta-gnome:

--- a/patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
+++ b/patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
@@ -1,0 +1,80 @@
+From 2bb1a9da96dd5a8d5cf13e39d16a6f7d1f2855b2 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 20 May 2026 14:29:24 +0300
+Subject: [PATCH] mariadb: fix building for the ARMv8.3-A and later systems
+
+Building mariadb for ARMv8.3-A and later, fails with:
+
+Assembler messages:
+{standard input}:169: Error: selected processor does not support `retaa'
+{standard input}:271: Error: selected processor does not support `retaa'
+
+It happens because the pmem_cvap() funciton manually inserts the `.arch
+armv8-2.a` clause, making GAS believe that retaa instruction (inserted
+by GCC) is invalid. Bump the manually inserted clause to armv8.3-a, to
+prevent GAS from choking on the retaa instructions.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Inappropriate [upstream ticket https://github.com/MariaDB/server/pull/3677#issuecomment-4497763227]
+---
+ meta-oe/recipes-dbs/mysql/mariadb.inc         |  1 +
+ ...-sync-cache.cc-bump-ARMv8-arch-to-AR.patch | 35 +++++++++++++++++++
+ 2 files changed, 36 insertions(+)
+ create mode 100644 meta-oe/recipes-dbs/mysql/mariadb/0001-storage-innobase-sync-cache.cc-bump-ARMv8-arch-to-AR.patch
+
+diff --git a/meta-oe/recipes-dbs/mysql/mariadb.inc b/meta-oe/recipes-dbs/mysql/mariadb.inc
+index 9470184d3d43..456c1e1354e8 100644
+--- a/meta-oe/recipes-dbs/mysql/mariadb.inc
++++ b/meta-oe/recipes-dbs/mysql/mariadb.inc
+@@ -25,6 +25,7 @@ SRC_URI = "https://archive.mariadb.org/${BP}/source/${BP}.tar.gz \
+            file://riscv32.patch \
+            file://0001-support-reproducible-builds.patch \
+            file://0001-storage-mroonga-CMakeLists.txt-fix-reproducible-buil.patch \
++           file://0001-storage-innobase-sync-cache.cc-bump-ARMv8-arch-to-AR.patch \
+           "
+ SRC_URI[sha256sum] = "14783ddc5edd966ff05aa0efd5ed6d3d369ed5b9e4080a448f00f87a9f0a4a6b"
+ 
+diff --git a/meta-oe/recipes-dbs/mysql/mariadb/0001-storage-innobase-sync-cache.cc-bump-ARMv8-arch-to-AR.patch b/meta-oe/recipes-dbs/mysql/mariadb/0001-storage-innobase-sync-cache.cc-bump-ARMv8-arch-to-AR.patch
+new file mode 100644
+index 000000000000..dfb6c7795407
+--- /dev/null
++++ b/meta-oe/recipes-dbs/mysql/mariadb/0001-storage-innobase-sync-cache.cc-bump-ARMv8-arch-to-AR.patch
+@@ -0,0 +1,35 @@
++From ac6553ff3a21eb048f623081b7b7e31e43d38d77 Mon Sep 17 00:00:00 2001
++From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++Date: Wed, 20 May 2026 14:14:02 +0300
++Subject: [PATCH] storage/innobase/sync/cache.cc: bump ARMv8 arch to ARMv8.3
++
++Building for ARMv8.3-A and later, fails with:
++
++Assembler messages:
++{standard input}:169: Error: selected processor does not support `retaa'
++{standard input}:271: Error: selected processor does not support `retaa'
++
++It happens because the pmem_cvap() funciton manually inserts the `.arch
++armv8-2.a` clause, making GAS believe that retaa instruction (inserted
++by GCC) is invalid. Bump the manually inserted clause to armv8.3-a, to
++prevent GAS from choking on the retaa instructions.
++
++Upstream-Status: Inappropriate [upstream ticket https://github.com/MariaDB/server/pull/3677#issuecomment-4497763227]
++Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++---
++ storage/innobase/sync/cache.cc | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/storage/innobase/sync/cache.cc b/storage/innobase/sync/cache.cc
++index c5e67709e22b..104a45cee9ee 100644
++--- a/storage/innobase/sync/cache.cc
+++++ b/storage/innobase/sync/cache.cc
++@@ -85,7 +85,7 @@ static void pmem_cvap(const void* buf, size_t size)
++ #if defined __ARM_ARCH && __ARM_ARCH == 9
++     __asm__ __volatile__(".arch armv9.4-a\n dc cvap, %0" :: "r"(u) : "memory");
++ #else
++-    __asm__ __volatile__(".arch armv8.2-a\n dc cvap, %0" :: "r"(u) : "memory");
+++    __asm__ __volatile__(".arch armv8.3-a\n dc cvap, %0" :: "r"(u) : "memory");
++ #endif
++ 
++   __asm__ __volatile__("dmb ishst" ::: "memory");
+-- 
+2.47.3
+


### PR DESCRIPTION
Building mariadb for ARMv8.3-A and later, fails with:

Assembler messages:
{standard input}:169: Error: selected processor does not support `retaa' {standard input}:271: Error: selected processor does not support `retaa'

It happens because the pmem_cvap() funciton manually inserts the `.arch armv8-2.a` clause, making GAS believe that retaa instruction (inserted by GCC) is invalid. Bump the manually inserted clause to armv8.3-a, to prevent GAS from choking on the retaa instructions.