### PR TITLE
ci: base.lock: update meta-audioreach layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -13,7 +13,7 @@ overrides:
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: 8b45caa354b772e44d5e011993a454d88b2e8bcc
+            commit: 263007cb243b9b6bf0b85619fa0daf7eeb9eca38
         meta-selinux:
             commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:


### PR DESCRIPTION
Relevant changes:
- 3f0c46d audioreach-conf: srcrev bump a8c8cf1...7143e0f
- 2a49bf6 audioreach-kernel: srcrev bump bf478f8..664f553
- e52220c audioreach-graphservices: srcrev bump 65320f2...8445aee
- 1a7b324 ci: reuse meta-qcom base.lock.yml and drop local overrides
- c28f708 ci/qcom-distro: apply MariaDB ARMv8.3+ build fix patch
- 52d1628 ci: base.lock: update layers to latest (except meta-oe) [1]
- 251d46d CI: switch to nodistro and drop poky