### PR TITLE
[Backport wrynose] os-release: record GitHub build/run id in BUILD_ID

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -63,16 +63,29 @@ jobs:
           echo "DL_DIR=${INPUTS_CACHE_DIR}/downloads" >> $GITHUB_ENV
           echo "SSTATE_DIR=${INPUTS_CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
           echo "KAS_WORK_DIR=${PWD}/../kas" >> $GITHUB_ENV
-          echo "KAS_YAMLS=ci/ci.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}" >> $GITHUB_ENV
+          echo "KAS_YAMLS=ci/ci.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}:ci/build-id.yml" >> $GITHUB_ENV
           echo "INPUTS_CACHE_DIR=${INPUTS_CACHE_DIR}" >> $GITHUB_ENV
           echo "INPUTS_MACHINE=${INPUTS_MACHINE}" >> $GITHUB_ENV
           echo "INPUTS_DISTRO_YAML=${INPUTS_DISTRO_YAML}" >> $GITHUB_ENV
           echo "INPUTS_KERNEL_YAML=${INPUTS_KERNEL_YAML}" >> $GITHUB_ENV
+          # kas-container does not forward arbitrary env vars into the
+          # container, so bake the CI run id into a kas fragment inside the
+          # mounted checkout. This overrides the local default set in
+          # ci/base.yml so the image's /etc/os-release maps back to the run
+          # (and to the S3 artifact folder named ${run_id}-${run_attempt}).
+          cat > ci/build-id.yml <<EOF
+          header:
+            version: 14
+          local_conf_header:
+            build-id: |
+              BUILD_ID = "${BUILD_ID}"
+          EOF
         env:
           INPUTS_CACHE_DIR: ${{inputs.cache_dir}}
           INPUTS_MACHINE: ${{ inputs.machine }}
           INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
           INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
+          BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Dump kas-build yaml
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib/qcom/__pycache__/
+ci/build-id.yml

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -56,6 +56,14 @@ local_conf_header:
     EXTRA_IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
     WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
+  os-release: |
+    # Record a build identifier in /etc/os-release. Defaults to a clearly
+    # marked local value; CI overrides BUILD_ID with the run id via the
+    # generated ci/build-id.yml fragment (see .github/workflows/compile.yml).
+    # Use a weak assignment so the CI override wins regardless of how kas
+    # orders the merged local.conf fragments.
+    OS_RELEASE_FIELDS:append = " BUILD_ID"
+    BUILD_ID ?= "local-${DATETIME}"
 
 machine: unset
 


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2408.