### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "d09996d91cc067e9c4e6a22d84a9bac56d07fdfa"
+SRCREV = "c88627275da8d6280d959e3b58c8e39390aec0a5"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Fang Wu (2):
    platforms/iq-615-evk: add missing cdt partition in Boot Area Partition 1
    tests: regenerate checksums.sha256 for iq-615-evk cdt change

Xueqian Nie (1):
    iq-x7181-evk: rename _a/_b partitions to main/backup naming