### PR TITLE
iq-x5121-evk: remove setting QCOM_DTB_DEFAULT

### DIFF
--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-purwa.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "purwa-iot-evk"
-
 KERNEL_DEVICETREE ?= " \
     qcom/purwa-iot-evk.dtb \
     "


### PR DESCRIPTION
Remove explicit setting of `QCOM_DTB_DEFAULT` to enable FIT multi-DTB support on IQ-X5121 IoT EVK.


Boot log:
```
 ParseFitDt: image_number 2
ProcessQcomMetaDtbOemNode: Board Param: OEM Id = 0
ProcessQcomMetaDtbSocNode:Board Param:
ChipId: 0x2C7
 ProcessQcomMetaDtbSocNode: Node purwa
FromDtbChipIdentifier = 2C7
ProcessQcomMetaDtbSocVerNode:Board Param: ChipVersion: 0x10000

 ProcessQcomMetaDtbSocVerNode: Node socv1.0 FromDtbChipRevision = 10000
 ProcessQcomMetaDtbBoardNode: Board Param: BoardId = 0x2F
 ProcessQcomMetaDtbBoardNode: Node evk BoardId = 0x2F
 ProcessQcomMetaDtbBoardRevNode: Board Param: Board Revision = 0x10000
 ProcessQcomMetaDtbBoardRevNode: Node r1.0 BoardRevId = 0x10000
PackageId: 0x0
ProcessQcomMetaDtbSocSkuNode: Board Param:
FoundryId: 0x1
PackageId: 0x0
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Board Param:
BoardSubTypeId = 0x0
 ProcessQcomMetaDtbBoardSubTypePeripheralSubTypeNode: Node subtype0 From fdt BoardSubTypeId = 0
Failed to get boot device type, Not Found
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Board Param:
BootDeviceType = 0x1
 ProcessQcomMetaDtbBoardSubTypeStorageSubTypeNode: Node emmc From fdt StorageTypeId = 1
 ProcessQcomMetaDtbBoardMemorySizeNode:Board Param:
Ddr Size = 0
 ProcessQcomMetaDtbBoardMemorySizeNode: Node 4GB+ From fdt DdrSizeId = 0
 ProcessQcomMetaDtbSoftSkuNode: Board Param: Board SoftSkuId = 0
 ProcessQcomMetaDtbSoftSkuNode: Node softsku0 SoftSkuId = 0
 ParseFitDt: Configuration From BoardParam
qcom, purwa, socv1.0, evk, r1.0, subtype0, emmc, 4GB+, softsku0,
 FindConfigToBoot: SubNode 500 And Node Name conf-1 Len = 6
 FindConfigToBoot: CompatibleMatchFlag = 1 CurrSubStringCnt = 2
FindConfigToBoot:Booting with = qcom,purwa-evk
 FindConfigToBoot: i = 0 fdt fdt-purwa-iot-evk.dtb str len = 21
ParseFitDt::
Config fdt-purwa-iot-evk.dtb & Type 0
FitLoadDtbFromFdt: Config fdt-purwa-iot-evk.dtb & Type 0
Reading of OsConfigTableSelection failed,checking DT settings
 HypDtFixupEventNotifyFunc: Dtb apply overlay skipped
UEFI Total : 2347 ms
```

The minimum boot firmware version for iq-x5121-evk multi-dtb support: #2270