### PR TITLE
ci: bump testkit to fix BT_SCAN, IRQ, hotplug, and AudioRecord failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "d02dbbca3e35c3f29dce5aa4c1eac506103f821d"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.05.11"
+  TESTKIT_REF: "testkit-2026.06.01"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
testkit-2026.06.01 fixes BT_SCAN misses from a single scan window, IRQ false failures on tickless CPUs, hotplug failures on fixed CPU ranges across Qualcomm SoCs, and AudioRecord false failures on platforms with no PipeWire capture source by skipping instead of failing.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>