### PR TITLE
AGENTS.md: reuse pre-existing env variables (for kas) and require signed-off-by

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,21 @@ Use the style seen in recent history:
 - Or concise imperative summary when cross-cutting, e.g.
   - `Drop SoC version suffixes from FIT DTB compatible strings (#2159)`
 
+Every commit **must** include a `Signed-off-by` trailer using the identity from
+the local git configuration:
+
+```sh
+git commit -s   # or pass --signoff; fetches user.name / user.email from git config
+```
+
+If committing programmatically, append the trailer explicitly:
+
+```text
+Signed-off-by: $(git config user.name) <$(git config user.email)>
+```
+
+Never fabricate a name or email; always read from `git config`.
+
 Guidelines:
 
 - Keep subject line short and specific; capture intent, not a file-by-file dump.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,14 @@ Notes:
 
 ## 2) Recommended environment
 
+If `KAS_WORK_DIR`, `DL_DIR`, and `SSTATE_DIR` are already set in the environment, use them
+directly — do not override them. Only set defaults when they are absent:
+
 ```sh
 export REPO_DIR="$(pwd)"                               # meta-qcom checkout
-export CACHE_ROOT="/path/to/shared-cache"              # shared across runs/agents
-export DL_DIR="${CACHE_ROOT}/downloads"
-export SSTATE_DIR="${CACHE_ROOT}/sstate-cache"
-export KAS_WORK_DIR="/path/to/kas-work"                # outside repo to avoid polling the checkout
+export KAS_WORK_DIR="${KAS_WORK_DIR:-/path/to/kas-work}"      # outside repo to avoid polling the checkout
+export DL_DIR="${DL_DIR:-/path/to/shared-cache/downloads}"
+export SSTATE_DIR="${SSTATE_DIR:-/path/to/shared-cache/sstate-cache}"
 mkdir -p "${DL_DIR}" "${SSTATE_DIR}" "${KAS_WORK_DIR}"
 ```
 


### PR DESCRIPTION
Update AGENTS.md (updated by the agent itself) to respect KAS_WORK_DIR, DL_DIR and SSTATE_DIR from the environment and to also require git signed-off-by on every commit.