### PR TITLE
qcom-capsule: enable capsule generation for hamoa (iq-x7181-evk)

### DIFF
--- a/classes-recipe/qcom-capsule.bbclass
+++ b/classes-recipe/qcom-capsule.bbclass
@@ -200,6 +200,57 @@ python generate_fvupdate() {
 
 do_compile[prefuncs] += "generate_fvupdate"
 
+# Inject the OEM root certificate into xbl_config.elf.
+# Dumps the config sections, auto-detects the post-DDR DTB (or uses
+# XBLCONFIG_DTB / XBLCONFIG_DTB_SECTION overrides), patches QcCapsuleRootCert
+# in that DTB, and repacks the updated DTB back into xbl_config.elf in place.
+# $1 - path to xbl_config.elf (modified in place on success)
+patch_xblconfig_cert() {
+    local xbl_config="$1"
+    local staged_dir
+    staged_dir=$(dirname "${xbl_config}")
+
+    XBL_DUMP_LOG="${CAPSULE_DIR}/xbl_dump.log"
+    qcom-capsule-tool parse-config \
+        "${xbl_config}" dump \
+        --out-dir "${staged_dir}" | tee "${XBL_DUMP_LOG}"
+
+    DTB_PATCH="${XBLCONFIG_DTB}"
+    DTB_SECTION="${XBLCONFIG_DTB_SECTION}"
+    if [ -z "${DTB_PATCH}" ]; then
+        # Parse a line like:
+        #   [+] config_item[6] -> PH# 8 -> './post-ddr-kodiak-1.0.dtb' (90280 bytes)
+        POST_DDR_LINE=$(grep -m1 "post-ddr.*\.dtb" "${XBL_DUMP_LOG}" || true)
+        if [ -n "${POST_DDR_LINE}" ]; then
+            DTB_PATCH=$(echo "${POST_DDR_LINE}" | sed "s|.* -> '||;s|'.*||" | xargs basename)
+            DTB_SECTION=$(echo "${POST_DDR_LINE}" | sed "s/.*PH# \([0-9]*\).*/\1/")
+        fi
+    fi
+
+    if [ -n "${DTB_PATCH}" ]; then
+        ORIG_DTB="${staged_dir}/${DTB_PATCH}"
+        UPDATED_DTB="${staged_dir}/${DTB_PATCH%.dtb}-updated.dtb"
+
+        qcom-capsule-tool set-dtb-property \
+            "${ORIG_DTB}" \
+            /sw/uefi/uefiplat \
+            QcCapsuleRootCert \
+            "@list:${ROOT_INC}" \
+            "${UPDATED_DTB}"
+
+        qcom-capsule-tool parse-config \
+            "${xbl_config}" replace \
+            "${DTB_SECTION}" \
+            "${UPDATED_DTB}" \
+            "${staged_dir}/xbl_config_patched.elf"
+
+        mv "${staged_dir}/xbl_config_patched.elf" \
+           "${xbl_config}"
+
+        touch "${CAPSULE_DIR}/.xbl_with_oem_cert"
+    fi
+}
+
 do_compile() {
     CBSP_DATA="${STAGING_DATADIR_NATIVE}/cbsp-boot-utilities"
     EDK2_BASETOOLS="${STAGING_DATADIR_NATIVE}/edk2-basetools"
@@ -234,47 +285,10 @@ do_compile() {
     mkdir -p "${BOOTBINS_STAGED}"
     cp -r "${BOOTBINS_DIR}/." "${BOOTBINS_STAGED}/"
 
-    # Dump xbl_config.elf sections; parse output to auto-detect the post-DDR
-    # DTB and its section index.  XBLCONFIG_DTB / XBLCONFIG_DTB_SECTION
-    # override auto-detection when set explicitly.
-    XBL_DUMP_LOG="${CAPSULE_DIR}/xbl_dump.log"
-    qcom-capsule-tool parse-config \
-        "${BOOTBINS_STAGED}/xbl_config.elf" dump \
-        --out-dir "${BOOTBINS_STAGED}" | tee "${XBL_DUMP_LOG}"
-
-    DTB_PATCH="${XBLCONFIG_DTB}"
-    DTB_SECTION="${XBLCONFIG_DTB_SECTION}"
-    if [ -z "${DTB_PATCH}" ]; then
-        # Parse a line like:
-        #   [+] config_item[6] -> PH# 8 -> './post-ddr-kodiak-1.0.dtb' (90280 bytes)
-        POST_DDR_LINE=$(grep -m1 "post-ddr.*\.dtb" "${XBL_DUMP_LOG}" || true)
-        if [ -n "${POST_DDR_LINE}" ]; then
-            DTB_PATCH=$(echo "${POST_DDR_LINE}" | sed "s|.* -> '||;s|'.*||" | xargs basename)
-            DTB_SECTION=$(echo "${POST_DDR_LINE}" | sed "s/.*PH# \([0-9]*\).*/\1/")
-        fi
-    fi
-
-    if [ -n "${DTB_PATCH}" ]; then
-        ORIG_DTB="${BOOTBINS_STAGED}/${DTB_PATCH}"
-        UPDATED_DTB="${BOOTBINS_STAGED}/${DTB_PATCH%.dtb}-updated.dtb"
-
-        qcom-capsule-tool set-dtb-property \
-            "${ORIG_DTB}" \
-            /sw/uefi/uefiplat \
-            QcCapsuleRootCert \
-            "@list:${ROOT_INC}" \
-            "${UPDATED_DTB}"
-
-        qcom-capsule-tool parse-config \
-            "${BOOTBINS_STAGED}/xbl_config.elf" replace \
-            "${DTB_SECTION}" \
-            "${UPDATED_DTB}" \
-            "${BOOTBINS_STAGED}/xbl_config_patched.elf"
-
-        mv "${BOOTBINS_STAGED}/xbl_config_patched.elf" \
-           "${BOOTBINS_STAGED}/xbl_config.elf"
-
-        touch "${CAPSULE_DIR}/.xbl_with_oem_cert"
+    # Inject OEM root cert into xbl_config.elf when present.  Platforms
+    # without xbl_config.elf (e.g. hamoa) skip this step.
+    if [ -f "${BOOTBINS_STAGED}/xbl_config.elf" ]; then
+        patch_xblconfig_cert "${BOOTBINS_STAGED}/xbl_config.elf"
     fi
 
     qcom-capsule-tool sysfw-version-create \

--- a/classes-recipe/qcom-capsule.bbclass
+++ b/classes-recipe/qcom-capsule.bbclass
@@ -59,13 +59,30 @@ XBLCONFIG_DTB_SECTION ?= ""
 BOOTBINS_DIR ?= "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}"
 
 # ---------------------------------------------------------------------------
-# Custom FvUpdate.xml (optional)
+# Custom / generated FvUpdate.xml
 # ---------------------------------------------------------------------------
 # To provide a board/project-specific capsule layout, append your file to
 # SRC_URI and name it FvUpdate.xml, e.g. in a .bbappend or local.conf:
 #   SRC_URI:append = " file://my-board-FvUpdate.xml;subdir=fvupdate"
 # The class detects a custom FvUpdate.xml placed in ${WORKDIR} and uses
 # it in place of the upstream default.
+#
+# Alternatively, set CAPSULE_ENTRIES to a space-separated list of entry
+# names to generate FvUpdate.xml at build time.  For each name FOO define
+# the following flags on CAPSULE_ENTRY_FOO:
+#
+#   [binary]           - input filename resolved relative to BOOTBINS_STAGED
+#   [dest_disk]        - destination DiskType  (e.g. SPINOR, UFS_LUN1)
+#   [dest_partition]   - destination PartitionName
+#   [dest_guid]        - destination PartitionTypeGUID
+#   [backup_disk]      - backup DiskType       (optional)
+#   [backup_partition] - backup PartitionName  (optional)
+#   [backup_guid]      - backup PartitionTypeGUID (optional)
+#
+# When CAPSULE_ENTRIES is empty the class falls back to a static FvUpdate.xml
+# provided via SRC_URI or the default bundled in cbsp-boot-utilities.
+CAPSULE_FLASH_TYPE ?= "UFS"
+CAPSULE_ENTRIES    ?= ""
 
 inherit python3native deploy
 
@@ -109,6 +126,80 @@ do_configure[noexec] = "1"
 # Ensure boot binaries are deployed before we try to consume them
 do_compile[depends] += "${@'${QCOM_BOOT_FIRMWARE}:do_deploy' if d.getVar('QCOM_BOOT_FIRMWARE') else ''}"
 
+python generate_fvupdate() {
+    """Generate FvUpdate.xml from CAPSULE_ENTRIES when the variable is set."""
+    import os
+
+    entries = d.getVar('CAPSULE_ENTRIES').split()
+    if not entries:
+        return
+
+    flash_type = d.getVar('CAPSULE_FLASH_TYPE')
+    outdir     = d.getVar('B')
+
+    lines = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<FVItems>',
+        '    <Metadata>',
+        '      <BreakingChangeNumber>0</BreakingChangeNumber>',
+        '      <FlashType>%s</FlashType>' % flash_type,
+        '    </Metadata>',
+        '',
+    ]
+
+    for name in entries:
+        def flag(f):
+            return d.getVarFlag('CAPSULE_ENTRY_%s' % name, f) or ''
+
+        binary    = flag('binary')
+        dest_disk = flag('dest_disk')
+        dest_part = flag('dest_partition')
+        dest_guid = flag('dest_guid')
+        bkup_disk = flag('backup_disk')
+        bkup_part = flag('backup_partition')
+        bkup_guid = flag('backup_guid')
+
+        if not binary or not dest_disk or not dest_part:
+            bb.warn('CAPSULE_ENTRY_%s: binary, dest_disk and dest_partition '
+                    'are required; skipping entry' % name)
+            continue
+
+        lines += [
+            '  <FwEntry>',
+            '    <InputBinary>%s</InputBinary>' % binary,
+            '    <InputPath>Images</InputPath>',
+            '    <Operation>UPDATE</Operation>',
+            '    <UpdateType>UPDATE_PARTITION</UpdateType>',
+            '    <BackupType>BACKUP_PARTITION</BackupType>',
+            '    <Dest>',
+            '      <DiskType>%s</DiskType>' % dest_disk,
+            '      <PartitionName>%s</PartitionName>' % dest_part,
+            '      <PartitionTypeGUID>%s</PartitionTypeGUID>' % dest_guid,
+            '    </Dest>',
+        ]
+
+        if bkup_part:
+            lines += [
+                '    <Backup>',
+                '      <DiskType>%s</DiskType>' % bkup_disk,
+                '      <PartitionName>%s</PartitionName>' % bkup_part,
+                '      <PartitionTypeGUID>%s</PartitionTypeGUID>' % bkup_guid,
+                '    </Backup>',
+            ]
+
+        lines += ['  </FwEntry>', '']
+
+    lines.append('</FVItems>')
+
+    os.makedirs(outdir, exist_ok=True)
+    out = os.path.join(outdir, 'FvUpdate.xml')
+    with open(out, 'w') as f:
+        f.write('\n'.join(lines))
+    bb.debug(1, 'Generated %s from CAPSULE_ENTRIES' % out)
+}
+
+do_compile[prefuncs] += "generate_fvupdate"
+
 do_compile() {
     CBSP_DATA="${STAGING_DATADIR_NATIVE}/cbsp-boot-utilities"
     EDK2_BASETOOLS="${STAGING_DATADIR_NATIVE}/edk2-basetools"
@@ -121,9 +212,12 @@ do_compile() {
     # directly below.
     export PYTHONPATH="${EDK2_BASETOOLS}${PYTHONPATH:+:$PYTHONPATH}"
 
-    # Use a board-specific FvUpdate.xml if provided via SRC_URI:append,
-    # otherwise fall back to the default bundled in cbsp-boot-utilities.
-    if [ -f "${WORKDIR}/FvUpdate.xml" ]; then
+    # Use a board-specific FvUpdate.xml if provided via SRC_URI:append or
+    # generated from CAPSULE_ENTRIES, otherwise fall back to the default
+    # bundled in cbsp-boot-utilities.
+    if [ -f "${B}/FvUpdate.xml" ]; then
+        FVUPDATE_XML="${B}/FvUpdate.xml"
+    elif [ -f "${WORKDIR}/FvUpdate.xml" ]; then
         FVUPDATE_XML="${WORKDIR}/FvUpdate.xml"
     else
         FVUPDATE_XML="${CBSP_DATA}/FvUpdate.xml"

--- a/classes-recipe/qcom-capsule.bbclass
+++ b/classes-recipe/qcom-capsule.bbclass
@@ -126,6 +126,9 @@ do_configure[noexec] = "1"
 # Ensure boot binaries are deployed before we try to consume them
 do_compile[depends] += "${@'${QCOM_BOOT_FIRMWARE}:do_deploy' if d.getVar('QCOM_BOOT_FIRMWARE') else ''}"
 
+# Pull in the kernel DTB when capsule includes a dtb entry.
+do_compile[depends] += "${@'virtual/kernel:do_deploy' if 'dtb' in d.getVar('CAPSULE_ENTRIES').split() else ''}"
+
 python generate_fvupdate() {
     """Generate FvUpdate.xml from CAPSULE_ENTRIES when the variable is set."""
     import os
@@ -284,6 +287,16 @@ do_compile() {
     BOOTBINS_STAGED="${CAPSULE_DIR}/bootbins"
     mkdir -p "${BOOTBINS_STAGED}"
     cp -r "${BOOTBINS_DIR}/." "${BOOTBINS_STAGED}/"
+
+    # Stage kernel DTB vfat image as dtb.bin so FVCreation.py can find it
+    # when FvUpdate.xml references dtb.bin.  Only needed when CAPSULE_ENTRIES
+    # includes a dtb entry (avoids touching platforms that don't need it).
+    if echo "${CAPSULE_ENTRIES}" | grep -qw dtb && \
+            [ -n "${QCOM_DTB_DEFAULT}" ] && \
+            [ -f "${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat" ]; then
+        cp "${DEPLOY_DIR_IMAGE}/dtb-${QCOM_DTB_DEFAULT}-image.vfat" \
+            "${BOOTBINS_STAGED}/dtb.bin"
+    fi
 
     # Inject OEM root cert into xbl_config.elf when present.  Platforms
     # without xbl_config.elf (e.g. hamoa) skip this step.

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -29,6 +29,8 @@ QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
 
+CAPSULE_GUID       = "0F6D58FC-2258-4D27-9E23-D77219B0897C"
+
 # Isolate rt cpu
 QCOM_RT_CPU        = "11"
 QCOM_IRQAFF        = "0-10"

--- a/dynamic-layers/meta-arm/recipes-firmware/firmware/firmware-qcom-capsule_%.bbappend
+++ b/dynamic-layers/meta-arm/recipes-firmware/firmware/firmware-qcom-capsule_%.bbappend
@@ -1,0 +1,13 @@
+CAPSULE_FLASH_TYPE:iq-x7181-evk = "NORUFS"
+CAPSULE_ENTRIES:iq-x7181-evk    = "dtb"
+
+# Hamoa stores the Linux DTB FIT image in SPINOR.  The firmware uses a
+# main/backup model: dtb is always the active partition; dtb_BACKUP holds a
+# rollback copy that is overwritten by <Backup> before dtb is updated.
+CAPSULE_ENTRY_dtb[binary]           = "dtb.bin"
+CAPSULE_ENTRY_dtb[dest_disk]        = "SPINOR"
+CAPSULE_ENTRY_dtb[dest_partition]   = "dtb"
+CAPSULE_ENTRY_dtb[dest_guid]        = "{2A1A52FC-AA0B-401C-A808-5EA0F91068F8}"
+CAPSULE_ENTRY_dtb[backup_disk]      = "SPINOR"
+CAPSULE_ENTRY_dtb[backup_partition] = "dtb_BACKUP"
+CAPSULE_ENTRY_dtb[backup_guid]      = "{A166F11A-2B39-4FAA-B7E7-F8AA080D0587}"

--- a/dynamic-layers/meta-arm/recipes-firmware/firmware/firmware-qcom-capsule_1.0.bb
+++ b/dynamic-layers/meta-arm/recipes-firmware/firmware/firmware-qcom-capsule_1.0.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "UEFI FMP capsule for Qualcomm platforms"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-COMPATIBLE_MACHINE = "qcm6490|qcs9100|qcs8300|qcs615"
+COMPATIBLE_MACHINE = "hamoa|qcm6490|qcs615|qcs8300|qcs9100"
 
 PROVIDES += "virtual/qcom-capsule-firmware"
 


### PR DESCRIPTION
   Enable UEFI FMP capsule generation for the Hamoa platform (iq-x7181-evk).
  Hamoa uses SPINOR flash and only updates the DTB partition via capsule.

  This extends the qcom-capsule class with a CAPSULE_ENTRIES mechanism for
  dynamic FvUpdate.xml generation and guards xbl_config.elf cert injection
  for platforms that lack this component.

 Built and verified capsule generation produces a valid .cap file targeting
 the SPINOR dtb/dtb_BACKUP main/backup partitions.
