### PR TITLE
Define QCOM_XBL_CONFIG in qcom-common.inc for XBL config selection

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -112,18 +112,13 @@ create_qcomflash_pkg() {
         done
 
         # xbl_config
-        xbl_config="xbl_config.elf"
-        if ${@bb.utils.contains('DISTRO_FEATURES', 'kvm', 'true', 'false', d)}; then
-            xbl_config="xbl_config_kvm.elf"
-        fi
-
         # Prefer the OEM-cert-injected xbl_config deployed by the capsule recipe
         # when available.
         if [ -n "${QCOM_CAPSULE_FIRMWARE}" ] && \
                 [ -f "${DEPLOY_DIR_IMAGE}/xbl_config-with-oem-cert.elf" ]; then
             install -m 0644 "${DEPLOY_DIR_IMAGE}/xbl_config-with-oem-cert.elf" xbl_config.elf
-        elif [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" ]; then
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${xbl_config}" xbl_config.elf
+        elif [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_XBL_CONFIG}" ]; then
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/${QCOM_XBL_CONFIG}" xbl_config.elf
         fi
 
         # bootloader selection

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -36,6 +36,9 @@ PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"
 IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 
+# XBL Config selection
+QCOM_XBL_CONFIG ?= "${@bb.utils.contains("COMBINED_FEATURES", "kvm", "xbl_config_kvm.elf", "xbl_config.elf", d)}"
+
 # Android boot image settings
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "4096"


### PR DESCRIPTION
Avoid hardcoding XBL configuration selection in image_types_qcom.bbclass, which limits flexibility to enable KVM selectively across boards.  Define QCOM_XBL_CONFIG to select the appropriate XBL config based on COMBINED_FEATURES. This enables per-board control of XBL configuration when KVM is enabled.