### PR TITLE
firmware-qcom-boot-glymur: update tag to 00065 and enable tech pack based releases

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
@@ -2,16 +2,14 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm GLYMUR-CRD platform"
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/software/chip/qualcomm_linux-spf-0-0/qualcomm-linux-spf-0-0_test_device_public"
-FW_BUILD_ID = "r0.0_${PV}/glymur-le-0-0"
-FW_BIN_PATH = "common/build/bin"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Glymur_bootbinaries.1.0/glymur_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "Glymur_bootbinaries"
 
 S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SC8480XP/cdt/sc8480xp-crd.zip;downloadfilename=sc8480xp-crd_${PV}.zip;name=sc8480xp-crd \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00009.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00009.0.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-glymur.inc
-
-SRC_URI[bootbinaries.sha256sum] = "79df8ab4cc3248472d819098d20829ab129828c19937525cfc16f089d65a7a42"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00065.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00065.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-glymur.inc
+
+SRC_URI[bootbinaries.sha256sum] = "bcc25ba8ac20b759d6068bf127af2aa0f8fccb08ea130a251dcdc6101123edc1"


### PR DESCRIPTION
Tech pack based release path and versionzing is for SPF agnostic paths across QLI targets. This enabled SP build label versioning of boot bins instead of release tag based versioning and explains the version bump to 00065.