### PR TITLE
Update Targets specific to wrynose/2.0

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -160,12 +160,9 @@ jobs:
       fail-fast: true
       matrix:
         machine:
-          - glymur-crd
           - qcom-armv8a
           - rb3gen2-core-kit
         distro:
-          - name: nodistro
-            yamlfile: ""
           - name: qcom-distro
             yamlfile: ':ci/qcom-distro.yml'
         kernel:
@@ -198,21 +195,16 @@ jobs:
       fail-fast: false
       matrix:
         machine:
-          - glymur-crd
           - iq-615-evk
           - iq-8275-evk
           - iq-9075-evk
           - iq-x5121-evk
           - iq-x7181-evk
-          - kaanapali-mtp
           - qcm6490-idp
           - qcom-armv8a
           - qcs615-ride
-          - qcs8300-ride-sx
-          - qcs9100-ride-sx
           - rb1-core-kit
           - rb3gen2-core-kit
-          - sm8750-mtp
         distro:
           - name: nodistro
             yamlfile: ""
@@ -236,16 +228,6 @@ jobs:
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
         exclude:
           # Exclude jobs from compile_warm_up
-          - machine: glymur-crd
-            distro:
-                name: nodistro
-            kernel:
-                type: default
-          - machine: glymur-crd
-            distro:
-                name: qcom-distro
-            kernel:
-                type: default
           - machine: qcom-armv8a
             distro:
                 name: nodistro


### PR DESCRIPTION
Update targets to build against respective kernel for wrynose/2.0

remove below 
qcs9100-ride-sx
qcs8300-ride-sx

conditoinalize below malinline targets to build against qcom->next kernel
glymur-crd
kaanapali-mtp
sm8750-mtp