### PR TITLE
camxlib-hamoa: Update to the 1.0.25 revision

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.24.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.24.1.bb
@@ -1,9 +1,0 @@
-PLATFORM = "hamoa"
-PBT_BUILD_DATE = "260519"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum] = "28ee162ab5873f70a18bf4349b4b6e489cd1daea0b206ed6c205ad3ef70de6f3"
-SRC_URI[camx.sha256sum] = "9fa2cb9365f8f0258a272e9e57e73ba27285d4cc43ddc1ff4182f69aedbd422d"
-SRC_URI[chicdk.sha256sum] = "3b89bda5fe9dd846b02cf50e9c8d2d21372857e47465fa1925b8e9c038e5cbd2"
-SRC_URI[camxcommon.sha256sum] = "6333a910f37a7195bd31efcb1b2978cb2186e655a13f655a96a3d11c6c961553"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.25.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.25.bb
@@ -1,0 +1,9 @@
+PLATFORM = "hamoa"
+PBT_BUILD_DATE = "260520"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "cd321d37bbfe4fdbf8e2fce649185b703bdda9e5252af9e7994617cb5f6f156f"
+SRC_URI[camx.sha256sum] = "2c43d0ad848cb18ee3579e9b908d2408cf14e0f27dc41a976b65007a83d4f567"
+SRC_URI[chicdk.sha256sum] = "933f8a4a8abdd66faa3772fb493900fd1ff82c08346dac2d455f3335bae4b8c2"
+SRC_URI[camxcommon.sha256sum] = "b36265c5a33f1a83e0659a89eb58e1cc3abc9bc02619d000a8c9cf112a451f62"


### PR DESCRIPTION
Update camxlib-hamoa to revision 1.0.25, which adds support for the
OG0VA1B camera sensor.

This support is intentionally kept Hamoa-specific for now. The OG0VA1B
is currently only wired up on the Hamoa EVK via a custom daughter card,
and the sensor driver carries target-specific configuration (slot IDs,
PHY lane config and tuning binaries) that is not portable to other
targets as-is.