### PR TITLE
[Backport wrynose] ci: enable KVM builds for rb3gen2-core-kit and iq-615-evk

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -319,6 +319,22 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: rb3gen2-core-kit
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: iq-615-evk
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: qcom-armv7a
             distro:
                 name: nodistro


### PR DESCRIPTION
Backport of #2144 to `wrynose`.