### PR TITLE
ci/base : append swiotlb parameter in cmdline

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -46,7 +46,7 @@ local_conf_header:
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
+    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1 swiotlb=128"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
Append swiotlb parameter in cmdline for all Qualcomm targets to change the default bounce buffer behaviour.