### PR TITLE
u-boot-qcom: bump SRCREV to 2026.07-rc2

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -5,9 +5,9 @@ DEPENDS += "bc-native dtc-native gnutls-native python3-pyelftools-native qtestsi
 
 COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
-PV = "2026.04+2026.07-rc1+git"
+PV = "2026.04+2026.07-rc2+git"
 
-SRCREV = "39a47cb4b336cda637e802c03d84cdac19464728"
+SRCREV = "7617ce012516d03e6724c5c6c7650c3a869d5591"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Update U-Boot revision from 2026.07-rc1 to 2026.07-rc2 by bumping SRCREV and PV. This brings in latest upstream fixes and updates from Qualcomm U-Boot repository.

Changelog:
- Sync to rc2 release
- Disable Guyneah teardown KVM configs in U-Boot since kernel does not enable KVM by default; can be re-enabled when supported
- Use DT fixup to propagate reserved memory regions to kernel for FIT boot.
- Set USB controllers to OTG mode in talos-evk for U-Boot flashing support.
- Remove preboot SCSI/USB scans to reduce boot time.
- Add PON NVMEM-based reboot-mode support to talos-evk DTS.
- Add SDCC1 (eMMC) clock support with frequency table for SA8775P.