### PR TITLE
iq-615-evk: Add QPS615 PCIe Ethernet daughter card support

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -146,7 +146,7 @@ FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
     "talos-evk talos-evk-camera-imx577 talos-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
+    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging talos-evk-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
     "talos-evk talos-evk-camx talos-staging"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -24,6 +24,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-615-evk-firmware \
     packagegroup-iq-615-evk-hexagon-dsp-binaries \
     qairt-sdk-hexagon-v66 \
+    qps615-dlkm \
 "
 
 QCOM_BOOT_FILES_SUBDIR = "qcs615"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -17,6 +17,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk-camx.dtbo \
                       qcom/talos-el2.dtbo \
                       qcom/talos-staging.dtbo \
+                      qcom/talos-evk-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/recipes-kernel/linux/linux-qcom-next/0001-PENDING-arm64-dts-qcom-talos-evk-add-QPS615-m.2-ethe.patch
+++ b/recipes-kernel/linux/linux-qcom-next/0001-PENDING-arm64-dts-qcom-talos-evk-add-QPS615-m.2-ethe.patch
@@ -1,0 +1,145 @@
+From a1425ca50ee852d6dee098e78fac42016b46bcf5 Mon Sep 17 00:00:00 2001
+From: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
+Date: Sun, 3 May 2026 20:39:51 +0530
+Subject: [PATCH] PENDING: arm64: dts: qcom: talos-evk: add QPS615 m.2 ethernet
+ staging overlay
+
+Add talos-evk-staging.dtso for the QPS615 m.2 e-key daughter card.
+When installed, the QPS615 PCIe switch replaces the direct WCN7850 WLAN
+connection at pcie_port0. The overlay:
+
+  - Enables PCIe with IOMMU mappings (required by QPS615 DMA traffic)
+  - Disables the direct WCN7850 WLAN at pcie_port0 (wifi@0)
+  - Moves WLAN to QPS615 downstream port 1 (pcie@1,0, bus 3 dev 0)
+  - Describes dual Ethernet (TC956X) at QPS615 downstream port 3
+    (pci@3,0, bus 5 dev 0 fn0/fn1)
+
+Upstream-Status: Submitted [https://github.com/qualcomm-linux/kernel-topics/pull/1314]
+Signed-off-by: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>
+---
+ arch/arm64/boot/dts/qcom/Makefile             |  2 +
+ .../boot/dts/qcom/talos-evk-staging.dtso      | 99 +++++++++++++++++++
+ 2 files changed, 101 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/qcom/talos-evk-staging.dtso
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index ecb2116d12a6..30cb8bc8c0a9 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -572,6 +572,8 @@ dtb-$(CONFIG_ARCH_QCOM)	+= talos-evk-camx.dtbo
+ 
+ dtb-$(CONFIG_ARCH_QCOM) += talos-staging.dtbo
+ 
++dtb-$(CONFIG_ARCH_QCOM) += talos-evk-staging.dtbo
++
+ dtb-$(CONFIG_ARCH_QCOM) += kodiak-staging.dtbo
+ 
+ dtb-$(CONFIG_ARCH_QCOM) += glymur-staging.dtbo
+diff --git a/arch/arm64/boot/dts/qcom/talos-evk-staging.dtso b/arch/arm64/boot/dts/qcom/talos-evk-staging.dtso
+new file mode 100644
+index 000000000000..ec1f40853ccd
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/talos-evk-staging.dtso
+@@ -0,0 +1,99 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++
++&pcie {
++	iommu-map = <0x0 &apps_smmu 0x400 0x1>,
++		    <0x100 &apps_smmu 0x401 0x1>,
++		    <0x208 &apps_smmu 0x402 0x1>,
++		    <0x210 &apps_smmu 0x403 0x1>,
++		    <0x218 &apps_smmu 0x404 0x1>,
++		    <0x300 &apps_smmu 0x405 0x1>,
++		    <0x400 &apps_smmu 0x406 0x1>,
++		    <0x500 &apps_smmu 0x407 0x1>,
++		    <0x501 &apps_smmu 0x408 0x1>;
++
++	status = "okay";
++};
++
++/*
++ * With QPS615 installed, the m.2 E-key slot is occupied by the QPS615
++ * PCIe switch (pci1179,0623) rather than the direct WCN7850 WLAN chip.
++ *
++ * QPS615 downstream port layout:
++ *   pcie@1,0 (bus 3) — WCN7850 WLAN, moved here from the direct connection
++ *   pcie@2,0 (bus 4) — free downstream port
++ *   pci@3,0  (bus 5) — TC956X dual Ethernet (QPS615 GPIO-reset PHYs)
++ */
++&pcie_port0 {
++	wifi@0 {
++		status = "disabled";
++
++		pcie@1,0 {
++			reg = <0x20800 0x0 0x0 0x0 0x0>;
++			#address-cells = <3>;
++			#size-cells = <2>;
++			device_type = "pci";
++			ranges;
++			bus-range = <0x3 0x3>;
++
++			wifi@0,0 {
++				compatible = "pci17cb,1103";
++				reg = <0x30000 0x0 0x0 0x0 0x0>;
++
++				qcom,calibration-variant = "QC_QCS615_Ride";
++
++				vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++				vddaon-supply = <&vreg_pmu_aon_0p59>;
++				vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++				vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++				vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++				vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++				vddrfa1p8-supply = <&vreg_pmu_rfa_1p7>;
++				vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
++				vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
++			};
++		};
++
++		pci@3,0 {
++			reg = <0x21800 0x0 0x0 0x0 0x0>;
++			#address-cells = <3>;
++			#size-cells = <2>;
++			device_type = "pci";
++			ranges;
++			bus-range = <0x5 0xff>;
++			compatible = "pci1179,0623";
++
++			qps615: pci@0,0 {
++				reg = <0x50000 0x0 0x0 0x0 0x0>;
++				#address-cells = <3>;
++				#size-cells = <2>;
++				device_type = "pci";
++				ranges;
++
++				gpio-controller;
++				#gpio-cells = <2>;
++
++				phy-reset-gpios = <&qps615 0 GPIO_ACTIVE_LOW>;
++				reset-deassert-us = <221000>;
++			};
++
++			pci@0,1 {
++				reg = <0x50100 0x0 0x0 0x0 0x0>;
++				#address-cells = <3>;
++				#size-cells = <2>;
++				device_type = "pci";
++				ranges;
++
++				phy-reset-gpios = <&qps615 1 GPIO_ACTIVE_LOW>;
++				reset-deassert-us = <20000>;
++			};
++		};
++	};
++};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -25,6 +25,7 @@ SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=http
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://0001-PENDING-arm64-dts-qcom-talos-evk-add-QPS615-m.2-ethe.patch \
 "
 
 # To build tip of qcom-next branch set preferred


### PR DESCRIPTION
The IQ 615 EVK has an optional daughter card that connects a QPS615 PCIe Ethernet bridge chip via the m.2 e-key slot. When installed, the QPS615 replaces the direct WLAN connection at pcie_port0 and requires dedicated platform resources for PHY management.

This series wires up the three Yocto/OE pieces needed to enable this configuration:

 - fit-dtb-compatible: Register talos-evk-staging as a valid overlay in FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] so the bootloader can select the right DTBO for this hardware variant.
 - LINUX_QCOM_KERNEL_DEVICETREE: Include qcom/talos-evk-staging.dtbo in the IQ 615 EVK machine definition so the overlay is built and packaged with the kernel image.
 - MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS: Add qps615-dlkm to ensure the out-of-tree QPS615 Ethernet driver is installed by default on this platform.

The overlay is only activated when the relevant FIT image is selected at boot.

This PR depends on the dtso being available in linux-qcom-next and linux-qcom-6.18 kernels.
1. linux-qcom-6.18 already has the dependent commit.
2. linux-qcom-next's dependent change is submitted and pending merge. **Till then, this PR introduces the same change as a temporary patch to the linux-qcom-next recipe (https://github.com/qualcomm-linux/kernel-topics/pull/1314).**