### PR TITLE
ci: pin kas-container to 5.3 and pull image from internal ECR mirror

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -28,6 +28,11 @@ concurrency:
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
+  # Internal mirror of ghcr.io/siemens/kas/kas, only reachable from the
+  # self-hosted runners. Keep the image tag in sync with KAS_VERSION
+  # (kas-container script version) and with compile.yml.
+  KAS_VERSION: "5.3"
+  KAS_CONTAINER_IMAGE: 418295714268.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/kas-image:5.3
 
 jobs:
   kas-setup:
@@ -38,8 +43,7 @@ jobs:
         run: |
           KAS_CONTAINER=$RUNNER_TEMP/kas-container
           echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
-          LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
-          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
+          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/${KAS_VERSION}/kas-container
           chmod +x ${KAS_CONTAINER}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,6 +26,10 @@ on:
 
 env:
   KAS_CLONE_DEPTH: 1
+  # Internal mirror of ghcr.io/siemens/kas/kas, only reachable from the
+  # self-hosted runners. Keep the image tag in sync with KAS_VERSION in
+  # build-yocto.yml (env does not propagate across workflow_call).
+  KAS_CONTAINER_IMAGE: 418295714268.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/kas-image:5.3
 
 jobs:
   reusable_compile_job:


### PR DESCRIPTION
Fetch the kas-container script from the pinned 5.3 tag instead of the latest siemens/kas tag, and set KAS_CONTAINER_IMAGE so all kas jobs pull the container image from the internal ECR mirror at 418295714268.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/kas-image:5.3.

All kas-container invocations run on the self-hosted runners, which are the only hosts with access to the mirror, so no GitHub-hosted job is affected. Pinning the script to the same version as the image avoids script/image skew when a new kas version is tagged upstream. The env var is set in both build-yocto.yml and compile.yml because env blocks do not propagate across workflow_call.