### PR TITLE
Add rtc testbench and xdp-tools recipes

### DIFF
--- a/recipes-support/xdp-tools/files/0001-configure-skip-toolchain-checks.patch
+++ b/recipes-support/xdp-tools/files/0001-configure-skip-toolchain-checks.patch
@@ -1,0 +1,46 @@
+From 029e6ac07998cadd6fcf0a51ac353e28aecd9d8d Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+Date: Tue, 19 May 2026 18:18:09 +0530
+Subject: [PATCH 1/2] configure: skip toolchain checks
+
+Current logic fetch full command line along with the tool. i.e
+gcc -m64 -march=skylake -mtune=generic ...
+
+Which throws ERROR: Cannot find tool -m64
+
+So need to re-write for loop, so it can work in cross-compilation
+environment too.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+---
+ configure | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configure b/configure
+index d57b2ae..842d206 100755
+--- a/configure
++++ b/configure
+@@ -70,12 +70,12 @@ check_toolchain()
+ 
+     CLANG=$(find_tool clang "$CLANG")
+ 
+-    for TOOL in $PKG_CONFIG $CC $OBJCOPY $CLANG $M4 $READELF; do
+-        if [ ! $(command -v ${TOOL} 2>/dev/null) ]; then
+-            echo "*** ERROR: Cannot find tool ${TOOL}" ;
+-            exit 1;
+-        fi;
+-    done
++    #for TOOL in $PKG_CONFIG $CC $OBJCOPY $CLANG $M4 $READELF; do
++    #    if [ ! $(command -v ${TOOL} 2>/dev/null) ]; then
++    #        echo "*** ERROR: Cannot find tool ${TOOL}" ;
++    #        exit 1;
++    #    fi;
++    #done
+ 
+     ARCH_NAME=$($CC -print-multiarch 2>/dev/null)
+ 
+-- 
+2.34.1
+

--- a/recipes-support/xdp-tools/files/0002-Makefile-fix-KeyError-failure.patch
+++ b/recipes-support/xdp-tools/files/0002-Makefile-fix-KeyError-failure.patch
@@ -1,0 +1,42 @@
+From 8c4842b47ddd31d531b5ec254a86985df437ba96 Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+Date: Tue, 19 May 2026 18:23:21 +0530
+Subject: [PATCH 2/2] Makefile: fix KeyError failure
+
+OE runs all install tasks under pseudo: a UID/GID faking layer that
+intercepts filesystem calls so that files can be owned by root in the
+package even though the build runs as a non-root user.
+
+When cp -p copies the library files, it calls lchown() on the
+destination to match the source ownership. Pseudo intercepts this
+lchown() call and internally tries to resolve the UID to a username
+using Python's pwd.getpwuid(). In a container or CI environment the
+build user has a synthetic UID that does not exist in /etc/passwd.
+Python's pwd.getpwuid() raises KeyError, which crashes pseudo and
+fails the install task:
+
+  Exception: KeyError: 'getpwuid(): uid not found: 11857215'
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+---
+ lib/libxdp/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 7ea7e7e..2b939ce 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -56,7 +56,7 @@ install: all
+ 	$(Q)install -d -m 0755 $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(Q)install -m 0644 $(LIB_HEADERS) $(DESTDIR)$(HDRDIR)/
+ 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
+-	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
++	$(Q)cp -fpR --no-preserve=ownership $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
+ 	$(Q)install -m 0644 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+ 	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
+-- 
+2.34.1
+

--- a/recipes-support/xdp-tools/xdp-tools_1.6.3.bb
+++ b/recipes-support/xdp-tools/xdp-tools_1.6.3.bb
@@ -1,0 +1,49 @@
+SUMMARY = "Utilities and library for managing XDP/eBPF programs"
+
+DESCRIPTION = "xdp-tools provides libxdp and command-line utilities for working \
+with XDP eBPF programs in Linux, including tools for loading programs, packet \
+processing, monitoring, traffic generation, and benchmarking."
+
+HOMEPAGE = "https://github.com/xdp-project/xdp-tools"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later & BSD-2-Clause"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=9ee53f8d06bbdb4c11b1557ecc4f8cd5 \
+    file://LICENSES/GPL-2.0;md5=994331978b428511800bfbd17eea3001 \
+    file://LICENSES/LGPL-2.1;md5=b370887980db5dd40659b50909238dbd \
+    file://LICENSES/BSD-2-Clause;md5=5d6306d1b08f8df623178dfd81880927 \
+"
+SRC_URI = " \
+    git://github.com/xdp-project/xdp-tools.git;tag=v1.6.3;nobranch=1;protocol=https \
+    file://0001-configure-skip-toolchain-checks.patch \
+    file://0002-Makefile-fix-KeyError-failure.patch \
+"
+SRCREV = "8fbad9f0af621a22aa87ff2520b3735915b1f0fd"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+DEPENDS += " \
+    libbpf \
+    clang-native \
+    zlib \
+    elfutils \
+    libpcap \
+"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE += " \
+    PREFIX=${prefix} \
+    LIBDIR=${libdir} \
+    PRODUCTION=1 \
+    BPF_CFLAGS='-D__aarch64__ -I${S}/headers -I${STAGING_INCDIR} -ffile-prefix-map=${S}=${TARGET_DBGSRC_DIR} -ffile-prefix-map=${STAGING_DIR_HOST}=' \
+"
+
+do_install () {
+    oe_runmake DESTDIR=${D} install
+}
+
+FILES:${PN} += "${libdir}/bpf ${libdir}/bpf/*"
+RDEPENDS:${PN} += "bash"

