### PR TITLE
recipes-bsp: u-boot: enable Gunyah exit support for KVM-enabled targets

### DIFF
--- a/recipes-bsp/u-boot/files/gunyah-exit.cfg
+++ b/recipes-bsp/u-boot/files/gunyah-exit.cfg
@@ -1,0 +1,4 @@
+// Enable Gunyah EL2 exit handling and
+// ARM SoC boot0 hook in QCOM SOCs
+CONFIG_QCOM_EL2_GUNYAH_EXIT_SUPPORT=y
+CONFIG_ENABLE_ARM_SOC_BOOT0_HOOK=y

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=http
 SRC_URI += " \
     file://disable-eficapsule-tool.cfg \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'file://tfa-optee.cfg', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'kvm', 'file://gunyah-exit.cfg', '', d)} \
 "
 
 python __anonymous() {


### PR DESCRIPTION
Add a new config fragment (gunyah-exit.cfg) to enable Gunyah exit handling and the ARM SoC boot0 hook required for KVM-based boot.

The fragment is conditionally included when MACHINE_FEATURES contains 'kvm'.