### PR TITLE
[Backport wrynose] fit-dtb-compatible: invert key direction and split linux-qcom-only entries

### DIFF
--- a/classes-recipe/dtb-fit-image.bbclass
+++ b/classes-recipe/dtb-fit-image.bbclass
@@ -7,7 +7,12 @@
 inherit kernel-arch
 
 require conf/image-fitimage.conf
-require conf/machine/include/fit-dtb-compatible.inc
+
+# Selects which FIT_DTB_COMPATIBLE include to load.  Defaults to the base
+# file; set to fit-dtb-compatible-linux-qcom.inc in linux-qcom* kernel
+# recipes to extend with linux-qcom-only overlay entries.
+LINUX_QCOM_FIT_DTB_COMPATIBLE ?= "conf/machine/include/fit-dtb-compatible.inc"
+require ${LINUX_QCOM_FIT_DTB_COMPATIBLE}
 
 DEPENDS += "\
     u-boot-tools-native \

--- a/classes-recipe/dtb-fit-image.bbclass
+++ b/classes-recipe/dtb-fit-image.bbclass
@@ -53,30 +53,45 @@ python do_generate_qcom_fitimage() {
     # Collect DTB/DTBO names selected in KERNEL_DEVICETREE to validate declarative FIT_DTB_COMPATIBLE combinations
     dtb_keys_list  = {os.path.splitext(f)[0].replace(',', '_') for f in files_set}
 
-    # Parse composite compatible keys :
-    # FIT_DTB_COMPATIBLE[base+ovl1+ovl2] = "..."
+    # Parse FIT_DTB_COMPATIBLE[<encoded-compat>] = "<dtb-stem> [<overlay-stem>...]"
+    # Flag keys encode commas as underscores (BitBake syntax constraint); decode
+    # with replace('_', ',') to recover the actual compatible string.
+    base_compats = {}   # base_dtb_id -> space-separated compat string(s)
     overlay_groups  = {}
     overlay_compats = {}
+    seen_combos = set()  # track overlay combos already added to overlay_groups
 
     compat_flags = d.getVarFlags("FIT_DTB_COMPATIBLE") or {}
-    for key, compat_val in compat_flags.items():
-        if '+' not in key:
-            continue
+    for encoded_key, combo_val in compat_flags.items():
+        compat_str = encoded_key.replace('_', ',')
 
-        parts = [os.path.basename(p) for p in key.split('+')]
+        parts = [os.path.basename(p) for p in combo_val.split()]
         if not parts:
             continue
 
-        # Skip base+overlay combinations not present in KERNEL_DEVICETREE to avoid generating invalid FIT configs
-        # from declarative FIT_DTB_COMPATIBLE metadata
+        # Skip combinations not present in KERNEL_DEVICETREE to avoid generating
+        # invalid FIT configs from declarative FIT_DTB_COMPATIBLE metadata.
         if not all(dtb in dtb_keys_list for dtb in parts):
             continue
 
         base = parts[0] + ".dtb"
+        base_dtb_id = base.replace(',', '_')
         overlays = [ovl + ".dtbo" for ovl in parts[1:]]
 
-        overlay_groups.setdefault(base, []).append(overlays)
-        overlay_compats[key] = compat_val
+        if overlays:
+            # Encode commas as underscores so combo_key matches the lookup_key
+            # built in fitimage_emit_section_qcomconfig (dtb_only_fitimage.py),
+            # which applies the same replacement; keep overlay_groups keyed by
+            # the encoded base id for the same reason.
+            combo_key = " ".join(p.replace(',', '_') for p in parts)
+            if combo_key not in seen_combos:
+                overlay_groups.setdefault(base_dtb_id, []).append(overlays)
+                seen_combos.add(combo_key)
+            existing = overlay_compats.get(combo_key, "")
+            overlay_compats[combo_key] = (existing + " " + compat_str).strip()
+        else:
+            existing = base_compats.get(base_dtb_id, "")
+            base_compats[base_dtb_id] = (existing + " " + compat_str).strip()
 
     # Emit DTB/DTBO sections for every entry from KERNEL_DEVICETREE
     for fname in files_set:
@@ -87,10 +102,13 @@ python do_generate_qcom_fitimage() {
         dtb_id = fname.replace(',', '_')
         compatible = ""
         if fname.endswith(".dtb"):
-            dtb_key = os.path.splitext(dtb_id)[0]
-            compatible = d.getVarFlag("FIT_DTB_COMPATIBLE", dtb_key) or ""
+            compatible = base_compats.get(dtb_id, "")
             if not compatible and dtb_id not in overlay_groups:
-                bb.fatal(f"FIT_DTB_COMPATIBLE[{dtb_key}] is not set for '{fname}'.")
+                bb.note(
+                    f"No FIT_DTB_COMPATIBLE entry covers '{fname}' for this "
+                    f"kernel variant; it will appear in the FIT image but have "
+                    f"no config node."
+                )
 
         root_node.fitimage_emit_section_dtb(dtb_id, dtb_path, compatible_str=compatible, dtb_type="flat_dt")
 

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -1,0 +1,198 @@
+# FIT_DTB_COMPATIBLE overrides for linux-qcom kernel variants.
+#
+# Extends fit-dtb-compatible.inc with entries whose combos include overlays
+# from LINUX_QCOM_KERNEL_DEVICETREE (overlays not available in linux-yocto).
+# Loaded automatically for linux-qcom* kernels via LINUX_QCOM_FIT_DTB_COMPATIBLE
+# in dtb-fit-image.bbclass; the base file is not loaded separately.
+#
+# A key that also exists in the base file will be overridden here because
+# BitBake applies last-write-wins for flag variables, and this file is
+# included after fit-dtb-compatible.inc.
+#
+# Syntax:
+# FIT_DTB_COMPATIBLE[<compatible-encoded>] = "<dtb-stem> [<overlay-stem> [<overlay-stem>...]]"
+#
+# <compatible-encoded> is the DT compatible string with every comma replaced
+# by an underscore (BitBake flag names cannot contain commas).
+
+require conf/machine/include/fit-dtb-compatible.inc
+
+# ---------- hamoa  ----------
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
+
+# ---------- lemans ----------
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
+    "lemans-evk lemans-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
+    "lemans-evk lemans-evk-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm-staging] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
+    "lemans-evk lemans-evk-ifp-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
+    "qcs9100-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm] = \
+    "qcs9100-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm-staging] = \
+    "qcs9100-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
+    "qcs9100-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
+    "qcs9100-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
+    "qcs9100-ride-r3 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm] = \
+    "qcs9100-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm-staging] = \
+    "qcs9100-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
+    "sa8775p-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm] = \
+    "sa8775p-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm-staging] = \
+    "sa8775p-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
+    "sa8775p-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
+    "sa8775p-ride-r3 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm] = \
+    "sa8775p-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm-staging] = \
+    "sa8775p-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+
+# ---------- monaco ----------
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = "monaco-evk monaco-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
+    "monaco-evk monaco-evk-camx monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm-staging] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = "qcs8300-ride monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm] = "qcs8300-ride monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm-staging] = \
+    "qcs8300-ride monaco-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = "qcs8300-ride qcs8300-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
+
+# ---------- talos ----------
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
+    "qcs615-ride talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm] = \
+    "qcs615-ride talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm-staging] = \
+    "qcs615-ride talos-el2 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = "talos-evk talos-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
+    "talos-evk talos-evk-camx talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm] = \
+    "talos-evk talos-evk-camx talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm-staging] = \
+    "talos-evk talos-evk-camx talos-el2 talos-staging"
+# Compatible string "qcom,talos-evk-lvds-auo,g133han01-staging" encodes as
+# "qcom_talos-evk-lvds-auo_g133han01-staging" (both commas become underscores).
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
+
+# ---------- kodiak ----------
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-el2kvm] = "qcm6490-idp kodiak-el2"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-el2kvm] = \
+    "qcs6490-rb3gen2 kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-el2kvm] = \
+    "qcs6490-rb3gen2 kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-staging] = \
+    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-staging] = \
+    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -1,238 +1,242 @@
-# Mapping from a DTB (and optional overlays on top) to its
-# Device Tree "compatible" string(s).
+# Mapping from a Device Tree compatible string to the DTB (and optional
+# overlays) that implement it.
 #
 # Syntax:
