### PR TITLE
Switch to Gunyah based virtualization on Ride platforms

### DIFF
--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs8300.inc
 
-MACHINE_FEATURES += "efi kvm pci"
+MACHINE_FEATURES += "efi pci"
 
 QCOM_DTB_DEFAULT ?= "qcs8300-ride"
 

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi kvm pci"
+MACHINE_FEATURES += "efi pci"
 
 QCOM_DTB_DEFAULT ?= "qcs9100-ride-r3"
 


### PR DESCRIPTION
Ride platforms lack multi-DTB support which needed for EL2 DTBO loading. Without EL2 DTBO, remoteproc won't be functional with KVM. Switch to Gunyah on Ride platforms until multi-DTB support is available.