### PR TITLE
linux-qcom-next: update to tag qcom-next-7.1-rc6-20260609

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -10,12 +10,12 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "7.0+7.1-rc5"
+LINUX_VERSION ?= "7.0+7.1-rc6"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.1-rc5-20260603
-SRCREV ?= "8b79525f5fd0f6893b67ea128db176132eafbabc"
+# tag: qcom-next-7.1-rc6-20260609
+SRCREV ?= "f74a35752ee9fde35f8980d2635660334bff6446"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.1-rc6-20260609, which corresponds to kernel version v7.1-rc6