### PR TITLE
ci/base : Limit swiotlb to 128

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -46,7 +46,7 @@ local_conf_header:
     https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
     "
   cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
+    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1 swiotlb=128"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
Add kernel command line parameter to set minimum
limit of 128 for bounce buffer as this will be used for DMA use cases on kmalloc addresses which are not page aligned.