### PR TITLE
Move CDT handling into separate recipes

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -6,6 +6,7 @@ inherit image_types
 IMAGE_TYPES += "qcomflash"
 
 QCOM_BOOT_FIRMWARE ?= ""
+QCOM_CDT_FIRMWARE ?= ""
 PREFERRED_PROVIDER_virtual/qcom-capsule-firmware ?= ""
 QCOM_CAPSULE_FIRMWARE ?= "${PREFERRED_PROVIDER_virtual/qcom-capsule-firmware}"
 
@@ -28,6 +29,7 @@ do_image_qcomflash[dirs] = "${QCOMFLASH_DIR}"
 do_image_qcomflash[cleandirs] = "${QCOMFLASH_DIR}"
 do_image_qcomflash[depends] += "${@ ['', '${QCOM_PARTITION_CONF}:do_deploy'][d.getVar('QCOM_PARTITION_CONF') != '']} \
                                 ${@ ['', '${QCOM_BOOT_FIRMWARE}:do_deploy'][d.getVar('QCOM_BOOT_FIRMWARE') != '']} \
+                                ${@ ['', '${QCOM_CDT_FIRMWARE}:do_deploy'][d.getVar('QCOM_CDT_FIRMWARE') != '']} \
                                 ${@ ['', '${QCOM_CAPSULE_FIRMWARE}:do_deploy'][d.getVar('QCOM_CAPSULE_FIRMWARE') != '']} \
                                 pigz-native:do_populate_sysroot virtual/kernel:do_deploy \
 				${@'virtual/bootloader:do_deploy' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader') else  ''} \

--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -23,3 +23,4 @@ QCOM_PARTITION_FILES_SUBDIR ?= "partitions/glymur-crd/nvme"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/glymur-crd/spinor"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-glymur"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-glymur"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -31,6 +31,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-615-evk/emmc"
 QCOM_CDT_FILE = "cdt_sm6150_4.1.0"
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs615"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs615"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "7"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -35,6 +35,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-8275-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs8300"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "3"

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -36,6 +36,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-9075-evk/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs9100"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "7"

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -27,5 +27,6 @@ QCOM_BOOT_FILES_SUBDIR = "iq-x7181"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
-# IQ-X5121 and IQ-x7181 share the same boot firmware.
+# IQ-X5121 and IQ-x7181 share the same boot firmware and CDT firmware.
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-iq-x7181"

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -30,6 +30,7 @@ QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-x7181-evk/ufs"
 QCOM_PARTITION_FILES_SUBDIR_SPINOR ?= "partitions/iq-x7181-evk/spinor"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-iq-x7181"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-iq-x7181"
 
 CAPSULE_GUID       = "0F6D58FC-2258-4D27-9E23-D77219B0897C"
 

--- a/conf/machine/kaanapali-mtp.conf
+++ b/conf/machine/kaanapali-mtp.conf
@@ -23,3 +23,4 @@ QCOM_BOOT_FILES_SUBDIR = "kaanapali"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/kaanapali-mtp/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-kaanapali"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-kaanapali"

--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -26,6 +26,7 @@ QCOM_CDT_FILE = "cdt_kodiak_idp_0.1.0"
 QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs6490"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcm6490-idp/ufs"
 
 # Isolate rt cpu

--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -29,6 +29,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs615-ride/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs615"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs615"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "7"

--- a/conf/machine/qcs8300-ride-sx.conf
+++ b/conf/machine/qcs8300-ride-sx.conf
@@ -32,6 +32,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs8300"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs8300-ride-sx/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs8300"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs8300"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "3"

--- a/conf/machine/qcs9100-ride-sx.conf
+++ b/conf/machine/qcs9100-ride-sx.conf
@@ -37,6 +37,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcs9100"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs9100-ride-sx/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs9100"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs9100"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "7"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -36,6 +36,7 @@ QCOM_BOOT_FILES_SUBDIR = "qcm6490"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qcs6490-rb3gen2/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs6490"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qcs6490"
 
 # Isolate rt cpu
 QCOM_RT_CPU        = "7"

