### PR TITLE
workflows: only run qcom-distro with 6.18 kernel on master

### DIFF
--- a/.github/workflows/test-pr-wrynose.yml
+++ b/.github/workflows/test-pr-wrynose.yml
@@ -27,17 +27,18 @@ jobs:
           BRANCH=$(echo "$PULL_REQUESTS_JSON" | jq -r '.[0].base.ref // "master"')
           echo "value=$BRANCH" >> "$GITHUB_OUTPUT"
 
-  test:
+  test-wrynose:
     needs: determine-target-branch
-    if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'master'
-    uses: ./.github/workflows/test.yml
+    if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'wrynose'
+    uses: qualcomm-linux/meta-qcom/.github/workflows/test.yml@wrynose
     secrets: inherit
     with:
       build_id: ${{ github.event.workflow_run.id }}
 
   comment-on-pr:
     name: "Comment on PR"
-    needs: test
+    needs: [test-wrynose]
+    if: always() && (needs.test-wrynose.result == 'success')
     runs-on: ubuntu-latest
     steps:
 
@@ -45,7 +46,7 @@ jobs:
         id: download-result-summary
         uses: actions/download-artifact@v7
         with:
-          artifact-ids: ${{ needs.test.outputs.summary_ids }}
+          artifact-ids: ${{ needs.test-wrynose.outputs.summary_ids }}
           path: results_summary
 
       - name: Download event file
@@ -86,7 +87,8 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/publish-results.yml
     secrets: inherit
-    needs: [test]
+    needs: [test-wrynose]
+    if: always() && (needs.test-wrynose.result == 'success')
     with:
       commit: ${{ github.event.workflow_run.sha }}
       event_file: artifacts/Event File/event.json


### PR DESCRIPTION
There are 2 tracks for running PR tests in meta-qcom branches: master and wrynrose. The build matrix in these branches diverged and qcom-distro with 6.18 kernel is not a separate build on wrynrose. When submitting a PR against wrynrose test workflow from master branch is used. For this reason the workflow from master must implement the logic to select branch specific test plan.