### PR TITLE
rpmsgexport: add recipe and enable in boot-essential packagegroup

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom.bb
@@ -14,6 +14,7 @@ RDEPENDS:${PN}-boot-essential = " \
     qrtr \
     rmtfs \
     tqftpserv \
+    rpmsgexport \
 "
 
 RDEPENDS:${PN}-boot-additional:append:aarch64 = " \

--- a/recipes-support/rpmsg-export/files/rpmsg.rules
+++ b/recipes-support/rpmsg-export/files/rpmsg.rules
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
+# lpaicp: create qsh_1_0 through qsh_1_8 endpoints
+ACTION=="add", SUBSYSTEM=="rpmsg", \
+    KERNEL=="rpmsg_ctrl[0-9]*", \
+    ATTRS{rpmsg_name}=="lpaicp", \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_0" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_1" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_2" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_3" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_4" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_5" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_6" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_7" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name qsh_1_8" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name LOOPBACK_CTL_LMCU" \
+    RUN+="/usr/bin/rpmsgexport /dev/$name LOOPBACK_DATA_LMCU"
+
+# stable ctrl symlinks: /dev/rpmsg/<edge>/ctrl
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg_ctrl[0-9]*", \
+    ATTRS{rpmsg_name}=="?*", \
+    SYMLINK+="rpmsg/$attr{rpmsg_name}/ctrl"
+
+# stable endpoint symlinks: /dev/rpmsg/<edge>/<channel>
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg[0-9]*", \
+    ATTR{name}=="?*", \
+    ATTRS{rpmsg_name}=="?*", \
+    SYMLINK+="rpmsg/$attr{rpmsg_name}/$attr{name}"
+
+# lpaicp glink_pkt compat symlinks: /dev/glinkpkt_lpaicp_<channel>
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg[0-9]*", \
+    ATTRS{rpmsg_name}=="lpaicp", \
+    ATTR{name}=="qsh_*", \
+    SYMLINK+="glinkpkt_lpaicp_$attr{name}"
+
+# lpaicp LMCU ctrl glink_pkt compat symlink: /dev/glink_pkt_ctrl_lmcu
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg[0-9]*", \
+    ATTRS{rpmsg_name}=="lpaicp", \
+    ATTR{name}=="LOOPBACK_CTL_LMCU", \
+    SYMLINK+="glink_pkt_ctrl_lmcu"
+
+# lpaicp LMCU data glink_pkt compat symlink: /dev/glink_pkt_data_lmcu
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg[0-9]*", \
+    ATTRS{rpmsg_name}=="lpaicp", \
+    ATTR{name}=="LOOPBACK_DATA_LMCU", \
+    SYMLINK+="glink_pkt_data_lmcu"

--- a/recipes-support/rpmsg-export/rpmsgexport_git.bb
+++ b/recipes-support/rpmsg-export/rpmsgexport_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Qualcomm RPMSGEXPORT application"
+HOMEPAGE = "https://github.com/andersson/rpmsgexport.git"
+SECTION = "devel"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ff273e1fd41fa52668171e0817c89724"
+
+inherit systemd
+
+SRCREV = "324d88d668f36c6a5e6a9c2003a050b8a5a3cd60"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
+		   file://rpmsg.rules"
+
+
+PV = "0.3+${SRCPV}"
+
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} CFLAGS='${CFLAGS}' LDFLAGS='${LDFLAGS}'"
+
+do_install () {
+    oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system ${sysconfdir}
+	install -d ${D}/${sysconfdir}/udev/rules.d/
+	install -m 0644 ${UNPACKDIR}/rpmsg.rules ${D}${sysconfdir}/udev/rules.d/rpmsg.rules
+}
+
+FILES:${PN} += "${systemd_unitdir}/system/"


### PR DESCRIPTION
Add a Yocto recipe for rpmsgexport [1], a userspace utility that creates
Qualcomm rpmsg endpoint character devices by issuing RPMSG_CREATE_EPT_IOCTL
on the rpmsg control device (/dev/rpmsg_ctrl*).

The recipe installs:
  - /usr/bin/rpmsgexport
  - /etc/udev/rules.d/rpmsg.rules
  
  The bundled udev rules automatically invoke rpmsgexport when a remote
  processor boots and its rpmsg control device appears, creating endpoint
  devices and stable symlinks for userspace clients.
  
  rpmsgexport is added to the boot-essential package group so it is
  available by default on Qualcomm targets.
  
  [1] https://github.com/andersson/rpmsgexport