### PR TITLE
ci: bump testkit to testkit-2026.06.10 for fastrpc and test reliability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "d02dbbca3e35c3f29dce5aa4c1eac506103f821d"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.06.01"
+  TESTKIT_REF: "testkit-2026.06.10"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
testkit-2026.06.10 rewrites fastrpc to validate across multiple DSP domains and protection domains instead of a single fixed target, replaces the Interrupts 120-second fixed sleep with a configurable poll loop cutting up to 90 seconds per run, and bounds the OpenCV smoke suite to prevent silent LAVA timeout before results are written.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>