### PR TITLE
Enable EL2 DTBO support for Hamoa and Purwa platforms

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -20,6 +20,7 @@ require conf/machine/include/fit-dtb-compatible.inc
 # ---------- hamoa  ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx hamoa-staging"
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-el2kvm] = "hamoa-iot-evk hamoa-evk-camx x1-el2 hamoa-camx-el2"
 
 # ---------- purwa -----------
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -23,6 +23,7 @@ FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx 
 
 # ---------- purwa -----------
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2"
 
 # ---------- lemans ----------
 

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/purwa-evk-camx.dtbo \
+    qcom/purwa-camx-el2.dtbo \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -16,6 +16,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/hamoa-evk-camx.dtbo \
     qcom/hamoa-staging.dtbo \
+    qcom/hamoa-camx-el2.dtbo \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Description:
  ## Summary

  - Add x1-el2.dtbo and hamoa-camx-el2.dtbo for Hamoa (iq-x7181-evk)
  - Add x1-el2.dtbo, purwa-evk-camx.dtbo, and purwa-camx-el2.dtbo for Purwa (iq-x5121-evk)
  - Add FIT_DTB_COMPATIBLE entries for EL2/KVM boot configurations

  This enables KVM/EL2 boot support on Hamoa and Purwa IoT EVK platforms,
  following the same pattern as PR #1851 for Monaco/Lemans.

  ## Dependencies

  - qualcomm-linux/kernel#587 (hamoa-camx-el2.dtso) — merged
  - qualcomm-linux/kernel#610 (purwa-camx-el2.dtso) — merged