### PR TITLE
u-boot-qcom: bump SRCREV to 5a77d467 (GENI I2C NACK fix)

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.04+2026.07-rc2+git"
 
-SRCREV = "41744cd6a4da3fd0054fad8e7c6e8d8d5bd20c33"
+SRCREV = "5a77d4670d8084ada24a2735dda75788ed5ce925"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Update SRCREV to pick up GENI I2C change that resets the controller on NACK, improving probe reliability under repeated NACK conditions and avoiding invalid bus states.