### PR TITLE
kgsl-dlkm: Update to v1.0.4

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.4.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.4.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "9ab5c108257cf64fe6628c0144765e98f489036f"
+SRCREV = "4300b655d3c0018b5341ecf876698cbb1c31f255"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.4 brings below fixes:

- Add support for gen8_1_0 GPU.
- enable ACD on gen8_1_0.
- Fix -ELOOP in firmware load by dispatching to workqueue.