--- a/conf/machine/sm8750-mtp.conf
+++ b/conf/machine/sm8750-mtp.conf
@@ -23,3 +23,4 @@ QCOM_BOOT_FILES_SUBDIR = "sm8750"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/sm8750-mtp/ufs"
 
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-sm8750"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-sm8750"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -24,7 +24,6 @@ do_deploy() {
     find "${S}" -maxdepth 1 -name 'qsahara_*.xml' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name '*.xz' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
 
-    find "${UNPACKDIR}" -iname '*cdt*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
 }
 addtask deploy before do_build after do_install
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur.inc
@@ -10,10 +10,8 @@ S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SC8480XP/cdt/sc8480xp-crd.zip;downloadfilename=sc8480xp-crd_${PV}.zip;name=sc8480xp-crd \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
-SRC_URI[sc8480xp-crd.sha256sum] = "d694eedb0addcc5ee588d6993661cd23996fba1d1a43afc3b196dad12534bffc"
 
 QCOM_BOOT_IMG_SUBDIR = "glymur-crd/spinor"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
@@ -12,9 +12,7 @@ S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/HAMOA_bootbinaries_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/X1E80100/cdt/IQ-X.1.2-EVK-CDT.tar.gz;downloadfilename=cdt-iq-x7181-evk_${PV}.tar.gz;name=cdt-iq-x7181-evk \
     "
-SRC_URI[cdt-iq-x7181-evk.sha256sum] = "279c47ff8f1a7f4300d296fcb7fbb3d025d903e4c16f62fbb74939804949584e"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "iq-x7181/spinor"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
@@ -10,10 +10,8 @@ BOOTBINARIES = "kaanapali_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SM8850/cdt/sm8850-mtp.zip;downloadfilename=sm8850-mtp_${PV}.zip;name=sm8850-mtp \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
-SRC_URI[sm8850-mtp.sha256sum] = "41b15acaa06311c8c7500d7467a5d8adb9fdee05aed09d983d3dad045865b1d7"
 
 QCOM_BOOT_IMG_SUBDIR = "kaanapali"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -8,11 +8,7 @@ BOOTBINARIES = "QCS615_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/EVK_SA6150P.zip;downloadfilename=cdt-iq-615-evk_${PV}.zip;name=iq-615-evk \
     "
-SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
-SRC_URI[iq-615-evk.sha256sum] = "e8ea707a27090e4338c709cabdad46159c06cd91e7c2fc5348f5d98db7bbb802"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs615"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
@@ -8,17 +8,7 @@ BOOTBINARIES = "QCM6490_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/qcm6490-idp.zip;downloadfilename=cdt-qcm6490-idp_${PV}.zip;name=qcm6490-idp \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-industrial-kit.zip;downloadfilename=cdt-rb3gen2-industrial-kit_${PV}.zip;name=rb3gen2-industrial-kit \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-vision-kit.zip;downloadfilename=cdt-rb3gen2-vision-kit_${PV}.zip;name=rb3gen2-vision-kit \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-industrial-mezz-kit.zip;downloadfilename=cdt-rb3gen2-industrial-mezz-kit_${PV}.zip;name=rb3gen2-industrial-mezz-kit \
     "
-SRC_URI[qcm6490-idp.sha256sum] = "32226891c51fe6f2bf8def4be66e614bf2994bffaf0dac343b9baa05f7829e11"
-SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"
-SRC_URI[rb3gen2-industrial-kit.sha256sum] = "6cf70a1b9eb0ff27176bb77c679d519f58fbad2cdf2fd7bec1e305c1bf52c013"
-SRC_URI[rb3gen2-vision-kit.sha256sum] = "a339e297b454c4dc3805fe8cd11d6d8dcb801aa8f0c2dc691561c2785019fa3c"
-SRC_URI[rb3gen2-industrial-mezz-kit.sha256sum] = "bb1c93e24c8c600f5850736294297a2f7256369c238a2d2e96acd68a118d31d6"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcm6490"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -8,11 +8,7 @@ BOOTBINARIES = "QCS8300_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \
     "
