### PR TITLE
fastrpc: upgrade 1.0.5 -> 1.0.6

### DIFF
--- a/recipes-support/fastrpc/fastrpc_1.0.6.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.6.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b67986b6880754696d418dbaa2cf51d1"
 DEPENDS = "libbsd libyaml"
 
-SRCREV = "29851fde11d4e2a4ce221536485d0f7d46ffca30"
+SRCREV = "5f0b6a33a19f3f7f0c06709846752a2caf64e413"
 SRC_URI = "\
     git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
     file://run-ptest \
@@ -14,7 +14,11 @@ SRC_URI = "\
 
 inherit autotools systemd ptest pkgconfig
 
-EXTRA_OECONF += "--with-systemdsystemunitdir=${systemd_system_unitdir}"
+EXTRA_OECONF += "\
+    --with-systemdsystemunitdir=${systemd_system_unitdir} \
+    --with-udevrulesdir=${nonarch_base_libdir}/udev/rules.d \
+    --with-sysusersdir=${nonarch_libdir}/sysusers.d \
+"
 
 SYSTEMD_SERVICE:${PN} = " \
     adsprpcd.service \
@@ -28,9 +32,6 @@ SYSTEMD_SERVICE:${PN} = " \
 
 do_install:append() {
     install -d ${D}${datadir}/qcom/
-
-    sed -i -e 's:/usr/bin/:${bindir}/:g' \
-        ${D}${systemd_system_unitdir}/*.service
 }
 
 FILES:${PN} += " \
@@ -42,6 +43,8 @@ FILES:${PN} += " \
     ${libdir}/libcdsprpc.so \
     ${libdir}/libsdsprpc.so \
     ${datadir}/qcom/ \
+    ${nonarch_base_libdir}/udev/rules.d/60-fastrpc.rules \
+    ${nonarch_libdir}/sysusers.d/fastrpc.conf \
 "
 
 FILES:${PN}-dev:remove = "${FILES_SOLIBSDEV}"


### PR DESCRIPTION
Upgrade fastrpc from version 1.0.5 to 1.0.6, bringing build warning fixes, improved systemd integration, and updated recipe configuration for better service management and packaging.

### **Changelog**
**Core Enhancements**
Improve systemd services with dedicated fastrpc user/group support

**Build & Tooling Improvements**
Fix build warnings
Add configure options for:
  udev rules directory
  sysusers directory



**Code Cleanup & Maintenance**
Remove service file path rewriting (sed on /usr/bin)
Align install paths with upstream defaults

**Package additional runtime components**
fastrpc daemon binaries (adsprpcd, cdsprpcd, sdsprpcd, gdsprpcd)
udev rules (60-fastrpc.rules)
sysusers configuration (fastrpc.conf)

**Full Changelog**
https://github.com/qualcomm/fastrpc/compare/v1.0.5...v1.0.6