### PR TITLE
conf/layer: Update QLI_BASELINE for wrynose branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,7 +33,7 @@ BBFILES_DYNAMIC += " \
 "
 
 # Qualcomm Linux baseline
-QLI_BASELINE = "main"
+QLI_BASELINE = "2.x"
 
 INHERIT += "qli-mirrors"
 


### PR DESCRIPTION
Update the QLI_BASELINE variable to ensure qli-mirrors.bbclass tracks the correct downloads mirror path for the wrynose branch.