### PR TITLE
camx: revision update for Hamoa, Lemans, Talos

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.25.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.25.bb
@@ -1,9 +1,0 @@
-PLATFORM = "hamoa"
-PBT_BUILD_DATE = "260520"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum] = "cd321d37bbfe4fdbf8e2fce649185b703bdda9e5252af9e7994617cb5f6f156f"
-SRC_URI[camx.sha256sum] = "2c43d0ad848cb18ee3579e9b908d2408cf14e0f27dc41a976b65007a83d4f567"
-SRC_URI[chicdk.sha256sum] = "933f8a4a8abdd66faa3772fb493900fd1ff82c08346dac2d455f3335bae4b8c2"
-SRC_URI[camxcommon.sha256sum] = "b36265c5a33f1a83e0659a89eb58e1cc3abc9bc02619d000a8c9cf112a451f62"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.26.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.26.bb
@@ -1,0 +1,9 @@
+PLATFORM = "hamoa"
+PBT_BUILD_DATE = "260608"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "de9462268613e3efce2b1103b81ac0b0927cdb957a9791779094114821017656"
+SRC_URI[camx.sha256sum] = "dc51e2fb8ba211551b86f22e849a41499aba1460f44d5c2fb6daf6759c0bf0b9"
+SRC_URI[chicdk.sha256sum] = "60eb44f2fee434bbe22fe7598771da9c2e5d11ad2d22954fc0d01e216827364c"
+SRC_URI[camxcommon.sha256sum] = "08e5e6256b80b9b8a0296977f247810f89dfb456da10618e76a9593ab6a75b78"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.26.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.26.bb
@@ -1,12 +1,14 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260515"
+PBT_BUILD_DATE = "260608"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum] = "15a96f7e3074a937f218d409ad068dba693eebc9ce518bf867399e6faf454e34"
-SRC_URI[camx.sha256sum] = "2c8d668138e2c81fee8179e3f71fc35c244f5b353bb83386bc3e5f3523263b9e"
-SRC_URI[chicdk.sha256sum] = "2770e377c159f25fb1bd656754987920f9439efb2233ad49135077808e073e4f"
-SRC_URI[camxcommon.sha256sum] = "ec9910a6b243af5518e748cb93b525bed9072a124d2cb87abfc1f61566a34b28"
+SRC_URI[camxlib.sha256sum] = "1a8b1e8d2ad8d1697b566130bde4f83df500d6ff0479613fdcda70e129d85686"
+SRC_URI[camx.sha256sum] = "b5b7e51f30bfd6cdbd56dcda9ceeee50cb1f0519c65e98c3a0fe74a1e77b2cec"
+SRC_URI[chicdk.sha256sum] = "765bdbac41ad3b223bd74e289f16b0fa2c12b2fe7a58e0dcf81dc7c653538857"
+SRC_URI[camxcommon.sha256sum] = "4897fd152b8858cf93d0b31ba2d8e46842cdcd917a3ed10493bc1fec84de3276"
+
+
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.24.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.24.bb
@@ -1,9 +1,0 @@
-PLATFORM = "talos"
-PBT_BUILD_DATE = "260515"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum] = "5ef124eeb3b3eae5ca54651820ba00e004aca6b6aa860fb37d86485ed6489b10"
-SRC_URI[camx.sha256sum] = "9bd108e58fc128c76d429c75907c765f5fdf23d1f467c5398b31dd70b10d963e"
-SRC_URI[chicdk.sha256sum] = "41f783d9614177bc61c0b8f95f8ff347af348d867fb708c670bc84473cb8dea8"
-SRC_URI[camxcommon.sha256sum] = "5b0aefeb4737474f23bf3fa1168ad4da33f528cace047ea82aac79931657a24c"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.26.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.26.bb
@@ -1,0 +1,9 @@
+PLATFORM = "talos"
+PBT_BUILD_DATE = "260608"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "71b6fa32d429a9811e3ab77b5d68b53184b13f1b0627f2830d2fe876524f1844"
+SRC_URI[camx.sha256sum] = "bfaf94dfc0efb09379d137d8fd50942ef4ac57f309e0d394d18a0e96c5d78420"
+SRC_URI[chicdk.sha256sum] = "157620217e819a84b04c8181e0b8b7e8ea580fd10f84dd6fe91eb8b5a89059e2"
+SRC_URI[camxcommon.sha256sum] = "80a9d45aa4008aadde7b8e49e6f5523eb60d87c3fd14c2accd85ea9239bcac98"


### PR DESCRIPTION
- Fix: Removed perf mode specific handling for metadata creation 

- Add swregistrationalgo library for Talos
Included swregistrationalgo.so required for Talos runtime.

- Add Sensor Module binaries Added required sensor module binaries for updated configurations.
Added files:
1. com.qti.sensormodule.hamoa_cmk_imx577_csi1.bin
2. com.qti.sensormodule.og0va1b.bin
3. com.qti.sensormodule.qti_tpg0_iqx.bin
4. com.qti.sensormodule.qti_tpg1_iqx.bin
5. com.qti.sensormodule.qti_tpg2_iqx.bin