--- a/recipes-test/rtc-testbench/files/0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch
+++ b/recipes-test/rtc-testbench/files/0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch
@@ -1,0 +1,59 @@
+From 63c71fb903b2fd687f60e6bdebbd6b131e1e33fb Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+Date: Thu, 21 May 2026 15:42:23 +0530
+Subject: [PATCH] CMakeLists.txt: make BPF clang and include paths configurable
+ for cross-builds
+
+The upstream CMakeLists.txt hardcodes the clang binary name and derives
+the BPF include path from CMAKE_C_LIBRARY_ARCHITECTURE, which is empty
+in a cross-compilation environment. This causes the BPF kernel programs
+to be compiled with the host clang and -I /usr/include/ (the build host
+include path), which fails with:
+
+  fatal error: 'asm/types.h' file not found
+
+Fix by converting the hardcoded values to CMake CACHE variables so they
+can be overridden from the recipe via -DCLANG=, -DBPF_INCLUDE_DIRS=, and
+-DBPF_EXTRA_FLAGS=. The defaults preserve the original upstream behaviour
+for native builds.
+
+Upstream-Status: Inappropriate [OE cross-compilation specific]
+
+Signed-off-by: Rajkumar Patel <rajkpate@qti.qualcomm.com>
+---
+ CMakeLists.txt | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f782304..b4b32a1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -174,15 +174,21 @@ include_directories("${PROJECT_BINARY_DIR}")
+ #
+ # Add code for compiling XDP eBPF programes.
+ #
+-set(ASM_INCLUDE "/usr/include/${CMAKE_C_LIBRARY_ARCHITECTURE}")
++set(CLANG "clang" CACHE STRING "Clang binary used for BPF compilation")
++set(BPF_INCLUDE_DIRS "" CACHE STRING "Sysroot include path for BPF compilation")
++set(BPF_EXTRA_FLAGS "" CACHE STRING "Extra flags for BPF clang compilation (space-separated)")
++
++separate_arguments(BPF_EXTRA_FLAGS_LIST UNIX_COMMAND "${BPF_EXTRA_FLAGS}")
++
+ set(CLANG_FLAGS -Wall -O2 -fno-stack-protector
+-    -I ${ASM_INCLUDE}
+-    -I ${PROJECT_BINARY_DIR}  # required for app_config.h
++    ${BPF_EXTRA_FLAGS_LIST}
++    -I ${BPF_INCLUDE_DIRS}
++    -I ${PROJECT_BINARY_DIR}
+ )
+ 
+ function(add_xdp_prog name)
+   add_custom_target(${name} ALL
+-    COMMAND clang ${CLANG_FLAGS} -target bpf -c -g -o ${CMAKE_BINARY_DIR}/${name}.o ${name}.c
++    COMMAND ${CLANG} ${CLANG_FLAGS} -target bpf -c -g -o ${CMAKE_BINARY_DIR}/${name}.o ${name}.c
+     DEPENDS reference
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+     SOURCES src/${name}.c
+-- 
+2.34.1
+

--- a/recipes-test/rtc-testbench/rtc-testbench_5.4.bb
+++ b/recipes-test/rtc-testbench/rtc-testbench_5.4.bb
@@ -1,0 +1,44 @@
+SUMMARY = "Real-time and non-real-time traffic validation tool for converged TSN networks"
+
+DESCRIPTION = "The Linux RealTime Communication Testbench validates real-time \
+performance and robustness of hardware, drivers, and the Linux network stack on \
+TSN-enabled Ethernet networks. It generates and mirrors cyclic traffic using \
+AF_PACKET or AF_XDP with eBPF, supporting protocols like PROFINET and OPC UA PubSub."
+
+HOMEPAGE = "https://github.com/Linutronix/RTC-Testbench"
+LICENSE = "BSD-2-Clause & (GPL-2.0-only | BSD-2-Clause)"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=f39e57686080f8752e19c4cd3e04e351 \
+    file://LICENSES/BSD-2-Clause.txt;md5=9e16594a228301089d759b4f178db91f \
+    file://LICENSES/GPL-2.0-only.txt;md5=3d26203303a722dedc6bf909d95ba815 \
+"
+SRC_URI = " \
+    git://github.com/Linutronix/RTC-Testbench.git;tag=v5.4;nobranch=1;protocol=https \
+    file://0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch \
+"
+SRCREV = "bf016fdf422094f1ef65c0d88f148f46663ebbd8"
+
+# This package is currently only used and tested on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
+DEPENDS += " \
+    libyaml \
+    libbpf \
+    xdp-tools \
+    openssl \
+    clang-native \
+"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE += " \
+    -DRX_TIMESTAMP=ON \
+    -DTX_TIMESTAMP=ON \
+    -DCLANG=${STAGING_BINDIR_NATIVE}/clang \
+    -DBPF_INCLUDE_DIRS=${STAGING_INCDIR} \
+    -DBPF_EXTRA_FLAGS='-D__aarch64__ -ffile-prefix-map=${S}=${TARGET_DBGSRC_DIR} -ffile-prefix-map=${STAGING_DIR_HOST}=' \
+"
+
+RDEPENDS:${PN} += "bash"


### PR DESCRIPTION
Add recipes for `xdp-tools` and `rtc-testbench`.

`xdp-tools` provides `libxdp`, which is required by `rtc-testbench` for
AF_XDP/eBPF packet processing support.

`rtc-testbench` is the Linux RealTime Communication Testbench from Linutronix
and is used to validate real-time networking performance on TSN-enabled
Ethernet networks.