### PR TITLE
ci: base.lock: update meta-audioreach layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -13,7 +13,7 @@ overrides:
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: 263007cb243b9b6bf0b85619fa0daf7eeb9eca38
+            commit: 6ae81980821608396386ca74c549e27f459ab6bc
         meta-selinux:
             commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:


### PR DESCRIPTION
Relevant change:
6ae8198 Merge pull request https://github.com/AudioReach/meta-audioreach/pull/112
6725f8f audioreach-graphservices: enable libdiag for QACT on qcom targets
d06a506 Merge pull request https://github.com/AudioReach/meta-audioreach/pull/140
8d54701 Switch default builds to qcom-multimedia-proprietary-image
6a55352 Merge pull request https://github.com/AudioReach/meta-audioreach/pull/138
55af477 audioreach-pal: srcrev bump 4a13cc4...2fa9b82