### PR TITLE
Add m2connector capability and introduce shared M.2 wireless firmware packagegroup

### DIFF
--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES += "efi kvm pci tpm2 phone"
+MACHINE_FEATURES += "efi kvm m2connector pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/lemans-evk.dtb \

--- a/conf/machine/qcs615-ride.conf
+++ b/conf/machine/qcs615-ride.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs615.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi m2connector pci"
 
 QCOM_DTB_DEFAULT ?= "qcs615-ride"
 

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/qcom-qcs6490.inc
 
 # NOTE: TPM hardware is only present on rb3gen2-industrial kit
-MACHINE_FEATURES += "efi pci tpm2 phone"
+MACHINE_FEATURES += "efi m2connector pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \

--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
+
+inherit packagegroup
+
+QCOM_M2_WIFI_FIRMWARE = " \
+    linux-firmware-ath12k-qcc2072 \
+    linux-firmware-ath12k-qcn9274 \
+    linux-firmware-ath12k-wcn7850 \
+"
+
+QCOM_M2_BT_FIRMWARE = " \
+    linux-firmware-qca-qcc2072 \
+    linux-firmware-qca-wcn7850 \
+"
+
+RRECOMMENDS:${PN} = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', '${QCOM_M2_WIFI_FIRMWARE}', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', '${QCOM_M2_BT_FIRMWARE}', '', d)} \
+"


### PR DESCRIPTION
This series introduces a machine capability flag for external M.2 wireless attachments and adds a shared firmware packagegroup for those attachments.

1. rb3gen2-core-kit: enable m2connector in MACHINE_FEATURES
2. qcs615-ride: enable m2connector in MACHINE_FEATURES
3. iq-9075-evk: enable m2connector in MACHINE_FEATURES
4. Add packagegroup-qcom-m2-firmware with M.2 attachment firmware:
    - WiFi: linux-firmware-ath12k-qcc2072, linux-firmware-ath12k-qcn9274, linux-firmware-ath12k-wcn7850
    - Bluetooth: linux-firmware-qca-qcc2072, linux-firmware-qca-wcn7850

qcn9274 is AP-only and has no Bluetooth support, so no BT firmware is included for qcn9274.