### PR TITLE
Enable KVM by default on IQ-615-EVK

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -311,14 +311,6 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
-          - machine: iq-615-evk
-            distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
-            kernel:
-                type: default
-                dirname: ""
-                yamlfile: ""
           - machine: qcom-armv7a
             distro:
                 name: nodistro

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -125,32 +125,32 @@ FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
     "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
 
 # ---------- talos ----------
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2gh-staging] = \
     "qcs615-ride talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = \
     "qcs615-ride talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
     "qcs615-ride talos-el2 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
     "talos-evk talos-evk-camera-imx577 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
     "talos-evk talos-evk-camera-imx577 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
     "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = "talos-evk talos-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
     "talos-evk talos-evk-camx talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = \
     "talos-evk talos-evk-camx talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx-staging] = \
     "talos-evk talos-evk-camx talos-el2 talos-staging"
 # Compatible string "qcom,talos-evk-lvds-auo,g133han01-staging" encodes as
 # "qcom_talos-evk-lvds-auo_g133han01-staging" (both commas become underscores).
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2gh-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm] = \
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2kvm-staging] = \
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
 
 # ---------- kodiak ----------

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs615.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi kvm pci"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \


### PR DESCRIPTION
All PILs are functioning correctly and KVM can be enabled by default on IQ-615-EVK.
Update FIT_DTB_COMPATIBLE entries and machine configurations to switch to default KVM.