### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "0909c6ea6e143e94beb8780b64172643d093d3d4"
+SRCREV = "d09996d91cc067e9c4e6a22d84a9bac56d07fdfa"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Vivek (2):
    platforms: add partition scheme for shikra-evk board
    platforms/kaanapali-mtp: update additional_chipid in contents.xml.in

Guanquan Tian (6):
    platforms/iq-x7181-evk: fix duplicate uefi_dtb_a partition name
    platforms/glymur-crd: drop duplicate SYSFW_VERSION partition
    platforms/iq-8275-evk: drop orphan _a partitions without B slots
    platforms/iq-9075-evk: drop orphan _a partitions without B slots
    platforms/qcs8275-monza: drop orphan _a partitions without B slots
    qcom_ptool/ptool: validate partition layout on XML load