### PR TITLE
Enable downstream camera for QCS5430 Kodiak lite FP1

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -181,17 +181,17 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-staging"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+    "qcs6490-rb3gen2 qcs5430-fps-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+    "qcs6490-rb3gen2 qcs5430-fps-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+    "qcs6490-rb3gen2 qcs5430-fps-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-staging] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+    "qcs6490-rb3gen2 qcs5430-fps-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -20,6 +20,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine-staging.dtbo \
                       qcom/kodiak-el2.dtbo \
                       qcom/kodiak-staging.dtbo \
+                      qcom/qcs5430-fps-camx.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Updated FIT_DTB_COMPATIBLE entries to enable downstream camera for 
QCS5430 base kodiak lite FP1 device.

Include the downstream qcs5430-fps-camx.dtbo DTB, so it is packaged
into the final image and downstream camera functionality is available
for the QCS5430 base kodiak lite FP1 device.

qcs6490-rb3gen2-vision-mezzanine-camx targets full RB3 Gen2 (QCS6490)
hardware, while Kodiak Lite is a QCS5430 Soft SKU where camera resources
(IFE etc.) are restricted by hypervisor based on license.
Using qcs6490-rb3gen2-vision-mezzanine-camx DT will lead to mismatch in
camera topology and inaccessible hardware blocks, so a dedicated qcs5430 camx DTBO is required.