### PR TITLE
ci: base.lock: update oe-core layer to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 31edc0b82a3dc7b1dd0338da4a8d0d8f5a1dc138
+            commit: 13cb97f6279e71320f6454fd5b89c3845b826c49
         bitbake:
             commit: 797b0a348d7426d03459e577feacd3488fdeee47
         meta-arm:


### PR DESCRIPTION
Update oe-core layer to the latest available SHA.

Changes in oe-core:
- b5c24e1491 python3: reference upstream ticket in a test skip
- 1e31746fdc libedit: upgrade 20251016 -> 20260512
- 79584fe7e7 uboot-sign: sign SPL FIT into a copy of the SPL DTB
- e46d8473fb oeqa/selftest/fitimage: fix missing whitespace around assignment
- c3097962ac rootfs: move tasks using image_list_installed_packages to postuninstall
- 311d418d22 vex: remove obsolete semicolon
- f143e23e2e bluez5: Fix sending extra bytes with MGMT_OP_ADD_EXT_ADV_DATA
- 47dd71b052 cmake: upgrade 4.3.2 -> 4.3.3
- b9b3b3098e go: upgrade 1.26.3 -> 1.26.4
- 8d47d68cd9 xev: upgrade 1.2.6 -> 1.2.7
- 870f55a651 python3-pyelftools: upgrade 0.32 -> 0.33
- 2a739de475 libxi: upgrade 1.8.2 -> 1.8.3
- d438d0aef1 gettext: Add missing xz-native DEPENDS for reproducibility
- d1930f82e6 base: Allow zstd and xz decompression from the host tools
- f9b8ca28d1 sysstat: Add missing xz-native DEPENDS
- 5babf4e57c python3-qemu-qmp: add a recipe
- 81bbe42edb insane.bbclass: check for build host HOME directory in packaged files
- beb245ef60 python3: sanitize userbase in _sysconfig_vars JSON to avoid host path leak
- 5fd7e3cb11 subversion: fix svn-revision.txt conflict when building for qemux86-64
- eeea0396b6 gawk: add Signed-off-by to randtest backport
- 1e86aa0391 devtool/upgrade.py: add --stable option
- a1e069d04c upstream-stable-release-point.bbclass: add bbclass for stable point upgrade
- fa302de94c pseudo: Update to version 1.9.8
- d21039cd14 nopackages: remove do_package_write_tar deltask
- 24f644c5bd documentation.conf: remove do_package_write_tar doc
- 24eb81273c package_manager: remove [True, False] list eval
- 89d1fa86aa package_manager: rootfs: remove install_order
- 77b6fe8999 package_manager: sdk: remove install_order
- 492e9df5b7 curl: upgrade 8.19.0 -> 8.20.0
- c6ba523565 curl: fix mbedtls detection
- a07e06cdb4 clang/llvm: Upgrade to 22.1.7 release
- b23ee2d0c1 rust: Upgrade 1.95.0 -> 1.96.0
- 358e62a808 avahi: upgrade 0.8 -> 0.9-rc4
- 5f5e8ba595 vim: upgrade 9.2.0340 -> 9.2.0569
- e4779ee254 gcc: Upgrade GCC to 16.1 release
- be009835e7 linux-yocto/6.18: update to v6.18.33
- 6bad64218b linux-yocto-dev: bump to v7.1
- a64b4f3972 staging.bbclass: Correct a typo