### PR TITLE
ci: base.lock: update meta-updater layer to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -17,7 +17,7 @@ overrides:
         meta-selinux:
             commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:
-            commit: 33af541b01954fd8cfd03c354faa9a2d221d7ede
+            commit: 7f5eef0421e966234230ee8f4e4a93e3fc8e3ac6
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:


### PR DESCRIPTION
ci: base.lock: update meta-updater layer to include required selinux changes

Changes in meta-updater:
7f5eef0  ostree: Exclude /usr/etc in OSTree build-time relabel
f9370ea refpolicy-targeted: allow generator to read symlinks and manage runtime files