### PR TITLE
iq-615-evk: Add QPS615 PCIe Ethernet daughter card support

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -137,7 +137,7 @@ FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
     "talos-evk talos-evk-camera-imx577 talos-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging"
+    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging talos-evk-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
     "talos-evk talos-evk-camx talos-staging"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -24,6 +24,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-iq-615-evk-firmware \
     packagegroup-iq-615-evk-hexagon-dsp-binaries \
     qairt-sdk-hexagon-v66 \
+    qps615-dlkm \
 "
 
 QCOM_BOOT_FILES_SUBDIR = "qcs615"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -17,6 +17,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk-camx.dtbo \
                       qcom/talos-el2.dtbo \
                       qcom/talos-staging.dtbo \
+                      qcom/talos-evk-staging.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
From master branch (https://github.com/qualcomm-linux/meta-qcom/pull/2433)

The IQ 615 EVK has an optional daughter card that connects a QPS615 PCIe Ethernet bridge chip via the m.2 e-key slot. When installed, the QPS615 replaces the direct WLAN connection at pcie_port0 and requires dedicated platform resources for PHY management.

This series wires up the three Yocto/OE pieces needed to enable this configuration:

 - fit-dtb-compatible: Register talos-evk-staging as a valid overlay in FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] so the bootloader can select the right DTBO for this hardware variant.
 - LINUX_QCOM_KERNEL_DEVICETREE: Include qcom/talos-evk-staging.dtbo in the IQ 615 EVK machine definition so the overlay is built and packaged with the kernel image.
 - MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS: Add qps615-dlkm to ensure the out-of-tree QPS615 Ethernet driver is installed by default on this platform.
The overlay is only activated when the relevant FIT image is selected at boot.

This PR depends on the qcom-6.18.y Kernel having the talos-evk-staging.dtso.