### PR TITLE
Add SoC staging file to Glymur-crd and Hamoa-evk

### DIFF
--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -12,6 +12,11 @@ KERNEL_DEVICETREE ?= " \
     qcom/glymur-crd.dtb \
 "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/glymur-staging.dtbo \
+"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-glymur-crd-firmware \
     packagegroup-glymur-crd-hexagon-dsp-binaries \

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -19,6 +19,7 @@ require conf/machine/include/fit-dtb-compatible.inc
 
 # ---------- hamoa  ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx hamoa-staging"
 
 # ---------- purwa -----------
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -210,3 +210,5 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+# ---------- glymur ----------
+FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -16,6 +16,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/hamoa-evk-camx.dtbo \
+    qcom/hamoa-staging.dtbo \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Add initial SoC staging overlay DTBO file includes TGU DT nodes to enable IPCB feature.
IPCB (inter-Processor Communication Bus) is a bus monitoring mechanism within the AOSS (Always On Subsystem) on Qualcomm SoCs. It helps understand the condition and activity of the always-on subsystems by monitoring traffic on the iPCB bus.