### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260609 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260601
-SRCREV ?= "b7cce9a3884a873855693af8591d4c9c469cd17e"
+# tag:qcom-6.18.y-20260609
+SRCREV ?= "997c1ece634c8c755c970af6895dba3a6c5e204a"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260609

Changelog:
QCLINUX: arm64: configs: qcom.config: Enable CONFIG_SWIOTLB_DYNAMIC
FROMLIST: scsi: ufs: ufs-qcom: Enable SKIP DEVICE RESET Quirk
FROMLIST: scsi: ufs: core: Add UFSHCD_QUIRK_SKIP_DEVICE_RESET quirk
QCLINUX: qcom.config: Enable CPU caches RAS
FROMLIST: misc: fastrpc: fix context leak and hang on signal-interrupted invoke
QCLINUX: arm64: dts: qcom: Change Purwa camera firmware path
FROMLIST: arm64: dts: qcom: monaco: add AEST error nodes
FROMLIST: arm64: dts: qcom: lemans: add AEST error nodes
FROMLIST: ras: aest: Add DT frontend for ARM AEST RAS error sources
FROMLIST: Bluetooth: qca: combine NVM and calibration data for QCC2072
FROMLIST: arm64: dts: qcom: Add M.2 QCC2072 support on qcs6490-rb3gen2 industrial mezzanine
FROMLIST: Bluetooth: qca: add QCC2072 support
FROMLIST: dt-bindings: net: bluetooth: qcom: document QCC2072
FROMLIST: Bluetooth: hci_qca: Use 100 ms SSR delay for rampatch and NVM loading
FROMLIST: mmc: sdhci-msm: Set ice clk rate
FROMLIST: arm64: dts: qcom: purwa-iot-evk: Update TSENS thermal zone
FROMLIST: serial: qcom_geni: Fix RX DMA stall when SE_DMA_RX_LEN_IN is zero
FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL
FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe
FROMLIST: misc: fastrpc: Fail Audio PD init when reserved memory is missing
FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation
FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool
Revert "FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool"
Revert "FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation"
Revert "FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe"
Revert "FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL"
FROMLIST: media: iris: switch to hardware mode after firmware boot
FROMLIST: media: iris: optimize COMV buffer allocation for VPU3x and VPU4x
FROMLIST: arm64: dts: qcom: qcs615-ride: fix sdhc_2 vqmmc supply for UHS-I mode
FROMLIST: media: iris: Add Gen2 firmware autodetect and fallback
FROMLIST: media: iris: Initialize HFI ops after firmware load in core init
FROMGIT: media: qcom: iris: extract firmware description data
FROMGIT: media: qcom: iris: use new firmware name for SM8250
FROMGIT: media: qcom: iris: split platform data from firmware data
FROMGIT: media: qcom: iris: split firmware_data from raw platform data
FROMGIT: media: qcom: iris: drop hw_response_timeout_val from platform data
FROMGIT: media: qcom: iris: move get_instance to iris_hfi_sys_ops
FROMGIT: media: qcom: iris: merge hfi_response_ops and hfi_command_ops
FROMGIT: media: qcom: iris: split HFI session ops from core ops
FROMGIT: media: qcom: iris: don't use function indirection in gen2-specific code
FROMGIT: media: qcom: iris: use common set_preset_registers function
FROMGIT: media: qcom: iris: drop pas_id from the iris_platform_data struct
FROMGIT: media: iris: drop remnants of UBWC configuration
FROMGIT: media: iris: don't specify max_channels in the source code
FROMGIT: media: iris: don't specify bank_spreading in the source code
FROMGIT: media: iris: don't specify ubwc_swizzle in the source code
FROMGIT: media: iris: don't specify highest_bank_bit in the source code
FROMGIT: media: iris: don't specify min_acc_length in the source code
FROMGIT: media: iris: retrieve UBWC platform configuration
FROMGIT: soc: qcom: ubwc: add helpers to get programmable values
FROMGIT: soc: qcom: ubwc: add helper to get min_acc length
FROMLIST: dt-bindings: arm: ras: Introduce bindings for ARM AEST
FROMLIST: ras: aest: Add panic_on_ue module parameter
FROMLIST: ras: aest: Skip unimplemented records in debugfs
FROMLIST: ras: aest: Fix CE/UE error counts not incrementing in debugfs
FROMLIST: ras: aest: Fix shared processor node handling and error log messages
FROMLIST: trace, ras: add ARM RAS extension trace event
FROMLIST: ras: AEST: support vendor node CMN700
FROMLIST: ras: AEST: Add framework to process AEST vendor node
FROMLIST: ras: AEST: Introduce AEST inject interface to test AEST driver
FROMLIST: ras: AEST: Allow configuring CE threshold via debugfs
FROMLIST: ras: AEST: Add error count tracking and debugfs interface
FROMLIST: ras: AEST: Introduce AEST driver sysfs interface
FROMLIST: ras: AEST: Add cpuhp callback
FROMLIST: ras: AEST: Enable and register IRQs
FROMLIST: ras: AEST: Support CE threshold of error record
FROMLIST: ras: AEST: Support RAS Common Fault Injection Model Extension
FROMLIST: ras: AEST: Probe RAS system architecture version
FROMLIST: ras: AEST: Unify the read/write interface for system and MMIO register
FROMLIST: ras: AEST: support different group format
FROMLIST: ras: AEST: Add probe/remove for AEST driver
FROMLIST: ACPI/AEST: Parse the AEST table