-# FIT_DTB_COMPATIBLE[<dtb-name>[+<overlay>[+<overlay>...]]] = "<compatible>[ <compatible>[ <compatible>...]]"
+# FIT_DTB_COMPATIBLE[<compatible-encoded>] = "<dtb-stem>[ <overlay-stem>[ <overlay-stem>...]]"
+#
+# <compatible-encoded> is the DT compatible string with every comma replaced
+# by an underscore (BitBake flag names cannot contain commas).  For example,
+# "qcom,apq8016-sbc" is written as "qcom_apq8016-sbc".
+#
+# Rules
+# -----
+# - do_generate_qcom_fitimage silently skips any combo whose files are absent
+#   from KERNEL_DEVICETREE, so entries that reference linux-qcom-only overlays
+#   (el2, camx, staging, ifp-mezzanine) are safely ignored for linux-yocto builds.
 
-FIT_DTB_COMPATIBLE[apq8016-sbc] = "qcom,apq8016-sbc"
-FIT_DTB_COMPATIBLE[apq8096-db820c] = "qcom,apq8096-sbc"
-FIT_DTB_COMPATIBLE[glymur-crd] = "qcom,glymur-crd"
-FIT_DTB_COMPATIBLE[hamoa-iot-evk+hamoa-iot-evk-camera-imx577] = " \
-    qcom,hamoa-evk \
-"
-FIT_DTB_COMPATIBLE[hamoa-iot-evk+hamoa-evk-camx] = " \
-    qcom,hamoa-evk-camx \
-"
-FIT_DTB_COMPATIBLE[kaanapali-mtp] = "qcom,kaanapali-mtp"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577] = " \
-    qcom,qcs9075-iot \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577+lemans-staging] = " \
-    qcom,qcs9075-iot-staging \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx] = " \
-    qcom,qcs9075-iot-camx \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-staging] = " \
-    qcom,qcs9075-iot-camx-staging \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577+lemans-el2] = " \
-    qcom,qcs9075-iot-el2kvm \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camera-csi1-imx577+lemans-el2+lemans-staging] = " \
-    qcom,qcs9075-iot-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2+lemans-camx-el2] = " \
-    qcom,qcs9075-iot-camx-el2kvm \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-camx+lemans-el2+lemans-camx-el2+lemans-staging] = " \
-    qcom,qcs9075-iot-camx-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine] = " \
-    qcom,qcs9075-iot-subtype1 \
-"
-FIT_DTB_COMPATIBLE[lemans-evk+lemans-evk-ifp-mezzanine+lemans-staging+lemans-evk-staging] = " \
-    qcom,qcs9075-iot-subtype1-staging \
-"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577+monaco-el2] = "qcom,qcs8275-iot-el2kvm"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577+monaco-el2+monaco-staging] = "qcom,qcs8275-iot-el2kvm-staging"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577] = "qcom,qcs8275-iot"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camera-imx577+monaco-staging] = "qcom,qcs8275-iot-staging"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx] = "qcom,qcs8275-iot-camx"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx+monaco-staging] = "qcom,qcs8275-iot-camx-staging"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx+monaco-el2+monaco-camx-el2] = "qcom,qcs8275-iot-camx-el2kvm"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-camx+monaco-el2+monaco-camx-el2+monaco-staging] = "qcom,qcs8275-iot-camx-el2kvm-staging"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine] = "qcom,qcs8275-iot-subtype3"
-FIT_DTB_COMPATIBLE[monaco-evk+monaco-evk-ifp-mezzanine+monaco-staging+monaco-evk-staging] = "qcom,qcs8275-iot-subtype3-staging"
-FIT_DTB_COMPATIBLE[purwa-iot-evk] = "qcom,purwa-evk"
-FIT_DTB_COMPATIBLE[qcm6490-idp] = "qcom,qcm6490-idp"
-FIT_DTB_COMPATIBLE[qcm6490-idp+kodiak-staging] = "qcom,qcm6490-idp-staging"
-FIT_DTB_COMPATIBLE[qcm6490-idp+kodiak-el2] = " \
-    qcom,qcm6490-idp-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcom-apq8064-asus-nexus7-flo] = "qcom,apq8064"
-FIT_DTB_COMPATIBLE[qcom-apq8064-ifc6410] = "qcom,apq8064-ifc6410"
-FIT_DTB_COMPATIBLE[qcom-apq8074-dragonboard] = "qcom,apq8074-dragonboard"
-FIT_DTB_COMPATIBLE[qcom-apq8084-ifc6540] = "qcom,apq8084-sbc"
-FIT_DTB_COMPATIBLE[qcom-msm8974-lge-nexus5-hammerhead] = "qcom,msm8974"
-FIT_DTB_COMPATIBLE[qcs404-evb-4000] = "qcom,qcs404-evb-4000"
-FIT_DTB_COMPATIBLE[qcs615-ride] = " \
-    qcom,qcs615-adp \
-"
-FIT_DTB_COMPATIBLE[qcs615-ride+talos-staging] = " \
-    qcom,qcs615-adp-staging \
-"
-FIT_DTB_COMPATIBLE[qcs615-ride+talos-el2] = " \
-    qcom,qcs615-adp-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs615-ride+talos-el2+talos-staging] = " \
-    qcom,qcs615-adp-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2] = " \
-    qcom,qcs5430-iot \
-    qcom,qcs6490-iot \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+kodiak-el2] = " \
-    qcom,qcs5430-iot-el2kvm \
-    qcom,qcs6490-iot-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+kodiak-staging+qcs6490-rb3gen2-staging] = " \
-    qcom,qcs5430-iot-staging \
-    qcom,qcs6490-iot-staging \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine] = " \
-    qcom,qcs5430-iot-subtype9 \
-    qcom,qcs6490-iot-subtype9 \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+kodiak-el2] = " \
-    qcom,qcs5430-iot-subtype9-el2kvm \
-    qcom,qcs6490-iot-subtype9-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-industrial-mezzanine+kodiak-staging+qcs6490-rb3gen2-industrial-mezzanine-staging] = " \
-    qcom,qcs5430-iot-subtype9-staging \
-    qcom,qcs6490-iot-subtype9-staging \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine] = " \
-    qcom,qcs5430-iot-subtype2 \
-    qcom,qcs6490-iot-subtype2 \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine+kodiak-el2] = " \
-    qcom,qcs5430-iot-subtype2-el2kvm \
-    qcom,qcs6490-iot-subtype2-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine+kodiak-staging] = " \
-    qcom,qcs5430-iot-subtype2-staging \
-    qcom,qcs6490-iot-subtype2-staging \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx] = " \
-    qcom,qcs5430-iot-camx \
-    qcom,qcs5430-iot-subtype2-camx \
-    qcom,qcs6490-iot-camx \
-    qcom,qcs6490-iot-subtype2-camx \
-"
-FIT_DTB_COMPATIBLE[qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine-camx+kodiak-staging] = " \
-    qcom,qcs5430-iot-camx-staging \
-    qcom,qcs5430-iot-subtype2-camx-staging \
-    qcom,qcs6490-iot-camx-staging \
-    qcom,qcs6490-iot-subtype2-camx-staging \
-"
-FIT_DTB_COMPATIBLE[qcs8300-ride] = "qcom,qcs8300-adp"
-FIT_DTB_COMPATIBLE[qcs8300-ride+monaco-staging] = "qcom,qcs8300-adp-staging"
-FIT_DTB_COMPATIBLE[qcs8300-ride+monaco-el2] = "qcom,qcs8300-adp-el2kvm"
-FIT_DTB_COMPATIBLE[qcs8300-ride+monaco-el2+monaco-staging] = "qcom,qcs8300-adp-el2kvm-staging"
-FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx] = "qcom,qcs8300-adp-camx"
-FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx+monaco-staging] = "qcom,qcs8300-adp-camx-staging"
-FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx+monaco-el2+monaco-camx-el2] = "qcom,qcs8300-adp-camx-el2kvm"
-FIT_DTB_COMPATIBLE[qcs8300-ride+qcs8300-ride-camx+monaco-el2+monaco-camx-el2+monaco-staging] = "qcom,qcs8300-adp-camx-el2kvm-staging"
-FIT_DTB_COMPATIBLE[qcs9100-ride] = " \
-    qcom,qcs9100-qam \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-staging] = " \
-    qcom,qcs9100-qam-staging \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx] = " \
-    qcom,qcs9100-qam-camx \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride+sa8775p-ride-camx+lemans-staging] = " \
-    qcom,qcs9100-qam-camx-staging \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2] = " \
-    qcom,qcs9100-qam-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride+lemans-el2+lemans-staging] = " \
-    qcom,qcs9100-qam-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3] = " \
-    qcom,qcs9100-qam-r2.0 \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+lemans-staging] = " \
-    qcom,qcs9100-qam-r2.0-staging \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx] = " \
-    qcom,qcs9100-qam-r2.0-camx \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+sa8775p-ride-camx+lemans-staging] = " \
-    qcom,qcs9100-qam-r2.0-camx-staging \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+lemans-el2] = " \
-    qcom,qcs9100-qam-r2.0-el2kvm \
-"
-FIT_DTB_COMPATIBLE[qcs9100-ride-r3+lemans-el2+lemans-staging] = " \
-    qcom,qcs9100-qam-r2.0-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[qrb2210-rb1] = "qcom,qrb2210-rb1"
-FIT_DTB_COMPATIBLE[qrb4210-rb2] = "qcom,qrb4210-rb2"
-FIT_DTB_COMPATIBLE[qrb5165-rb5] = "qcom,qrb5165-rb5"
-FIT_DTB_COMPATIBLE[sa8775p-ride] = " \
-    qcom,sa8775p-qam \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+lemans-staging] = " \
-    qcom,sa8775p-qam-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+lemans-el2] = " \
-    qcom,sa8775p-qam-el2kvm \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+lemans-el2+lemans-staging] = " \
-    qcom,sa8775p-qam-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx] = " \
-    qcom,sa8775p-qam-camx \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx+lemans-staging] = " \
-    qcom,sa8775p-qam-camx-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx+lemans-el2+lemans-camx-el2] = " \
-    qcom,sa8775p-qam-camx-el2kvm \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride+sa8775p-ride-camx+lemans-el2+lemans-camx-el2+lemans-staging] = " \
-    qcom,sa8775p-qam-camx-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3] = " \
-    qcom,sa8775p-qam-r2.0 \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+lemans-staging] = " \
-    qcom,sa8775p-qam-r2.0-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+lemans-el2] = " \
-    qcom,sa8775p-qam-r2.0-el2kvm \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+lemans-el2+lemans-staging] = " \
-    qcom,sa8775p-qam-r2.0-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx] = " \
-    qcom,sa8775p-qam-r2.0-camx \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx+lemans-staging] = " \
-    qcom,sa8775p-qam-r2.0-camx-staging \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx+lemans-el2+lemans-camx-el2] = " \
-    qcom,sa8775p-qam-r2.0-camx-el2kvm \
-"
-FIT_DTB_COMPATIBLE[sa8775p-ride-r3+sa8775p-ride-camx+lemans-el2+lemans-camx-el2+lemans-staging] = " \
-    qcom,sa8775p-qam-r2.0-camx-el2kvm-staging \
-"
-FIT_DTB_COMPATIBLE[sdm845-db845c] = "qcom,sdm845"
-FIT_DTB_COMPATIBLE[sm8450-hdk] = "qcom,sm8450-hdk"
-FIT_DTB_COMPATIBLE[sm8750-mtp] = "qcom,sm8750-mtp"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577] = "qcom,qcs615-iot"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577+talos-staging] = "qcom,qcs615-iot-staging"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577+talos-el2] = "qcom,qcs615-iot-el2kvm"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camera-imx577+talos-el2+talos-staging] = "qcom,qcs615-iot-el2kvm-staging"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx] = "qcom,qcs615-iot-camx"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx+talos-staging] = "qcom,qcs615-iot-camx-staging"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx+talos-el2] = "qcom,qcs615-iot-camx-el2kvm"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-camx+talos-el2+talos-staging] = "qcom,qcs615-iot-camx-el2kvm-staging"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01] = "qcom,talos-evk-lvds-auo,g133han01"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01+talos-staging] = "qcom,talos-evk-lvds-auo,g133han01-staging"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01+talos-el2] = "qcom,talos-evk-lvds-auo,g133han01-el2kvm"
-FIT_DTB_COMPATIBLE[talos-evk+talos-evk-lvds-auo_g133han01+talos-el2+talos-staging] = "qcom,talos-evk-lvds-auo,g133han01-el2kvm-staging"
+# ---------- Direct mapping, no overlay ----------
+FIT_DTB_COMPATIBLE[qcom_apq8016-sbc] = "apq8016-sbc"
+FIT_DTB_COMPATIBLE[qcom_apq8064-ifc6410] = "qcom-apq8064-ifc6410"
+FIT_DTB_COMPATIBLE[qcom_apq8064] = "qcom-apq8064-asus-nexus7-flo"
+FIT_DTB_COMPATIBLE[qcom_apq8074-dragonboard] = "qcom-apq8074-dragonboard"
+FIT_DTB_COMPATIBLE[qcom_apq8084-sbc] = "qcom-apq8084-ifc6540"
+FIT_DTB_COMPATIBLE[qcom_apq8096-sbc] = "apq8096-db820c"
+FIT_DTB_COMPATIBLE[qcom_glymur-crd] = "glymur-crd"
+FIT_DTB_COMPATIBLE[qcom_kaanapali-mtp] = "kaanapali-mtp"
+FIT_DTB_COMPATIBLE[qcom_msm8974] = "qcom-msm8974-lge-nexus5-hammerhead"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk] = "purwa-iot-evk"
+FIT_DTB_COMPATIBLE[qcom_qcs404-evb-4000] = "qcs404-evb-4000"
+FIT_DTB_COMPATIBLE[qcom_qrb2210-rb1] = "qrb2210-rb1"
+FIT_DTB_COMPATIBLE[qcom_qrb4210-rb2] = "qrb4210-rb2"
+FIT_DTB_COMPATIBLE[qcom_qrb5165-rb5] = "qrb5165-rb5"
+FIT_DTB_COMPATIBLE[qcom_sdm845] = "sdm845-db845c"
+FIT_DTB_COMPATIBLE[qcom_sm8450-hdk] = "sm8450-hdk"
+FIT_DTB_COMPATIBLE[qcom_sm8750-mtp] = "sm8750-mtp"
+
+# ---------- hamoa ----------
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk] = \
+    "hamoa-iot-evk hamoa-iot-evk-camera-imx577"
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
+
+# ---------- lemans ----------
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
+    "lemans-evk lemans-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
+    "lemans-evk lemans-evk-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm-staging] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
+    "lemans-evk lemans-evk-ifp-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam] = "qcs9100-ride"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
+    "qcs9100-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm] = \
+    "qcs9100-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm-staging] = \
+    "qcs9100-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
+    "qcs9100-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
+    "qcs9100-ride sa8775p-ride-camx lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0] = "qcs9100-ride-r3"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
+    "qcs9100-ride-r3 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm] = \
+    "qcs9100-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm-staging] = \
+    "qcs9100-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam] = "sa8775p-ride"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
+    "sa8775p-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm] = \
+    "sa8775p-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm-staging] = \
+    "sa8775p-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
+    "sa8775p-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0] = "sa8775p-ride-r3"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
+    "sa8775p-ride-r3 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm] = \
+    "sa8775p-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm-staging] = \
+    "sa8775p-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+
+# ---------- monaco ----------
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
+    "monaco-evk monaco-evk-camera-imx577"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = "monaco-evk monaco-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
+    "monaco-evk monaco-evk-camx monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm-staging] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = "qcs8300-ride monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm] = "qcs8300-ride monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm-staging] = \
+    "qcs8300-ride monaco-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = "qcs8300-ride qcs8300-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
+
+# ---------- talos ----------
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = "qcs615-ride"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
+    "qcs615-ride talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm] = \
+    "qcs615-ride talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm-staging] = \
+    "qcs615-ride talos-el2 talos-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = "talos-evk talos-evk-camera-imx577"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = "talos-evk talos-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
+    "talos-evk talos-evk-camx talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm] = \
+    "talos-evk talos-evk-camx talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm-staging] = \
+    "talos-evk talos-evk-camx talos-el2 talos-staging"
+
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
+    "talos-evk talos-evk-lvds-auo_g133han01"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
+
+# ---------- kodiak ----------
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp] = "qcm6490-idp"
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-el2kvm] = "qcm6490-idp kodiak-el2"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot] = "qcs6490-rb3gen2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot] = "qcs6490-rb3gen2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-el2kvm] = \
+    "qcs6490-rb3gen2 kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-el2kvm] = \
+    "qcs6490-rb3gen2 kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-staging] = \
+    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-staging] = \
+    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -2,7 +2,7 @@
 # overlays) that implement it.
 #
 # Syntax:
-# FIT_DTB_COMPATIBLE[<compatible-encoded>] = "<dtb-stem>[ <overlay-stem>[ <overlay-stem>...]]"
+# FIT_DTB_COMPATIBLE[<compatible-encoded>] = "<dtb-stem> [<overlay-stem> [<overlay-stem>...]]"
 #
 # <compatible-encoded> is the DT compatible string with every comma replaced
 # by an underscore (BitBake flag names cannot contain commas).  For example,
@@ -10,9 +10,16 @@
 #
 # Rules
 # -----
+# - linux-qcom tracks a newer kernel than linux-yocto, so it can carry extra
+#   device trees -- both .dtb and .dtbo -- that have not landed in linux-yocto
+#   yet.  Entries that rely on those linux-qcom-only device trees are kept in
+#   fit-dtb-compatible-linux-qcom.inc.  Splitting them out lets linux-qcom add
+#   device trees quickly while a build using only linux-yocto stays functional
+#   from this file alone; as linux-yocto is updated and gains the same device
+#   trees, the corresponding entries migrate back into this file.
 # - do_generate_qcom_fitimage silently skips any combo whose files are absent
-#   from KERNEL_DEVICETREE, so entries that reference linux-qcom-only overlays
-#   (el2, camx, staging, ifp-mezzanine) are safely ignored for linux-yocto builds.
+#   from KERNEL_DEVICETREE, so entries here are safe to leave even when a
+#   particular machine or kernel does not include every listed file.
 
 # ---------- Direct mapping, no overlay ----------
 FIT_DTB_COMPATIBLE[qcom_apq8016-sbc] = "apq8016-sbc"
