### PR TITLE
Always install adbd packages in images

### DIFF
--- a/classes-recipe/image-adbd.bbclass
+++ b/classes-recipe/image-adbd.bbclass
@@ -10,9 +10,7 @@
 
 IMAGE_FEATURES[validitems] += "enable-adbd"
 
-ADBD_PKGS = "${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "android-tools-adbd android-tools-adbd-cmdline", "", d)}"
-
-PACKAGE_INSTALL:append = " ${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], '${ADBD_PKGS}', '',d)} "
+PACKAGE_INSTALL:append = " ${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "android-tools-adbd android-tools-adbd-cmdline", "", d)}"
 
 enable_adbd_at_boot () {
     touch ${IMAGE_ROOTFS}/etc/usb-debugging-enabled


### PR DESCRIPTION
Avoid coupling adbd package installation with autostart behavior through IMAGE_FEATURES, which prevents on-demand adb usage without rebuilding the image. Always include adbd packages and control runtime behavior using the usb-debugging-enabled flag.