### PR TITLE
conf: qcom-common: append efi=runtime to kernel cmdline for RT builds

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -92,7 +92,7 @@ RT_ARGS_IDLE  = "${@oe.utils.conditional('QCOM_CPUIDLE_OFF',   '', '', \
 
 # Combine
 RT_KERNEL_CMDLINE = "${RT_ARGS_ISOL} ${RT_ARGS_IRQ} ${RT_ARGS_NOCBS} \
-                     ${RT_ARGS_EXP} ${RT_ARGS_IDLE}"
+                     ${RT_ARGS_EXP} ${RT_ARGS_IDLE} efi=runtime"
 
 # Append only when RT kernel is selected
 KERNEL_CMDLINE_EXTRA:append = "${@bb.utils.contains_any('PREFERRED_PROVIDER_virtual/kernel',\


### PR DESCRIPTION
When PREEMPT_RT is enabled, EFI_DISABLE_RUNTIME defaults to 'y'
(drivers/firmware/efi/Kconfig), which disables EFI runtime services to
avoid the large latencies EFI calls can introduce under RT workloads.

EFI runtime services are required on Qualcomm platforms for several
post-boot operations. KVM hypervisor mode (el2kvm) is activated by
writing the VendorDtbOverlays EFI variable from userspace to select
the EL2 DTB overlay before rebooting; without EFI runtime services
this variable write fails, blocking KVM enablement. Watchdog and ramdump
collection, and remoteproc/PIL firmware loading, similarly require EFI
runtime services to be active.

Append efi=runtime to RT_KERNEL_CMDLINE in qcom-common
to re-enable EFI runtime services. Non-RT builds are unaffected as
EFI_DISABLE_RUNTIME is not set for them.