### PR TITLE
meta-qcom: recipes-kernel: linux: skip BT devices  without bt-enable GPIO

### DIFF
--- a/recipes-kernel/linux/linux-qcom-6.18/power-sequencing-qcom-wcn-skip-BT-devices-without.patch
+++ b/recipes-kernel/linux/linux-qcom-6.18/power-sequencing-qcom-wcn-skip-BT-devices-without.patch
@@ -1,0 +1,72 @@
+From e911689ee64ed4e98c2c33c4f6d572e3c5dcafeb Mon Sep 17 00:00:00 2001
+From: Shuai Zhang <shuai.zhang@oss.qualcomm.com>
+Date: Fri, 29 May 2026 14:55:17 +0800
+Subject: [PATCH v1] power: sequencing: qcom-wcn: skip BT devices without
+ bt-enable GPIO
+
+Add a bt_gpio_required flag to the per-platform data to indicate that
+a chip's BT enable path requires a dedicated GPIO.  Only skip matching
+the "bluetooth" device node when this flag is set and bt_gpio is absent.
+
+Previously the bt_gpio check was applied unconditionally, which caused
+chips like WCN3990 that have no separate BT/WLAN enable pins by design
+to fail matching even when bt-enable GPIO is legitimately absent from
+the DT.  Set bt_gpio_required for WCN6855 and WCN7850 which do require
+a dedicated BT enable GPIO.
+
+Upstream-Status: Pending
+Signed-off-by: Shuai Zhang <shuai.zhang@oss.qualcomm.com>
+---
+ drivers/power/sequencing/pwrseq-qcom-wcn.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/power/sequencing/pwrseq-qcom-wcn.c b/drivers/power/sequencing/pwrseq-qcom-wcn.c
+index 916fa0560..13541145b 100644
+--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
++++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
+@@ -23,6 +23,7 @@ struct pwrseq_qcom_wcn_pdata {
+ 	unsigned int pwup_delay_ms;
+ 	unsigned int gpio_enable_delay_ms;
+ 	const struct pwrseq_target_data **targets;
++	bool bt_gpio_required;
+ };
+ 
+ struct pwrseq_qcom_wcn_ctx {
+@@ -309,6 +310,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn6855_of_data = {
+ 	.pwup_delay_ms = 50,
+ 	.gpio_enable_delay_ms = 5,
+ 	.targets = pwrseq_qcom_wcn6855_targets,
++	.bt_gpio_required = true,
+ };
+ 
+ static const char *const pwrseq_wcn7850_vregs[] = {
+@@ -326,6 +328,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn7850_of_data = {
+ 	.num_vregs = ARRAY_SIZE(pwrseq_wcn7850_vregs),
+ 	.pwup_delay_ms = 50,
+ 	.targets = pwrseq_qcom_wcn_targets,
++	.bt_gpio_required = true,
+ };
+ 
+ static int pwrseq_qcom_wcn_match(struct pwrseq_device *pwrseq,
+@@ -364,11 +367,17 @@ static int pwrseq_qcom_wcn_match(struct pwrseq_device *pwrseq,
+ 	 * The consumer driver will fall back to its legacy power control path
+ 	 * and correctly set power_ctrl_enabled to false.
+ 	 *
++	 * Only apply this check for chips whose BT enable path requires a
++	 * dedicated GPIO (bt_gpio_required).  Chips like WCN3990 have no
++	 * separate BT/WLAN enable pins by design and must always be matched
++	 * even when bt_gpio is NULL.
++	 *
+ 	 * BT device nodes are conventionally named "bluetooth" in the DT,
+ 	 * so use of_node_name_eq() as a generic check rather than enumerating
+ 	 * specific compatible strings.
+ 	 */
+-	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
++	if (ctx->pdata->bt_gpio_required && !ctx->bt_gpio &&
++	    of_node_name_eq(dev_node, "bluetooth"))
+ 		return PWRSEQ_NO_MATCH;
+ 
+ 	return PWRSEQ_MATCH_OK;
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-next/power-sequencing-qcom-wcn-skip-BT-devices-without.patch
+++ b/recipes-kernel/linux/linux-qcom-next/power-sequencing-qcom-wcn-skip-BT-devices-without.patch
@@ -1,0 +1,72 @@
+From 1221c8f1459df8005a3221b7e9f950f9c64687da Mon Sep 17 00:00:00 2001
+From: Shuai Zhang <shuai.zhang@oss.qualcomm.com>
+Date: Fri, 29 May 2026 14:09:54 +0800
+Subject: power: sequencing: qcom-wcn: skip BT devices without
+ bt-enable GPIO
+
+Add a bt_gpio_required flag to the per-platform data to indicate that
+a chip's BT enable path requires a dedicated GPIO.  Only skip matching
+the "bluetooth" device node when this flag is set and bt_gpio is absent.
+
+Previously the bt_gpio check was applied unconditionally, which caused
+chips like WCN3990 that have no separate BT/WLAN enable pins by design
+to fail matching even when bt-enable GPIO is legitimately absent from
+the DT.  Set bt_gpio_required for WCN6855 and WCN7850 which do require
+a dedicated BT enable GPIO.
+
+Upstream-Status: Pending
+Signed-off-by: Shuai Zhang <shuai.zhang@oss.qualcomm.com>
+---
+ drivers/power/sequencing/pwrseq-qcom-wcn.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/power/sequencing/pwrseq-qcom-wcn.c b/drivers/power/sequencing/pwrseq-qcom-wcn.c
+index dc83d3241..a68e6fb34 100644
+--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
++++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
+@@ -25,6 +25,7 @@ struct pwrseq_qcom_wcn_pdata {
+ 	unsigned int gpio_enable_delay_ms;
+ 	const struct pwrseq_target_data **targets;
+ 	bool has_vddio; /* separate VDD IO regulator */
++	bool bt_gpio_required; /* BT enable path requires a dedicated GPIO */
+ 	int (*match)(struct pwrseq_device *pwrseq, struct device *dev);
+ };
+ 
+@@ -383,6 +384,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn6855_of_data = {
+ 	.pwup_delay_ms = 50,
+ 	.gpio_enable_delay_ms = 5,
+ 	.targets = pwrseq_qcom_wcn6855_targets,
++	.bt_gpio_required = true,
+ };
+ 
+ static const char *const pwrseq_wcn7850_vregs[] = {
+@@ -400,6 +402,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn7850_of_data = {
+ 	.num_vregs = ARRAY_SIZE(pwrseq_wcn7850_vregs),
+ 	.pwup_delay_ms = 50,
+ 	.targets = pwrseq_qcom_wcn_targets,
++	.bt_gpio_required = true,
+ };
+ 
+ static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
+@@ -439,11 +442,17 @@ static int pwrseq_qcom_wcn_match_regulator(struct pwrseq_device *pwrseq,
+ 	 * The consumer driver will fall back to its legacy power control path
+ 	 * and correctly set power_ctrl_enabled to false.
+ 	 *
++	 * Only apply this check for chips whose BT enable path requires a
++	 * dedicated GPIO (bt_gpio_required).  Chips like WCN3990 have no
++	 * separate BT/WLAN enable pins by design and must always be matched
++	 * even when bt_gpio is NULL.
++	 *
+ 	 * BT device nodes are conventionally named "bluetooth" in the DT,
+ 	 * so use of_node_name_eq() as a generic check rather than enumerating
+ 	 * specific compatible strings.
+ 	 */
+-	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
++	if (ctx->pdata->bt_gpio_required && !ctx->bt_gpio &&
++	    of_node_name_eq(dev_node, "bluetooth"))
+ 		return PWRSEQ_NO_MATCH;
+ 
+ 	return PWRSEQ_MATCH_OK;
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -23,6 +23,7 @@ SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=http
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://power-sequencing-qcom-wcn-skip-BT-devices-without.patch \
 "
 
 # To build tip of qcom-next branch set preferred

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -23,6 +23,7 @@ SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https \
     file://0001-tools-use-basename-to-identify-file-in-gen-mach-type.patch \
+    file://power-sequencing-qcom-wcn-skip-BT-devices-without.patch \
 "
 
 # Additional kernel configs.


### PR DESCRIPTION
This patch is solely for CI validation to check whether the changes affect other platforms no review is needed.

If I mark it as draft, CI may not run.
If this approach is inappropriate, please feel free to close this PR