### PR TITLE
qairt-sdk: upgrade 2.43.0 -> 2.47.0

### DIFF
--- a/recipes-ml/qairt/qairt-sdk_2.47.0.260601.bb
+++ b/recipes-ml/qairt/qairt-sdk_2.47.0.260601.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.pdf;md5=878b885995f453e328edbcd5a1302306"
 NO_GENERIC_LICENSE[qcom-ai-stack] = "LICENSE.pdf"
 
 SRC_URI = "https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/${PV}/v${PV}.zip"
-SRC_URI[sha256sum] = "e3fce35419310bf80aa2947442a4b39366d80237c4bd72946b77832f71b75223"
+SRC_URI[sha256sum] = "d3497e110eae82c35a9152a93c0a18bbede402aaf9faa7a97c8079eb0f522b01"
 
 S = "${UNPACKDIR}/qairt/${PV}"
 


### PR DESCRIPTION
Upgrade version from 2.43.0.260128 to 2.47.0.260601

- HTP: Added block quantization support; Int16 Hadamard Transform; VTCM virtual address optimization; updateable quantized tensors in TransposeConv2d; ONNX RotaryEmbedding (RoPE) Op support.
- GPU: Extended QNN_DATATYPE_SFIXED_POINT_8 and INT8 support across pooling, activation, convolution, and reduction ops; asynchronouse graph execution.
- Genie: Added GenieNode_train and GenieNode_saveLora APIs; linear attention support; LoRA memory release API; removed QnnGenAITransformerBE OpPackage dependency.
- CPU: Enhanced MatMul kernel reliability on ARM Cortex-A55.
- Tools: Added Ubuntu 24.04, Python 3.12, and ARM-Linux host support; multiple new converter optimization passes including GRU/LSTM unrolling, negation simplification, GroupNorm reshape, and remove_disconnected_nodes pruning.

Bug fixes address HTP stability issues including crashes, hangs, and accuracy regressions in Softmax, elementwise, and LoRA operations, as well as converter failures in BatchNormalization, quantization encoding handling, and LSTM/GRU translation.

For more details, please refer to the release notes at qairt/${PV}/QAIRT_ReleaseNotes.txt in the QAIRT SDK source archive.