### PR TITLE
rb3gen2-core-kit: add paho-mqtt-c as machine essential

### DIFF
--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -29,6 +29,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     qairt-sdk-hexagon-v68 \
     qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
     qps615-dlkm \
+    paho-mqtt-c \
 "
 
 QCOM_CDT_FILE = "cdt_core_kit"


### PR DESCRIPTION
Add Eclipse Paho MQTT C client library to rb3gen2-core-kit
machine configuration to enable MQTT connectivity with SSL/TLS
support out of the box.

Validated on QLI20_May8 build on RB3 Gen2 Core Kit:
- Paho MQTT C client SSL publish/subscribe verified
- mTLS with client certificate verification working