### PR TITLE
Update boot to 00126

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00123.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "9693a9d6ceeb8ecd47f6d8f7a4e28180602973d7d47da77673023a6fa7ad5789"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "bdbc6aa0390f5c78059e0d9f2c70f8bc0695b350d1a8a47d65c9c758847050f2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00123.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "df120b750128166c9f8f9ad28c7ecd30d3938c2750a250f2a12362757dc416b0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "25b19ccc56d6e4133df15b7b5ac9353357efc66cbf17e9f84d0a459724e0e3e0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00123.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a0fca33863d5a665535717aa943d668d3ffa9e2970bbc10e7e5d04d9269a1b1f"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "a94a26782bdcef18599fcc098fee77db50154ac31126dae86847c32205b224e6"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00123.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00123.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "74bc46555034173a4d5282fe96b1e96e0874cfd7f874f4483d431eaa72300345"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "6bcc47460e2127c6bf1ebda1726e87659820dadeceb68f15c52aed80086b64a2"


### PR DESCRIPTION
This PR update boot to 00126 version for QCM6490, QCS9100, QCS8300 and QCS615.

Known fixes:
feat: add feature flag for secure VM authentication and reset with cross-hypervisor compatibility
fix: prevent security module unload to resolve runtime variable I/O errors during VM boot
chore: introduce "never unload" option to ensure persistent security module with no behavior changes