@@ -36,207 +43,41 @@ FIT_DTB_COMPATIBLE[qcom_sm8750-mtp] = "sm8750-mtp"
 # ---------- hamoa ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk] = \
     "hamoa-iot-evk hamoa-iot-evk-camera-imx577"
-FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 
 # ---------- lemans ----------
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
     "lemans-evk lemans-evk-camera-csi1-imx577"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2kvm-staging] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
-    "lemans-evk lemans-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
-    "lemans-evk lemans-evk-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm] = \
-    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-el2kvm-staging] = \
-    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
-    "lemans-evk lemans-evk-ifp-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
-    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging"
 
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam] = "qcs9100-ride"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
-    "qcs9100-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm] = \
-    "qcs9100-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2kvm-staging] = \
-    "qcs9100-ride lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
-    "qcs9100-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
-    "qcs9100-ride sa8775p-ride-camx lemans-staging"
-
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0] = "qcs9100-ride-r3"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
-    "qcs9100-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm] = \
-    "qcs9100-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2kvm-staging] = \
-    "qcs9100-ride-r3 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
-    "qcs9100-ride-r3 sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
-    "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
 
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam] = "sa8775p-ride"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
-    "sa8775p-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm] = \
-    "sa8775p-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2kvm-staging] = \
-    "sa8775p-ride lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
-    "sa8775p-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2kvm-staging] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
-
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0] = "sa8775p-ride-r3"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
-    "sa8775p-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm] = \
-    "sa8775p-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2kvm-staging] = \
-    "sa8775p-ride-r3 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-el2kvm-staging] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
 
 # ---------- monaco ----------
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
     "monaco-evk monaco-evk-camera-imx577"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2kvm-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = "monaco-evk monaco-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
