### PR TITLE
[Backport Wrynose] Enable Purwa camx DTB compilation for linux-qcom kernel

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -20,6 +20,9 @@ require conf/machine/include/fit-dtb-compatible.inc
 # ---------- hamoa  ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 
+# ---------- purwa -----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
+
 # ---------- lemans ----------
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-staging] = \
     "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging"

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -10,6 +10,11 @@ KERNEL_DEVICETREE ?= " \
     qcom/purwa-iot-evk.dtb \
     "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom kernels
+LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/purwa-evk-camx.dtbo \
+"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-purwa-iot-evk-firmware \
     packagegroup-purwa-iot-evk-hexagon-dsp-binaries \


### PR DESCRIPTION
Downstream camera DTB is not included in the final image
when building linux-qcom, linux-qcom-next, linux-qcom-rt,
or linux-qcom-next-rt kernels for the purwa EVK board.
This prevents the downstream camera stack from being
enabled at boot, even though the kernel supports it.

Include the downstream camera DTB so it is packaged into
the final image and downstream camera functionality is
available for the IQ-x5121 EVK.

Add multi-DTB support for camx overlay to enable downstream
camera for IQ-x5121 (purwa-evk-camx).