### PR TITLE
[Backport wrynose] recipes-graphics: backport A704 GPU support patch

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
+SRC_URI:append:qcom = " file://0001-freedreno-Add-support-for-A704.patch"
+
 # Enable freedreno driver
 PACKAGECONFIG_FREEDRENO = "\
     freedreno \

--- a/recipes-graphics/mesa/mesa/0001-freedreno-Add-support-for-A704.patch
+++ b/recipes-graphics/mesa/mesa/0001-freedreno-Add-support-for-A704.patch
@@ -1,0 +1,27 @@
+From 7b3535d0073f3b1d32fe118aa447857ed53b069c Mon Sep 17 00:00:00 2001
+From: Lakshman Chandu Kondreddy <lkondred@qti.qualcomm.com>
+Date: Fri, 8 May 2026 13:30:09 +0530
+Subject: [PATCH] freedreno: Add support for A704
+
+Add initial changes to enable basic functionality of A704.
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/8055fefea12c0e0527f425306617bb40fafc466a]
+Signed-off-by: Lakshman Chandu Kondreddy <lkondred@qti.qualcomm.com>
+---
+ src/freedreno/common/freedreno_devices.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/freedreno/common/freedreno_devices.py b/src/freedreno/common/freedreno_devices.py
+index 267190f91d4..19244c0ad5e 100644
+--- a/src/freedreno/common/freedreno_devices.py
++++ b/src/freedreno/common/freedreno_devices.py
+@@ -693,6 +693,7 @@ add_gpus([
+         GPUId(702), # KGSL
+         GPUId(chip_id=0x00b207002000, name="FD702"), # QRB2210 RB1
+         GPUId(chip_id=0xffff07002000, name="FD702"), # Default no-speedbin fallback
++        GPUId(chip_id=0xffff07000400, name="Adreno (TM) 704"),
+     ], A6xxGPUInfo(
+         CHIP.A6XX, # NOT a mistake!
+         [a6xx_base, a6xx_gen1_low, GPUProps(
+-- 
+2.34.1


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2294 to wrynose.