-    "monaco-evk monaco-evk-camx monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-el2kvm-staging] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
-    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging"
 
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = "qcs8300-ride monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm] = "qcs8300-ride monaco-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2kvm-staging] = \
-    "qcs8300-ride monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = "qcs8300-ride qcs8300-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-el2kvm-staging] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
 
 # ---------- talos ----------
 FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = "qcs615-ride"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
-    "qcs615-ride talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm] = \
-    "qcs615-ride talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm-staging] = \
-    "qcs615-ride talos-el2 talos-staging"
-
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = "talos-evk talos-evk-camera-imx577"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = "talos-evk talos-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
-    "talos-evk talos-evk-camx talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm] = \
-    "talos-evk talos-evk-camx talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm-staging] = \
-    "talos-evk talos-evk-camx talos-el2 talos-staging"
-
 FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
     "talos-evk talos-evk-lvds-auo_g133han01"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm-staging] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
 
 # ---------- kodiak ----------
 FIT_DTB_COMPATIBLE[qcom_qcm6490-idp] = "qcm6490-idp"
-FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"
-FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-el2kvm] = "qcm6490-idp kodiak-el2"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot] = "qcs6490-rb3gen2"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot] = "qcs6490-rb3gen2"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-el2kvm] = \
-    "qcs6490-rb3gen2 kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-el2kvm] = \
-    "qcs6490-rb3gen2 kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-staging] = \
-    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-staging] = \
-    "qcs6490-rb3gen2 kodiak-staging qcs6490-rb3gen2-staging"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-el2kvm] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-el2kvm] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-el2kvm] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-el2kvm] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
-
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"

--- a/lib/oeqa/selftest/cases/qcom_fitimage.py
+++ b/lib/oeqa/selftest/cases/qcom_fitimage.py
@@ -890,6 +890,11 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
             self._layer_dir(), "conf", "machine", "include",
             "fit-dtb-compatible.inc")
 
+    def _linux_qcom_fit_compat_inc(self):
+        return os.path.join(
+            self._layer_dir(), "conf", "machine", "include",
+            "fit-dtb-compatible-linux-qcom.inc")
+
     @staticmethod
     def _parse_fit_compatible_map(inc_path):
         """Parse a fit-dtb-compatible*.inc file into {encoded_compat: dtb_combo}.
@@ -913,7 +918,7 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
         return result
 
     def _fit_compatible_map(self):
-        """Return the FIT_DTB_COMPATIBLE map from fit-dtb-compatible.inc.
+        """Return the base FIT_DTB_COMPATIBLE map (fit-dtb-compatible.inc only).
 
         Returns {encoded_compat: dtb_combo_str}.
         """
@@ -1120,10 +1125,10 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
     def test_fit_dtb_compatible_combos_exist_in_kernel_sources(self):
         """Every FIT_DTB_COMPATIBLE value must name DT files present in kernel sources.
 
-        All entries are checked against the union of linux-yocto and qcom kernel
-        sources.  Combos that reference linux-qcom-only overlays (camx, staging)
-        are silently skipped by the bbclass for non-qcom kernels, so checking
-        against the union is sufficient here.
+        Base file entries are checked against the union of linux-yocto and qcom
+        kernel sources.  Entries from fit-dtb-compatible-linux-qcom.inc are
+        checked against qcom kernel sources only (they reference
+        LINUX_QCOM_KERNEL_DEVICETREE overlays not available in linux-yocto).
         """
         available = set(self._available_providers())
 
@@ -1136,20 +1141,33 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
         for provider in [self.KERNEL_PROVIDER_YOCTO] + qcom_available:
             all_outputs |= self._provider_output_files(provider)
 
-        missing = []
-        for encoded_key, combo_val in self._fit_compatible_map().items():
-            parts = combo_val.split()
-            base = parts[0]
-            if len(parts) == 1:
-                if not self._has_dt_output(all_outputs, base, (".dtb", ".dtbo")):
-                    missing.append(f"{encoded_key} -> {combo_val}")
-                continue
-            if not self._has_dt_output(all_outputs, base, (".dtb",)):
-                missing.append(f"{encoded_key} -> {combo_val}")
-                continue
-            if any(not self._has_dt_output(all_outputs, ovl, (".dtbo",))
-                   for ovl in parts[1:]):
-                missing.append(f"{encoded_key} -> {combo_val}")
+        qcom_outputs = set()
+        for provider in qcom_available:
+            qcom_outputs |= self._provider_output_files(provider)
+
+        def _check_combos(compat_map, output_files, label):
+            missing = []
+            for encoded_key, combo_val in compat_map.items():
+                parts = combo_val.split()
+                base = parts[0]
+                if len(parts) == 1:
+                    if not self._has_dt_output(output_files, base, (".dtb", ".dtbo")):
+                        missing.append(f"{encoded_key} -> {combo_val}  [{label}]")
+                    continue
+                if not self._has_dt_output(output_files, base, (".dtb",)):
+                    missing.append(f"{encoded_key} -> {combo_val}  [{label}]")
+                    continue
+                if any(not self._has_dt_output(output_files, ovl, (".dtbo",))
+                       for ovl in parts[1:]):
+                    missing.append(f"{encoded_key} -> {combo_val}  [{label}]")
+            return missing
+
+        missing = _check_combos(self._fit_compatible_map(), all_outputs, "base")
+
+        qcom_inc = self._linux_qcom_fit_compat_inc()
+        if os.path.exists(qcom_inc):
+            qcom_map = self._parse_fit_compatible_map(qcom_inc)
+            missing += _check_combos(qcom_map, qcom_outputs, "linux-qcom")
 
         if missing:
             self.fail(
@@ -1157,31 +1175,35 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
                 + "\n".join(sorted(missing)))
 
     def test_fit_dtb_compatible_no_duplicate_keys(self):
