### PR TITLE
libdiag: bump up libdiag version

### DIFF
--- a/recipes-test/libdiag/libdiag_1.0.5.bb
+++ b/recipes-test/libdiag/libdiag_1.0.5.bb
@@ -1,12 +1,12 @@
 SUMMARY = "Prebuilt Qualcomm diagnostic library and utility applications"
 DESCRIPTION = "Prebuilt library and utility applications for diagnostic traffic"
 LICENSE = "LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/diag/NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=7a5da794b857d786888bbf2b7b7529c8"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/diag/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
 SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/core-technologies.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/diag_15.0.qcom+really${PV}_armv8a.tar.gz"
 
-PBT_BUILD_DATE = "251127"
-SRC_URI[sha256sum] = "e6780a404aaa89ffa7f20e659efae4f7b45beaeda8ca1fc05b5a1229ae648c49"
+PBT_BUILD_DATE = "260616"
+SRC_URI[sha256sum] = "6f064a43f6e2682ff9201f403cc10168f50846a2c7f402711667b0ee46d50d86"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Bump up libdiag version from 1.0.3 to 1.0.4.

Changes for 1.0.5(2026-05-13):
* Add LMCU support
* fix diagid name handling