-SRC_URI[qcs8300-ride-sx.sha256sum] = "d7fc667372b28383a36d586333097d84b9d9c104f4dd1845d33904e2d6b39f80"
-SRC_URI[cdt-iq8275-evk-pro-sku.sha256sum] = "cbe2009c8ef7dbacd716141bf01b8e1b26788c4a4f3145e60fe3b4a6b3aabc04"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs8300"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -8,11 +8,7 @@ BOOTBINARIES = "QCS9100_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx_v3.zip;downloadfilename=cdt-qcs9100-ride-sx-v3_${PV}.zip;name=qcs9100-ride-sx \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/rb8_core_kit.zip;downloadfilename=cdt-qcs9100-rb8-core-kit_${PV}.zip;name=qcs9100-rb8-ck \
     "
-SRC_URI[qcs9100-rb8-ck.sha256sum] = "a252244f800d7c9e15883e12935af4113f9f2ecba6490e46cd9b943169f15bfa"
-SRC_URI[qcs9100-ride-sx.sha256sum] = "377a8405899ac82199deaf70bca3648c15b924a3fcef8f109555e661ed70f4b9"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs9100"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
@@ -9,10 +9,8 @@ BOOTBINARIES = "pakala_bootbinaries"
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
-    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/SM8750/cdt/sm8750-mtp_wcn7881.zip;downloadfilename=sm8750-mtp_wcn7881_${PV}.zip;name=sm8750-mtp_wcn7881 \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
-SRC_URI[sm8750-mtp_wcn7881.sha256sum] = "474c35a6f06948808be118a8b0dac61ca53fd71182c1f03b92ca30d34dbb8a58"
 
 QCOM_BOOT_IMG_SUBDIR = "sm8750"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-common.inc
