### PR TITLE
qcom-common.inc: reduce SWIOTLB allocation to 2 MB

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -95,3 +95,5 @@ RT_KERNEL_CMDLINE = "${RT_ARGS_ISOL} ${RT_ARGS_IRQ} ${RT_ARGS_NOCBS} \
 KERNEL_CMDLINE_EXTRA:append = "${@bb.utils.contains_any('PREFERRED_PROVIDER_virtual/kernel',\
                               'linux-qcom-rt linux-qcom-next-rt', \
                               ' ${RT_KERNEL_CMDLINE}', '', d)}"
+
+KERNEL_CMDLINE_EXTRA:append = " swiotlb=128"


### PR DESCRIPTION
The default SWIOTLB allocation of 64 MiB leads to unnecessary kernel reserved memory.

Limit the SWIOTLB pool to 2 MiB by setting swiotlb=128 in the kernel command line.
Validation confirms the allocation is reduced from 64 MiB to 2 MiB.

This change reduces the kernel reserved memory footprint and
improves available RAM for user space.
