### PR TITLE
Use COMBINED_FEATURES to select KVM XBL config

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -37,7 +37,7 @@ IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 
 # XBL Config selection
-QCOM_XBL_CONFIG ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "xbl_config_kvm.elf", "xbl_config.elf", d)}"
+QCOM_XBL_CONFIG ?= "${@bb.utils.contains("COMBINED_FEATURES", "kvm", "xbl_config_kvm.elf", "xbl_config.elf", d)}"
 
 # Android boot image settings
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"


### PR DESCRIPTION
Select xbl_config_kvm.elf when 'kvm' is in COMBINED_FEATURES. Switching to COMBINED_FEATURES allows per-platform control as well as distribution specific control of KVM enablement.