### PR TITLE
packagegroup-purwa-iot-evk: add Purwa-specific DSP binaries

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
@@ -19,6 +19,6 @@ RRECOMMENDS:${PN}-firmware = " \
 
 # Purwa IoT EVK and Hamoa IoT EVK share the same Hexagon DSP binaries.
 RDEPENDS:${PN}-hexagon-dsp-binaries = " \
-    hexagon-dsp-binaries-qcom-hamoa-iot-evk-adsp \
-    hexagon-dsp-binaries-qcom-hamoa-iot-evk-cdsp \
+    hexagon-dsp-binaries-qcom-purwa-iot-evk-adsp \
+    hexagon-dsp-binaries-qcom-purwa-iot-evk-cdsp \
 "


### PR DESCRIPTION
Purwa currently reuses Hamoa DSP binaries via symlinks, but still needs its own hexagon-dsp-binaries packages to ensure the binaries are properly deployed to the target rootfs.

Add hexagon-dsp-binaries-qcom-purwa-iot-evk-adsp and hexagon-dsp-binaries-qcom-purwa-iot-evk-cdsp to RDEPENDS