@@ -1,0 +1,23 @@
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+
+inherit allarch
+
+CDT_ARTIFACTORY = "artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux"
+
+S = "${UNPACKDIR}"
+
+QCOM_CDT_SUBDIR ?= "${QCOM_BOOT_FILES_SUBDIR}"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${QCOM_CDT_SUBDIR}
+    find "${UNPACKDIR}" -iname '*cdt*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_CDT_SUBDIR} \;
+}
+addtask deploy before do_build after do_install

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-glymur.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-glymur.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm Glymur platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/SC8480XP/cdt/sc8480xp-crd.zip;downloadfilename=sc8480xp-crd_${PV}.zip;name=sc8480xp-crd \
+    "
+SRC_URI[sc8480xp-crd.sha256sum] = "d694eedb0addcc5ee588d6993661cd23996fba1d1a43afc3b196dad12534bffc"
+
+QCOM_CDT_SUBDIR = "glymur-crd/spinor"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-iq-x7181.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-iq-x7181.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm IQ-X7181 (Hamoa) platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/X1E80100/cdt/IQ-X.1.2-EVK-CDT.tar.gz;downloadfilename=cdt-iq-x7181-evk_${PV}.tar.gz;name=cdt-iq-x7181-evk \
+    "
+SRC_URI[cdt-iq-x7181-evk.sha256sum] = "279c47ff8f1a7f4300d296fcb7fbb3d025d903e4c16f62fbb74939804949584e"
+
+QCOM_CDT_SUBDIR = "iq-x7181/spinor"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-kaanapali.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-kaanapali.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm Kaanapali platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/SM8850/cdt/sm8850-mtp.zip;downloadfilename=sm8850-mtp_${PV}.zip;name=sm8850-mtp \
+    "
+SRC_URI[sm8850-mtp.sha256sum] = "41b15acaa06311c8c7500d7467a5d8adb9fdee05aed09d983d3dad045865b1d7"
+
+QCOM_CDT_SUBDIR = "kaanapali"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs615.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs615.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm QCS615 platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
+    https://${CDT_ARTIFACTORY}/QCS615/cdt/EVK_SA6150P.zip;downloadfilename=cdt-iq-615-evk_${PV}.zip;name=iq-615-evk \
+    "
+SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
+SRC_URI[iq-615-evk.sha256sum] = "e8ea707a27090e4338c709cabdad46159c06cd91e7c2fc5348f5d98db7bbb802"
+
+QCOM_CDT_SUBDIR = "qcs615"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs6490.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs6490.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm QCS6490 platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/QCS6490/cdt/qcm6490-idp.zip;downloadfilename=cdt-qcm6490-idp_${PV}.zip;name=qcm6490-idp \
+    https://${CDT_ARTIFACTORY}/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit \
+    https://${CDT_ARTIFACTORY}/QCS6490/cdt/rb3gen2-industrial-kit.zip;downloadfilename=cdt-rb3gen2-industrial-kit_${PV}.zip;name=rb3gen2-industrial-kit \
+    https://${CDT_ARTIFACTORY}/QCS6490/cdt/rb3gen2-vision-kit.zip;downloadfilename=cdt-rb3gen2-vision-kit_${PV}.zip;name=rb3gen2-vision-kit \
+    https://${CDT_ARTIFACTORY}/QCS6490/cdt/rb3gen2-industrial-mezz-kit.zip;downloadfilename=cdt-rb3gen2-industrial-mezz-kit_${PV}.zip;name=rb3gen2-industrial-mezz-kit \
+    "
+SRC_URI[qcm6490-idp.sha256sum] = "32226891c51fe6f2bf8def4be66e614bf2994bffaf0dac343b9baa05f7829e11"
+SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"
+SRC_URI[rb3gen2-industrial-kit.sha256sum] = "6cf70a1b9eb0ff27176bb77c679d519f58fbad2cdf2fd7bec1e305c1bf52c013"
+SRC_URI[rb3gen2-vision-kit.sha256sum] = "a339e297b454c4dc3805fe8cd11d6d8dcb801aa8f0c2dc691561c2785019fa3c"
+SRC_URI[rb3gen2-industrial-mezz-kit.sha256sum] = "bb1c93e24c8c600f5850736294297a2f7256369c238a2d2e96acd68a118d31d6"
+
+QCOM_CDT_SUBDIR = "qcm6490"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs8300.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs8300.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm QCS8300 platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/QCS8300/cdt/ride-sx.zip;downloadfilename=cdt-qcs8300-ride-sx_${PV}.zip;name=qcs8300-ride-sx \
+    https://${CDT_ARTIFACTORY}/QCS8300/cdt/qcs8275-iq-8275-evk-pro-sku.zip;downloadfilename=cdt-iq8275-evk-pro-sku_${PV}.zip;name=cdt-iq8275-evk-pro-sku \
+    "
+SRC_URI[qcs8300-ride-sx.sha256sum] = "d7fc667372b28383a36d586333097d84b9d9c104f4dd1845d33904e2d6b39f80"
+SRC_URI[cdt-iq8275-evk-pro-sku.sha256sum] = "cbe2009c8ef7dbacd716141bf01b8e1b26788c4a4f3145e60fe3b4a6b3aabc04"
+
+QCOM_CDT_SUBDIR = "qcs8300"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs9100.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-qcs9100.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm QCS9100 platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/QCS9100/cdt/ride-sx_v3.zip;downloadfilename=cdt-qcs9100-ride-sx-v3_${PV}.zip;name=qcs9100-ride-sx \
+    https://${CDT_ARTIFACTORY}/QCS9100/cdt/rb8_core_kit.zip;downloadfilename=cdt-qcs9100-rb8-core-kit_${PV}.zip;name=qcs9100-rb8-ck \
+    "
+SRC_URI[qcs9100-ride-sx.sha256sum] = "377a8405899ac82199deaf70bca3648c15b924a3fcef8f109555e661ed70f4b9"
+SRC_URI[qcs9100-rb8-ck.sha256sum] = "a252244f800d7c9e15883e12935af4113f9f2ecba6490e46cd9b943169f15bfa"
+
+QCOM_CDT_SUBDIR = "qcs9100"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-sm8750.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-sm8750.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm SM8750 platform"
+
+SRC_URI = " \
+    https://${CDT_ARTIFACTORY}/SM8750/cdt/sm8750-mtp_wcn7881.zip;downloadfilename=sm8750-mtp_wcn7881_${PV}.zip;name=sm8750-mtp_wcn7881 \
+    "
+SRC_URI[sm8750-mtp_wcn7881.sha256sum] = "474c35a6f06948808be118a8b0dac61ca53fd71182c1f03b92ca30d34dbb8a58"
+
+QCOM_CDT_SUBDIR = "sm8750"
+
+include firmware-qcom-cdt-common.inc


### PR DESCRIPTION
Move CDT installation to dedicated firmware-qcom-cdt-* recipes for all platforms.