-        """Each FIT_DTB_COMPATIBLE key must be defined exactly once.
+        """Each FIT_DTB_COMPATIBLE key must be defined exactly once per file.
 
         Bitbake silently overwrites a flag variable when the same key is
         assigned twice, dropping the first set of compatible strings without
         any warning.
         """
-        inc_path = self._fit_compatible_inc()
-        key_re = re.compile(r'^\s*FIT_DTB_COMPATIBLE\[([^\]]+)\]\s*=')
-        seen = {}
-        with open(inc_path) as f:
-            for lineno, line in enumerate(f, 1):
-                m = key_re.match(line)
-                if m:
-                    key = m.group(1).strip()
-                    seen.setdefault(key, []).append(lineno)
+        errors = []
+        for inc_path in (self._fit_compatible_inc(), self._linux_qcom_fit_compat_inc()):
+            if not os.path.exists(inc_path):
+                continue
+            key_re = re.compile(r'^\s*FIT_DTB_COMPATIBLE\[([^\]]+)\]\s*=')
+            seen = {}
+            with open(inc_path) as f:
+                for lineno, line in enumerate(f, 1):
+                    m = key_re.match(line)
+                    if m:
+                        key = m.group(1).strip()
+                        seen.setdefault(key, []).append(lineno)
 
-        duplicates = {k: lines for k, lines in seen.items() if len(lines) > 1}
-        if duplicates:
-            msgs = [
-                f"  '{k}' defined at lines: {', '.join(str(l) for l in lines)}"
-                for k, lines in sorted(duplicates.items())
-            ]
+            fname = os.path.basename(inc_path)
+            for k, lines in sorted(seen.items()):
+                if len(lines) > 1:
+                    errors.append(
+                        f"  '{k}' in {fname} defined at lines: "
+                        f"{', '.join(str(l) for l in lines)}")
+
+        if errors:
             self.fail(
-                "Duplicate FIT_DTB_COMPATIBLE keys in fit-dtb-compatible.inc:\n"
-                + "\n".join(msgs))
+                "Duplicate FIT_DTB_COMPATIBLE keys:\n" + "\n".join(errors))
 
     def test_fit_dtb_compatible_compat_key_format(self):
         """Each FIT_DTB_COMPATIBLE key must be an encoded compatible string.
