### PR TITLE
workflows: fix PR test branch detection for forked PRs

### DIFF
--- a/.github/workflows/test-pr-wrynose.yml
+++ b/.github/workflows/test-pr-wrynose.yml
@@ -13,6 +13,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  actions: read
 
 jobs:
   determine-target-branch:
@@ -20,11 +21,21 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.value }}
     steps:
+      # github.event.workflow_run.pull_requests is empty for PRs opened from
+      # forked repositories, so the target branch can't be read from the event
+      # payload. Read it instead from the Event File artifact uploaded by the
+      # build: it is the literal pull_request event that triggered the build and
+      # therefore identifies the target branch reliably, forks included.
+      - name: Download event file
+        uses: actions/download-artifact@v7
+        with:
+          name: Event File
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - id: branch
-        env:
-          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
-          BRANCH=$(echo "$PULL_REQUESTS_JSON" | jq -r '.[0].base.ref // "master"')
+          BRANCH=$(jq -r '.pull_request.base.ref // "master"' event.json)
+          echo "::notice title=Target branch::Resolved target branch: $BRANCH"
           echo "value=$BRANCH" >> "$GITHUB_OUTPUT"
 
   test-wrynose:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -13,6 +13,7 @@ permissions:
   pull-requests: write
   contents: read
   packages: read
+  actions: read
 
 jobs:
   determine-target-branch:
@@ -20,11 +21,21 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.value }}
     steps:
+      # github.event.workflow_run.pull_requests is empty for PRs opened from
+      # forked repositories, so the target branch can't be read from the event
+      # payload. Read it instead from the Event File artifact uploaded by the
+      # build: it is the literal pull_request event that triggered the build and
+      # therefore identifies the target branch reliably, forks included.
+      - name: Download event file
+        uses: actions/download-artifact@v7
+        with:
+          name: Event File
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - id: branch
-        env:
-          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
-          BRANCH=$(echo "$PULL_REQUESTS_JSON" | jq -r '.[0].base.ref // "master"')
+          BRANCH=$(jq -r '.pull_request.base.ref // "master"' event.json)
+          echo "::notice title=Target branch::Resolved target branch: $BRANCH"
           echo "value=$BRANCH" >> "$GITHUB_OUTPUT"
 
   test:


### PR DESCRIPTION
github.event.workflow_run.pull_requests is empty for pull requests opened from forked repositories, so determine-target-branch always fell through to the "master" default. As nearly all PRs come from forks, PRs targeting wrynose ended up running the master test plan while the wrynose plan was skipped, so the branch-specific routing introduced for the two test tracks never worked for fork PRs.

Read the target branch from the Event File artifact uploaded by the build instead. It is the literal pull_request event that triggered the build, so it resolves the target branch reliably, forks included. Add the actions: read permission needed to download that artifact from the build run.