### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260601 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -10,14 +10,14 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "6.18.25"
+LINUX_VERSION ?= "6.18.30"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260519
-SRCREV ?= "6964936c9bfc3337aa8ba8a0fb25021d06e5ce04"
+# tag:qcom-6.18.y-20260601
+SRCREV ?= "b7cce9a3884a873855693af8591d4c9c469cd17e"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260601

Changelog:
Merge tag 'v6.18.30' into qcom-6.18.y
FROMLIST: arm64: dts: qcom: talos: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: monaco: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: lemans: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: kodiak: Add GEM_NOC interconnect for adreno SMMU
PENDING: arm64: defconfig: select INTERCONNECT_QCOM_SHIKRA as built-in
QCLINUX: arm64: dts: qcom: add purwa CAMX EL2 overlay
FROMLIST: arm64: dts: qcom: shikra: enable WiFi on EVK boards
FROMLIST: arm64: dts: qcom: shikra: add WiFi node support
FROMLIST: arm64: dts: qcom: shikra: Enable BT support on EVK boards
FROMLIST: arm64: dts: qcom: shikra: Enable TSENS and thermal zones
FROMLIST: arm64: dts: qcom: shikra-iqs: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra-cqs: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra-cqm: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra: Add CDSP, LPAICP, MPSS remoteproc PAS nodes
FROMLIST: arm64: dts: qcom: shikra: Add SMP2P nodes
FROMLIST: arm64: dts: qcom: shikra: Add CPU OPP tables to scale DDR/L3
FROMLIST: arm64: dts: qcom: shikra: Add EPSS L3 interconnect provider node
FROMLIST: arm64: dts: qcom: shikra: Add DDR BWMON support
FROMLIST: arm64: dts: qcom: shikra: Add cpufreq scaling node
FROMLIST: arm64: dts: qcom: Add QUPv3 configuration for Shikra
FROMLIST: dt-bindings: interconnect: qcom-bwmon: Add Shikra cpu-bwmon compatible
FROMLIST: dt-bindings: dma: qcom,gpi: Document GPI DMA engine for Shikra SoC
FROMLIST: interconnect: qcom: Add EPSS L3 scaling support for Shikra SoC
FROMLIST: dt-bindings: interconnect: qcom,shikra-epss-l3: Add EPSS L3 DT binding
FROMLIST: pinctrl: qcom: Unconditionally mark gpio as wakeup enable
FROMLIST: soc: qcom: smem: Switch partitions to xarray
FROMLIST: media: venus: prefer iris driver for qcm2290 when IRIS is enabled
FROMLIST: dt-bindings: media: qcom,qcm2290-venus: document shikra Iris compatible
FROMLIST: dt-bindings: arm-smmu: Add adreno-smmu compatible for Qualcomm Shikra
FROMLIST: regulator: qcom_usb_vbus: add support for qcom,pm4125-vbus-reg
FROMLIST: dt-bindings: regulator: qcom,usb-vbus-regulator: add qcom,pm4125-vbus-reg
FROMLIST: arm64: dts: qcom: shikra: Add ICE, TRNG and QCE nodes
FROMLIST: dt-bindings: dma: qcom,bam-dma: Increase iommus maxItems to seven
FROMLIST: dt-bindings: crypto: qcom-qce: Document the Shikra crypto engine
FROMLIST: dt-bindings: crypto: qcom,prng: Document Shikra TRNG
FROMLIST: dt-bindings: crypto: qcom,inline-crypto-engine: Document Shikra ICE
FROMLIST: dt-bindings: thermal: qcom-tsens: Document the Shikra Temperature Sensor
FROMLIST: remoteproc: qcom: pas: Add Shikra remoteproc support
FROMLIST: dt-bindings: remoteproc: qcom,shikra-pas: Document Shikra PAS remoteprocs
FROMLIST: clk: qcom: Add support for GPU Clock Controller on Shikra
FROMLIST: clk: qcom: Add support for Display Clock Controller on Shikra
FROMLIST: dt-bindings: clock: qcom: Add Shikra GPU clock controller
FROMLIST: dt-bindings: clock: qcom: Add Shikra Display clock controller
FROMLIST: arm64: dts: qcom: Add Shikra EVK boards
FROMLIST: arm64: dts: qcom: Add Shikra IQ2390S SoM platform
FROMLIST: arm64: dts: qcom: Add Shikra CQ2390M SoM platform
FROMLIST: arm64: dts: qcom: Introduce Shikra SoC base dtsi
FROMLIST: dt-bindings: arm: qcom: Document Shikra and its EVK boards
FROMLIST: dt-bindings: mmc: sdhci-msm: Document the Shikra compatible
FROMLIST: dt-bindings: cache: qcom,llcc: Document Shikra LLCC
FROMLIST: dt-bindings: nvmem: qcom,qfprom: Add Shikra compatible
FROMLIST: dt-bindings: watchdog: qcom-wdt: Document Shikra watchdog
FROMLIST: dt-bindings: mfd: qcom,tcsr: Add compatible for Shikra
FROMLIST: dt-bindings: firmware: qcom,scm: Document SCM on Shikra SoC
FROMLIST: cpufreq: qcom: Add cpufreq scaling support for Qualcomm Shikra SoC
FROMLIST: dt-bindings: cpufreq: Document Qualcomm Shikra SoC EPSS
FROMLIST: dt-bindings: sram: Document qcom,shikra-imem compatible
FROMLIST: dt-bindings: arm-smmu: qcom: Add compatible for Qualcomm Shikra SoC
FROMLIST: dt-bindings: usb: qcom,snps-dwc3: Add Shikra compatible
FROMLIST: phy: qcom: qmp-usbc: Add qmp configuration for Shikra
FROMLIST: phy: qcom-qusb2: Add support for Shikra
FROMLIST: dt-bindings: phy: qcom,msm8998-qmp-usb3-phy: Add support for Shikra
FROMLIST: dt-bindings: phy: qcom,qusb2: Document QUSB2 Phy for Shikra
FROMLIST: dt-bindings: mailbox: qcom: Add Shikra APCS compatible
FROMLIST: dt-bindings: remoteproc: Add Shikra RPM processor compatible
FROMLIST: dt-bindings: soc: qcom: smd-rpm: Add Shikra rpm-smd compatible
FROMLIST: clk: qcom: Add Global clock controller support on Qualcomm Shikra SoC
FROMLIST: clk: qcom: smd-rpm: Add support for RPM clocks on Qualcomm Shikra SoC
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra SoC Global Clock Controller
FROMLIST: dt-bindings: clock: qcom,rpmcc: Add Qualcomm Shikra SoC RPMCC
FROMLIST: pmdomain: qcom: rpmpd: Add Shikra RPM Power Domains
FROMLIST: dt-bindings: power: qcom,rpmpd: document the Shikra RPM Power Domains
FROMLIST: regulator: qcom_smd: Add PM8150 regulators
FROMLIST: dt-bindings: regulator: qcom,smd-rpm-regulator: Document PM8150 IC
FROMLIST: interconnect: qcom: add Shikra interconnect provider driver
FROMLIST: dt-bindings: interconnect: document the RPM Network-On-Chip interconnect in Shikra SoC
FROMLIST: pinctrl: qcom: Add Shikra pinctrl driver
FROMLIST: dt-bindings: pinctrl: qcom: Document Shikra Top Level Mode Multiplexer
FROMLIST: soc: qcom: socinfo: Add SoC ID for Shikra IoT variants
FROMLIST: dt-bindings: arm: qcom,ids: Add SoC ID for Shikra IoT variants
FROMLIST: wifi: ath11k: raise max vdevs to 4 on hardware with P2P and dual-station support
FROMLIST: misc: fastrpc: fix use-after-free of fastrpc_user in workqueue context
Revert "FROMLIST: misc: fastrpc: Add reference counting for fastrpc_user structure"
FROMLIST: arm64: dts: qcom: lemans: enable EUD support
FROMLIST: iommu/arm-smmu: Add interconnect bandwidth voting support
FROMLIST: dt-bindings: iommu: arm,smmu: Document optional interconnects property
QCLINUX: arm64: configs: Add Linux software RAID support
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add WCD headset playback and record for qcs6490-rb3gen2 industrial mezzanine
FROMLIST: Bluetooth: hci_qca: Fix missing wakeup during SSR memdump handling
FROMLIST: Bluetooth: hci_qca: Convert timeout from jiffies to ms
FROMLIST: wifi: ath12k: enable threaded NAPI when DP IRQ affinity is unavailable
FROMLIST: genirq: export irq_can_set_affinity() for module drivers
QCLINUX: arm64: dts: qcom: add hamoa CAMX EL2 overlay
FROMLIST: arm64: dts: qcom: monaco: fix wrong connection for the replicator
BACKPORT: arm64: dts: qcom: monaco: Add CTCU and ETR nodes
BACKPORT: dt-bindings: arm: add CTCU device for monaco
BACKPORT: phy: qcom: edp: Add PHY-specific LDO config for eDP low vdiff
BACKPORT: phy: qcom: edp: Fix AUX_CFG8 programming for DP mode
BACKPORT: phy: qcom: edp: Add SC7280/SC8180X swing/pre-emphasis tables
BACKPORT: phy: qcom: edp: Add eDP/DP mode switch support
BACKPORT: phy: qcom: edp: Unify generic DP/eDP swing and pre-emphasis tables
BACKPORT: phy: qcom: edp: Fix NULL pointer dereference for phy v6 (x1e80100)
BACKPORT: phy: qcom: edp: Add Glymur platform support
BACKPORT: phy: qcom-qmp: qserdes-com: Add v8 DP-specific qserdes register offsets
BACKPORT: phy: qcom: edp: Fix the DP_PHY_AUX_CFG registers count
FROMLIST: dt-bindings: phy: qcom-edp: Add reference clock for sa8775p eDP PHY
BACKPORT: dt-bindings: phy: Add DP PHY compatible for Glymur
Revert "FROMLIST: dt-bindings: phy: qcom-edp: Add eDP ref clk for sa8775p"
Revert "FROMLIST: phy: qcom: edp: Initialize swing_pre_emph_cfg for sc7280"
FROMLIST: fastrpc: Reduce log level for DSP info and reserved memory messages
FROMLIST: wifi: ath12k: fix peer_id usage in normal RX path
FROMLIST: wifi: ath12k: add channel 177 to the 5 GHz channel list