### PR TITLE
ci/performance.yml: rename cmdline unit to cmdline-perf

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -2,5 +2,5 @@ header:
   version: 14
 
 local_conf_header:
-  cmdline: |
+  cmdline-perf: |
     KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"


### PR DESCRIPTION
The local_conf_header key "cmdline" in performance.yml shadowed the "cmdline" unit in base.yml, dropping the
qcom_scm.download_mode=1 parameter from perf builds. Rename it to "cmdline-perf" so both units are preserved and
KERNEL_CMDLINE_EXTRA is not overwritten.