@@ -1192,9 +1214,14 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
         can decode it back to a valid 'qcom,…' compatible string.
         """
         errors = []
-        for encoded_key in self._parse_fit_compatible_map(self._fit_compatible_inc()):
-            if not encoded_key.startswith("qcom_"):
-                errors.append(f"  '{encoded_key}': must start with 'qcom_'")
+        for inc_path in (self._fit_compatible_inc(), self._linux_qcom_fit_compat_inc()):
+            if not os.path.exists(inc_path):
+                continue
+            fname = os.path.basename(inc_path)
+            for encoded_key in self._parse_fit_compatible_map(inc_path):
+                if not encoded_key.startswith("qcom_"):
+                    errors.append(
+                        f"  '{encoded_key}' in {fname}: must start with 'qcom_'")
 
         if errors:
             self.fail(

--- a/lib/oeqa/selftest/cases/qcom_fitimage.py
+++ b/lib/oeqa/selftest/cases/qcom_fitimage.py
@@ -77,9 +77,10 @@ class QcomFitImageTests(OESelftestTestCase):
         Args:
             kernel_devicetree: Space-separated DTB/DTBO filenames
                 (the value of KERNEL_DEVICETREE).
-            fit_dtb_compatible: Dict mapping DTB keys (with optional '+'
-                for overlay combos) to compatible string(s)
-                (the FIT_DTB_COMPATIBLE flags).
+            fit_dtb_compatible: Dict mapping encoded compatible strings
+                (commas replaced with underscores, e.g. ``"qcom_board-iot"``)
+                to DTB+overlay combo strings (e.g. ``"board"`` or
+                ``"board overlay"``). (the FIT_DTB_COMPATIBLE flags)
 
         Returns:
             (its_path, parsed) where *parsed* is the dict returned by
@@ -112,20 +113,32 @@ class QcomFitImageTests(OESelftestTestCase):
         dtb_keys_list = {os.path.splitext(f)[0].replace(',', '_')
                          for f in files_set}
 
+        base_compats = {}   # base_dtb_id -> space-separated compat string(s)
         overlay_groups = {}
         overlay_compats = {}
-        for key, compat_val in fit_dtb_compatible.items():
-            if '+' not in key:
-                continue
-            parts = [os.path.basename(p) for p in key.split('+')]
+        seen_combos = set()  # track overlay combos already added to overlay_groups
+        for encoded_key, combo_val in fit_dtb_compatible.items():
+            compat_str = encoded_key.replace('_', ',')
+            parts = [os.path.basename(p) for p in combo_val.split()]
             if not parts:
                 continue
             if not all(dtb in dtb_keys_list for dtb in parts):
                 continue
             base = parts[0] + ".dtb"
+            base_dtb_id = base.replace(',', '_')
             overlays = [ovl + ".dtbo" for ovl in parts[1:]]
-            overlay_groups.setdefault(base, []).append(overlays)
-            overlay_compats[key] = compat_val
+            if overlays:
+                # Mirror the bbclass: encode commas so combo_key/overlay_groups
+                # keys match the lookup_key in fitimage_emit_section_qcomconfig.
+                combo_key = " ".join(p.replace(',', '_') for p in parts)
+                if combo_key not in seen_combos:
+                    overlay_groups.setdefault(base_dtb_id, []).append(overlays)
+                    seen_combos.add(combo_key)
+                existing = overlay_compats.get(combo_key, "")
+                overlay_compats[combo_key] = (existing + " " + compat_str).strip()
+            else:
+                existing = base_compats.get(base_dtb_id, "")
+                base_compats[base_dtb_id] = (existing + " " + compat_str).strip()
 
         # ---- emit image nodes (sorted for deterministic output) ----
         for fname in sorted(files_set):
@@ -134,8 +147,7 @@ class QcomFitImageTests(OESelftestTestCase):
             dtb_id = fname.replace(',', '_')
             compatible = ""
             if fname.endswith(".dtb"):
-                dtb_key = os.path.splitext(dtb_id)[0]
-                compatible = fit_dtb_compatible.get(dtb_key, "")
+                compatible = base_compats.get(dtb_id, "")
             root_node.fitimage_emit_section_dtb(
                 dtb_id, fpath,
                 compatible_str=compatible, dtb_type="flat_dt")
@@ -239,7 +251,7 @@ class QcomFitImageTests(OESelftestTestCase):
         """Single DTB with one compatible string."""
         _, p = self._build_qcom_fitimage(
             "myboard.dtb",
-            {"myboard": "qcom,myboard-idp"})
+            {"qcom_myboard-idp": "myboard"})
 
         # Images
         self.assertIn('fdt-qcom-metadata.dtb', p['images'])
@@ -262,7 +274,10 @@ class QcomFitImageTests(OESelftestTestCase):
         """Single DTB with multiple compatibles -> one config per compat."""
         _, p = self._build_qcom_fitimage(
             "qcs6490-rb3gen2.dtb",
-            {"qcs6490-rb3gen2": "qcom,qcs5430-iot qcom,qcs6490-iot"})
+            {
+                "qcom_qcs5430-iot": "qcs6490-rb3gen2",
+                "qcom_qcs6490-iot": "qcs6490-rb3gen2",
+            })
 
         self.assertEqual(len(p['images']), 2)   # metadata + 1 DTB
         self.assertEqual(len(p['configurations']), 2)
@@ -283,8 +298,8 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "qcs6490-rb3gen2.dtb qcs6490-rb3gen2-vision-mezzanine.dtbo",
             {
-                "qcs6490-rb3gen2": "qcom,qcs6490-iot",
-                "qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine": "qcom,qcs6490-iot-subtype2",
+                "qcom_qcs6490-iot": "qcs6490-rb3gen2",
+                "qcom_qcs6490-iot-subtype2": "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine",
             })
 
         self.assertEqual(len(p['images']), 3)
@@ -315,10 +330,11 @@ class QcomFitImageTests(OESelftestTestCase):
             "lemans-evk.dtb lemans-evk-camx.dtbo "
             "lemans-el2.dtbo lemans-camx-el2.dtbo",
             {
-                "lemans-evk": "qcom,qcs9075-iot",
-                "lemans-evk+lemans-evk-camx+lemans-el2+lemans-camx-el2":
-                    "qcom,qcs9075-iot-camx-el2kvm "
-                    "qcom,qcs9075-socv2.0-iot-camx-el2kvm",
+                "qcom_qcs9075-iot": "lemans-evk",
+                "qcom_qcs9075-iot-camx-el2kvm":
+                    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2",
+                "qcom_qcs9075-socv2.0-iot-camx-el2kvm":
+                    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2",
             })
 
         self.assertEqual(len(p['images']), 5)
@@ -352,7 +368,7 @@ class QcomFitImageTests(OESelftestTestCase):
         """Metadata DTB appears as image (type=qcom_metadata) but never in configs."""
         _, p = self._build_qcom_fitimage(
             "simple.dtb",
-            {"simple": "qcom,simple-evk"})
+            {"qcom_simple-evk": "simple"})
 
         meta = p['images'].get('fdt-qcom-metadata.dtb')
         self.assertIsNotNone(meta, "Metadata image node missing")
@@ -369,8 +385,8 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "base.dtb",            # overlay DTBO not listed
             {
-                "base": "qcom,base-iot",
-                "base+missing-overlay": "qcom,base-iot-subtype2",
+                "qcom_base-iot": "base",
+                "qcom_base-iot-subtype2": "base missing-overlay",
             })
 
         # Only 1 config (base); overlay combo silently dropped
@@ -385,9 +401,9 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "board.dtb camx.dtbo el2.dtbo",
             {
-                "board": "qcom,board-iot",
-                "board+camx": "qcom,board-iot-subtype2",
-                "board+camx+el2": "qcom,board-iot-el2kvm",
+                "qcom_board-iot": "board",
+                "qcom_board-iot-subtype2": "board camx",
+                "qcom_board-iot-el2kvm": "board camx el2",
             })
 
         self._assert_fdt_linkage(p)
@@ -402,10 +418,12 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "qcs6490-rb3gen2.dtb qcs6490-rb3gen2-vision-mezzanine.dtbo",
             {
-                "qcs6490-rb3gen2":
-                    "qcom,qcs6490-iot qcom,qcs5430-iot",
-                "qcs6490-rb3gen2+qcs6490-rb3gen2-vision-mezzanine":
-                    "qcom,qcs6490-iot-subtype2 qcom,qcs5430-iot-subtype2",
+                "qcom_qcs6490-iot": "qcs6490-rb3gen2",
+                "qcom_qcs5430-iot": "qcs6490-rb3gen2",
+                "qcom_qcs6490-iot-subtype2":
+                    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine",
+                "qcom_qcs5430-iot-subtype2":
+                    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine",
             })
 
         all_valid = self.METADATA_SUFFIXES | self.COMPAT_EXTENSIONS
@@ -424,9 +442,9 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "base.dtb overlay1.dtbo overlay2.dtbo",
             {
-                "base": "qcom,base-iot",
-                "base+overlay1": "qcom,base-iot-subtype1",
-                "base+overlay2": "qcom,base-iot-subtype2",
+                "qcom_base-iot": "base",
+                "qcom_base-iot-subtype1": "base overlay1",
+                "qcom_base-iot-subtype2": "base overlay2",
             })
 
         for cname, cprops in p['configurations'].items():
@@ -443,10 +461,10 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "boardA.dtb boardA-cam.dtbo boardB.dtb boardB-cam.dtbo",
             {
-                "boardA": "qcom,boardA-iot",
-                "boardA+boardA-cam": "qcom,boardA-iot-subtype2",
-                "boardB": "qcom,boardB-idp",
-                "boardB+boardB-cam": "qcom,boardB-idp-subtype2",
+                "qcom_boardA-iot": "boardA",
+                "qcom_boardA-iot-subtype2": "boardA boardA-cam",
+                "qcom_boardB-idp": "boardB",
+                "qcom_boardB-idp-subtype2": "boardB boardB-cam",
             })
 
         self.assertEqual(len(p['images']), 5)  # metadata + 2×(base+ovl)
@@ -479,8 +497,8 @@ class QcomFitImageTests(OESelftestTestCase):
         _, p = self._build_qcom_fitimage(
             "base.dtb overlay.dtbo",
             {
-                # No "base" key – the DTB is only referenced through overlays
-                "base+overlay": "qcom,base-iot-subtype2",
+                # No standalone base entry – the DTB is only referenced via overlays
+                "qcom_base-iot-subtype2": "base overlay",
             })
 
         # Only 1 config (the overlay combo), no base-only config
@@ -499,8 +517,8 @@ class QcomFitImageTests(OESelftestTestCase):
         its_path, p = self._build_qcom_fitimage(
             "testboard.dtb testboard-cam.dtbo",
             {
-                "testboard": "qcom,testboard-iot",
-                "testboard+testboard-cam": "qcom,testboard-iot-subtype2",
+                "qcom_testboard-iot": "testboard",
+                "qcom_testboard-iot-subtype2": "testboard testboard-cam",
             })
 
         # Build u-boot-tools-native (mkimage/dumpimage) and dtc-native
@@ -867,37 +885,39 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
                 machines.append(name[:-5])  # strip ".conf"
         return machines
 
-    def _fit_compatible_keys(self):
-        inc_path = os.path.join(
+    def _fit_compatible_inc(self):
+        return os.path.join(
             self._layer_dir(), "conf", "machine", "include",
             "fit-dtb-compatible.inc")
-        key_re = re.compile(r'^\s*FIT_DTB_COMPATIBLE\[([^\]]+)\]\s*=')
-        keys = []
-        with open(inc_path) as f:
-            for line in f:
-                m = key_re.match(line)
-                if m:
-                    keys.append(m.group(1).strip())
-        return keys
 
-    def _fit_compatible_map(self):
-        """Parse fit-dtb-compatible.inc and return {key: list[compat_str]}.
+    @staticmethod
+    def _parse_fit_compatible_map(inc_path):
+        """Parse a fit-dtb-compatible*.inc file into {encoded_compat: dtb_combo}.
 
-        Handles both single-line and backslash-continued multi-line values.
+        Each key is an encoded compatible string (commas replaced with
+        underscores, e.g. ``"qcom_board-iot"``) and each value is the
+        corresponding DTB+overlay combo string (e.g. ``"board"`` or
+        ``"board overlay"``).  Handles both single-line and
+        backslash-continued multi-line values.  Comment lines are skipped.
         """
-        inc_path = os.path.join(
-            self._layer_dir(), "conf", "machine", "include",
-            "fit-dtb-compatible.inc")
         with open(inc_path) as f:
             content = f.read()
         content = content.replace('\\\n', ' ')
