### PR TITLE
[Wrynose] ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,22 +3,22 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
+            commit: 06dd66e6220e5ce4ed4b9af4d8231ae5f0a8ce80
         bitbake:
-            commit: a2dd9be788274d9c7280be5b1be5eb5c3990cf54
+            commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:
-            commit: d987a5945802dcbbc06be91a0d34f00431ea840e
+            commit: d3b55902fb9963978be90d6f283296de456b4b63
         meta-openembedded:
-            commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
+            commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
         meta-virtualization:
-            commit: 052241689a0c419d13e15e83e7ad65dd16fc8ffd
+            commit: 959a211fbba059689a1c3a1b24fe0abb9224281a
         meta-audioreach:
-            commit: 75402c8d1ea1203dcf3a63792161f7d5d93946bb
+            commit: aeb4ca3af42ab593497647c8ed98807c18495b16
         meta-selinux:
-            commit: f7306d7af4425553684a860df6f6d0ee66efba31
+            commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:
-            commit: 7fbd0d7d73d4e252ee31e5260e547cbf17945a82
+            commit: 7f5eef0421e966234230ee8f4e4a93e3fc8e3ac6
         meta-security:
-            commit: 596b966a0d047c2f48cb768821558e918ae0c477
+            commit: c0d1d6200e7a84c39fb940cb1f22aad4b0b3d808
         meta-dpdk:
             commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257


### PR DESCRIPTION
Update meta-arm, meta-audioreach, meta-security, meta-updater, oe-core, meta-oe and bitbake layers to the latest available SHAs on wrynose.
