### PR TITLE
camx-dlkm: Update camx driver to v1.0.3

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.3.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.3.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
 "
 
-SRCREV = "60755e6a8d744d5629d1b4d07237179a238b6778"
+SRCREV = "56b463cba50c1db1f2cc53ddd8790730f14bd8a8"
 
 inherit module
 


### PR DESCRIPTION
This tag v1.0.3 brings a below updates:

- Add CPAS support for v696_100
- Fix -EBUSY on shared GPIOs.