### PR TITLE
iq-615-evk: add EVK CDT zip and QCOM_CDT_FILE

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -27,6 +27,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_BOOT_FILES_SUBDIR = "qcs615"
 QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq-615-evk/emmc"
+QCOM_CDT_FILE = "cdt_sm6150_4.1.0"
 QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qcs615"
 
 # Isolate rt cpu

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615.inc
@@ -9,8 +9,10 @@ SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip;downloadfilename=cdt-qcs615-adp-air_${PV}.zip;name=qcs615-adp-air \
+    https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/EVK_SA6150P.zip;downloadfilename=cdt-iq-615-evk_${PV}.zip;name=iq-615-evk \
     "
 SRC_URI[qcs615-adp-air.sha256sum] = "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
+SRC_URI[iq-615-evk.sha256sum] = "e8ea707a27090e4338c709cabdad46159c06cd91e7c2fc5348f5d98db7bbb802"
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "qcs615"


### PR DESCRIPTION
Add CDT support for the IQ-615 EVK board:

 - Add EVK_SA6150P.zip as a CDT source in firmware-qcom-boot-qcs615.inc
 - Set QCOM_CDT_FILE = "cdt_sm6150_4.1.0" in the IQ-615 EVK machine
configuration to select the correct CDT binary at boot