### PR TITLE
ci: workflows/build-yocto: move the sdk build to the second stage 

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -192,6 +192,7 @@ jobs:
             yamlfile: ""
     uses: ./.github/workflows/compile.yml
     with:
+      name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}
@@ -206,6 +207,7 @@ jobs:
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     uses: ./.github/workflows/compile.yml
     with:
+      name: qcom-armv8a/qcom-distro-sdk
       sdk: true
       target: false
       world: false
@@ -401,6 +403,7 @@ jobs:
                 yamlfile: ""
     uses: ./.github/workflows/compile.yml
     with:
+      name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
       enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -199,6 +199,23 @@ jobs:
       kernel_dirname: ${{matrix.kernel.dirname}}
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
 
+  compile_sdk:
+    needs: [github-cache-check, compile_warm_up, compile-env]
+    if: |
+      github.repository_owner == 'qualcomm-linux' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
+    uses: ./.github/workflows/compile.yml
+    with:
+      sdk: true
+      target: false
+      world: false
+      machine: 'qcom-armv8a'
+      distro_yaml: ':ci/qcom-distro.yml'
+      distro_name: 'qcom-distro-sdk'
+      kernel_yaml: ''
+      kernel_dirname: ''
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+
   compile:
     needs: [github-cache-check, compile_warm_up, compile-env]
     if: |
@@ -393,7 +410,7 @@ jobs:
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
 
   publish_summary:
-    needs: [github-cache-check, compile]
+    needs: [github-cache-check, compile, compile_sdk]
     if: |
       always() && github.repository_owner == 'qualcomm-linux' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
@@ -409,7 +426,7 @@ jobs:
           pattern: build-url*
 
   github-cache-save:
-    needs: [github-cache-check, compile]
+    needs: [github-cache-check, compile, compile_sdk]
     if: |
       github.repository_owner == 'qualcomm-linux' &&
       inputs.skip_if_github_cached == true &&
@@ -428,7 +445,7 @@ jobs:
 
   build_successful:
     if: github.repository_owner == 'qualcomm-linux'
-    needs: compile
+    needs: [compile, compile_sdk]
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -5,6 +5,18 @@ on:
         required: false
         type: boolean
         default: true
+      sdk:
+        required: false
+        type: boolean
+        default: false
+      target:
+        required: false
+        type: boolean
+        default: true
+      world:
+        required: false
+        type: boolean
+        default: true
       machine:
         required: true
         type: string
@@ -81,6 +93,7 @@ jobs:
           $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
 
       - name: Kas build world
+        if:  inputs.world
         shell: bash
         run: |
           $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
@@ -89,6 +102,7 @@ jobs:
           mv $KAS_WORK_DIR/build/buildstats* .
 
       - name: Kas build images
+        if:  inputs.target
         shell: bash
         run: |
           $KAS_CONTAINER build ${KAS_YAMLS}
@@ -96,19 +110,15 @@ jobs:
           mv $KAS_WORK_DIR/build/buildstats* .
 
       - name: Kas build SDK
+        if:  inputs.sdk
         shell: bash
         run: |
-          if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
-            # SDK only with the default kernel and qcom-distro
-            if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then
-              $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
-                --target qcom-multimedia-image \
-                --target qcom-multimedia-proprietary-image
-              ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
-              rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
-              mv $KAS_WORK_DIR/build/buildstats* .
-            fi
-          fi
+          $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
+            --target qcom-multimedia-image \
+            --target qcom-multimedia-proprietary-image
+          ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+          rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
+          mv $KAS_WORK_DIR/build/buildstats* .
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: boolean
         default: true
+      name:
+        required: true
+        type: string
       machine:
         required: true
         type: string
@@ -43,7 +46,7 @@ jobs:
   reusable_compile_job:
     if: inputs.enabled
     runs-on: [self-hosted, qcom-u2404, amd64]
-    name: ${{ inputs.machine }}/${{ inputs.distro_name }}${{ inputs.kernel_dirname }}
+    name: ${{ inputs.name }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -100,6 +100,11 @@ jobs:
         shell: bash
         run: |
           $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
+
+      - name: Kas build world (buildstats)
+        if:  inputs.world
+        shell: bash
+        run: |
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
           mv $KAS_WORK_DIR/build/buildstats* .
@@ -109,6 +114,11 @@ jobs:
         shell: bash
         run: |
           $KAS_CONTAINER build ${KAS_YAMLS}
+
+      - name: Kas build images (buildstats)
+        if:  inputs.target
+        shell: bash
+        run: |
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           mv $KAS_WORK_DIR/build/buildstats* .
 
@@ -119,6 +129,11 @@ jobs:
           $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
             --target qcom-multimedia-image \
             --target qcom-multimedia-proprietary-image
+
+      - name: Kas build SDK (buildstats)
+        if:  inputs.sdk
+        shell: bash
+        run: |
           ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
           rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
           mv $KAS_WORK_DIR/build/buildstats* .

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -130,11 +130,13 @@ jobs:
           deploy_dir=../kas/build/tmp/deploy/images/${INPUTS_MACHINE}
           uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
           mkdir -p $uploads_dir
-          # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
-          find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
-          # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
-          # Copy *.efi, *.efi and *.vfat as they are useful for debugging
-          find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
+          if [ -d $deploy_dir ]; then
+            # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
+            find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
+            # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
+            # Copy *.efi, *.efi and *.vfat as they are useful for debugging
+            find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
+          fi
           cp buildstats* kas-build.yml $uploads_dir/
           if [ -d $deploy_dir/../../sdk ]; then
             cp $deploy_dir/../../sdk/* $uploads_dir/


### PR DESCRIPTION
Currently, the heavy lifting of the build is divided into two stages where the
compilation takes place. The first one we call it "warmup", and in this stage
we intend to generate the sstate-cache building different architectures so that
it can be used as much as possible in the second stage.

The SDK is built in this first stage, more specifically on machine "qcom-armv8a".
Since it's an additional step, it considerably increases the time required to
complete this machine. The SDK is taking too long to build, reaching 3 times
the build time of the target image. The SDK main pain point it's really in the
last image:do_populate_sdk task which is quite difficult to reduce.
It currently takes approximately 30 minutes minutes to complete in the best case.

One solution to remove the 30 minutes delay introduced by the SDK build would be
moving it from the first "warmup" stage to the second stage of the build.
Thus, the first one finishes earlier, causing the second one to also start earlier.
In the second stage the SDK build will reuse all the sstate-cache from the "warmup"
and will jump directly image:do_populate_sdk task.

In the reusable workflow, control parameters were added for the internal sub-blocks
to allows us to skip it if necessary:
    - inputs.world
    - inputs.target
    - inputs.sdk

buildstats.log example for the best case (when everything comes from sstate-cache):
```
0:00:01    gcc-cross-canadian-aarch64:do_package_write_rpm_setscene
0:00:02    nativesdk-clang:do_package_write_rpm_setscene
0:00:02    nativesdk-llvm:do_package_write_rpm_setscene
0:00:02    nativesdk-spirv-tools:do_package_write_rpm_setscene
0:00:04    nativesdk-glibc-locale:do_package_write_rpm_setscene
0:00:05    nativesdk-glibc-locale:do_packagedata_setscene
0:00:08    nativesdk-qemu:do_package_write_rpm_setscene
0:34:07    qcom-multimedia-image:do_populate_sdk
0:35:56    qcom-multimedia-proprietary-image:do_populate_sdk
```