+        content = '\n'.join(
+            l for l in content.split('\n') if not l.lstrip().startswith('#'))
         result = {}
         for m in re.finditer(
                 r'FIT_DTB_COMPATIBLE\[([^\]]+)\]\s*=\s*"([^"]*)"', content):
             key = m.group(1).strip()
-            vals = m.group(2).split()
-            result[key] = vals
+            result[key] = m.group(2).strip()
         return result
+
+    def _fit_compatible_map(self):
+        """Return the FIT_DTB_COMPATIBLE map from fit-dtb-compatible.inc.
+
+        Returns {encoded_compat: dtb_combo_str}.
+        """
+        return self._parse_fit_compatible_map(self._fit_compatible_inc())
 
     @staticmethod
     def _name_variants(name):
@@ -1097,8 +1117,14 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
         if errors:
             self.fail("\n".join(errors))
 
-    def test_fit_dtb_compatible_keys_exist_in_kernel_sources(self):
-        """Every FIT_DTB_COMPATIBLE key must map to DT files in kernel sources."""
+    def test_fit_dtb_compatible_combos_exist_in_kernel_sources(self):
+        """Every FIT_DTB_COMPATIBLE value must name DT files present in kernel sources.
+
+        All entries are checked against the union of linux-yocto and qcom kernel
+        sources.  Combos that reference linux-qcom-only overlays (camx, staging)
+        are silently skipped by the bbclass for non-qcom kernels, so checking
+        against the union is sufficient here.
+        """
         available = set(self._available_providers())
 
         qcom_available = [p for p in self.KERNEL_PROVIDERS_QCOM if p in available]
@@ -1106,31 +1132,24 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
             len(qcom_available), 0,
             "No qcom kernel provider available (linux-qcom-next/linux-qcom)")
 
-        providers = [self.KERNEL_PROVIDER_YOCTO] + qcom_available
-        output_files = set()
-        for provider in providers:
-            output_files |= self._provider_output_files(provider)
+        all_outputs = set()
+        for provider in [self.KERNEL_PROVIDER_YOCTO] + qcom_available:
+            all_outputs |= self._provider_output_files(provider)
 
-        fit_keys = self._fit_compatible_keys()
         missing = []
-
-        for key in fit_keys:
-            parts = key.split('+')
+        for encoded_key, combo_val in self._fit_compatible_map().items():
+            parts = combo_val.split()
             base = parts[0]
-
-            # Single-part keys can be either .dtb or .dtbo naming styles.
             if len(parts) == 1:
-                if not self._has_dt_output(output_files, base, (".dtb", ".dtbo")):
-                    missing.append(key)
+                if not self._has_dt_output(all_outputs, base, (".dtb", ".dtbo")):
+                    missing.append(f"{encoded_key} -> {combo_val}")
                 continue
-
-            # Composite keys: first part must be base .dtb, rest are .dtbo overlays.
-            if not self._has_dt_output(output_files, base, (".dtb",)):
-                missing.append(key)
+            if not self._has_dt_output(all_outputs, base, (".dtb",)):
+                missing.append(f"{encoded_key} -> {combo_val}")
                 continue
-            if any(not self._has_dt_output(output_files, ovl, (".dtbo",))
+            if any(not self._has_dt_output(all_outputs, ovl, (".dtbo",))
                    for ovl in parts[1:]):
-                missing.append(key)
+                missing.append(f"{encoded_key} -> {combo_val}")
 
         if missing:
             self.fail(
@@ -1144,9 +1163,7 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
         assigned twice, dropping the first set of compatible strings without
         any warning.
         """
-        inc_path = os.path.join(
-            self._layer_dir(), "conf", "machine", "include",
-            "fit-dtb-compatible.inc")
+        inc_path = self._fit_compatible_inc()
         key_re = re.compile(r'^\s*FIT_DTB_COMPATIBLE\[([^\]]+)\]\s*=')
         seen = {}
         with open(inc_path) as f:
@@ -1166,30 +1183,20 @@ class QcomFitImageMatrixTests(OESelftestTestCase):
                 "Duplicate FIT_DTB_COMPATIBLE keys in fit-dtb-compatible.inc:\n"
                 + "\n".join(msgs))
 
-    def test_fit_dtb_compatible_no_duplicate_values(self):
-        """Each compatible string must appear in exactly one FIT_DTB_COMPATIBLE entry.
+    def test_fit_dtb_compatible_compat_key_format(self):
+        """Each FIT_DTB_COMPATIBLE key must be an encoded compatible string.
 
-        When the same compatible string is listed under multiple keys the UEFI
-        firmware may match the wrong DTB configuration at boot, because it
-        scans entries in ITS order and stops at the first hit.
+        Keys encode the Device Tree compatible string with commas replaced by
+        underscores (BitBake flag names cannot contain commas).  Every key
+        must therefore start with the 'qcom_' prefix, ensuring the bbclass
+        can decode it back to a valid 'qcom,…' compatible string.
         """
-        compat_map = self._fit_compatible_map()
+        errors = []
+        for encoded_key in self._parse_fit_compatible_map(self._fit_compatible_inc()):
+            if not encoded_key.startswith("qcom_"):
+                errors.append(f"  '{encoded_key}': must start with 'qcom_'")
 
-        compat_to_keys = {}
-        for key, compats in compat_map.items():
-            for compat in compats:
-                compat_to_keys.setdefault(compat, []).append(key)
-
-        duplicates = {
-            compat: keys
-            for compat, keys in compat_to_keys.items()
-            if len(keys) > 1
-        }
-        if duplicates:
-            msgs = [
-                f"  '{compat}' in keys: {', '.join(sorted(keys))}"
-                for compat, keys in sorted(duplicates.items())
-            ]
+        if errors:
             self.fail(
-                "Duplicate compatible strings in fit-dtb-compatible.inc:\n"
-                + "\n".join(msgs))
+                "FIT_DTB_COMPATIBLE keys must be encoded compatible strings "
+                "(qcom_<compat>):\n" + "\n".join(errors))

--- a/lib/qcom/dtb_only_fitimage.py
+++ b/lib/qcom/dtb_only_fitimage.py
@@ -118,7 +118,7 @@ class QcomItsNodeRoot(ItsNodeRootKernel):
                 dt_list = [dtb_id] + ovl_list
 
                 fdtentries = [f"fdt-{dt}" for dt in dt_list]
-                lookup_key = "+".join([os.path.splitext(dt)[0].replace(',', '_') for dt in dt_list])
+                lookup_key = " ".join([os.path.splitext(dt)[0].replace(',', '_') for dt in dt_list])
                 bb.note(lookup_key)
 
                 ovl_compats = str(((overlay_compats or {}).get(lookup_key, "")) or "").split()

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -8,6 +8,8 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
+LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
+
 LINUX_VERSION ?= "7.0"
 
 PV = "${LINUX_VERSION}+git"

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,6 +8,8 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
+LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
+
 LINUX_VERSION ?= "6.18.25"
 
 PV = "${LINUX_VERSION}"


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2305 to `wrynose`.