### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260611 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260609
-SRCREV ?= "997c1ece634c8c755c970af6895dba3a6c5e204a"
+# tag:qcom-6.18.y-20260611
+SRCREV ?= "d58ad5c480fa06f04fff90d42ad0367ea093bc7f"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260611

Changelog:
FROMLIST: misc: fastrpc: Add polling mode support for fastRPC driver
FROMLIST: misc: fastrpc: Expand context ID mask for DSP polling mode support
FROMLIST: misc: fastrpc: Replace hardcoded ctxid mask with GENMASK
FROMLIST: misc: fastrpc: Move fdlist to invoke context structure
Revert "FROMLIST: misc: fastrpc: Move fdlist to invoke context structure"
Revert "FROMLIST: misc: fastrpc: Add polling mode support for fastRPC driver"
QCLINUX: arm64: configs: qcom.config: Enable LZ4 backend for zram
FROMLIST: drm/panel: add Ilitek ILI7807S panel driver
FROMLIST: dt-bindings: display: panel: add Ilitek ILI7807S panel controller
FROMLIST: arm64: dts: qcom: talos-evk: fix sdhc_2 vqmmc-supply for UHS-I mode
PENDING: arm64: dts: qcom: lemans: Add TSC node in staging dtso
PENDING: arm64: configs: Enable Qualcomm TSCSS driver support
PENDING: ptp: Add support for Qualcomm TSCSS hardware
PENDING: dt-bindings: ptp: Add support for Qualcomm TSCSS module
FROMLIST: rpmsg: glink: Make glink smem interrupt wakeup capable
FROMLIST: soc: qcom: ubwc: Add Shikra UBWC config
FROMLIST: dt-bindings: display: msm: qcm2290: Add Shikra MDSS
FROMLIST: drm/msm/dp: Introduce poll_hpd_irq callback for MST sideband handling
FROMLIST: drm/msm/dp: add HPD callback for dp MST
FROMLIST: drm/msm/dp: add connector abstraction for DP MST
FROMLIST: drm/msm/dp: add dp_mst_drm to manage DP MST bridge operations
Revert "FROMLIST: drm/msm/dp: add dp_mst_drm to manage DP MST bridge operations"
Revert "FROMLIST: drm/msm/dp: add connector abstraction for DP MST"
Revert "FROMLIST: drm/msm/dp: add HPD callback for dp MST"
QCLINUX: arm64: dts: qcom: add IFE Lite CPAS paths to purwa camera dtsi
PENDING: arm64: dts: qcom: glymur: add TGU and ETR in staging dtso
PENDING: arm64: dts: qcom: hamoa: add TGU in staging dtso
FROMLIST: arm64: dts: qcom: shikra-iqs-evk-imx577-camera: Add DT overlay
FROMLIST: arm64: dts: qcom: shikra-cqm-evk-imx577-camera: Add DT overlay
FROMLIST: arm64: dts: qcom: shikra: Add pin configuration for mclks
FROMLIST: arm64: dts: qcom: shikra: Add CCI definitions
FROMLIST: arm64: dts: qcom: shikra: Add CAMSS node
FROMLIST: media: qcom: camss: add support for QCM2390 camss
FROMLIST: dt-bindings: i2c: qcom-cci: Document Shikra compatible
FROMLIST: dt-bindings: media: qcom: Add Shikra CAMSS compatible
FROMLIST: arm64: dts: qcom: Add GP M/N clock controller node for SA8775P and QCS8300
FROMLIST: arm64: dts: qcom: Add gp_mn pin state for GP M/N clock output
FROMLIST: pinctrl: qcom: Add gp_mn mux function for QCS8300, SA8775P and SC7280
FROMLIST: clk: qcom: Add a driver for PDM GP_MN fractional clock divider
QCLINUX: arm64: dts: qcom: monaco-evk: disable unused camera regulators
FROMLIST: arm64: dts: qcom: shikra: Add support for AudioCoreCC node
FROMLIST: clk: qcom: Add Audio Core clock controller support on Qualcomm Shikra SoC
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra Audio Core Clock Controller
FROMLIST: clk: qcom: common: Register reset controller only when resets are present
FROMLIST: clk: qcom: gcc-shikra: Add USB3 DP PHY reset and LPASS clocks
FROMLIST: dt-bindings: clock: qcom: Add the definition for the USB3 DP PHY reset
FROMLIST: misc: fastrpc: Add cache maintenance for non-coherent platforms
PENDING: arm64: dts: qcom: talos-evk: add QPS615 m.2 ethernet staging overlay
FROMLIST: drm/msm/a6xx: Fix stale rpmh votes after suspend
FROMLIST: dt-bindings: clock: qcom: Add bindings for PDM GP_MN clock divider
FROMLIST: arm64: dts: qcom: shikra: Add support for DISPCC/GPUCC nodes
FROMLIST: arm64: dts: qcom: agatti: Add DSI1 PHY and sleep clocks to DISPCC node
FROMLIST: clk: qcom: Add support for Qualcomm GPU Clock Controller on Shikra
FROMLIST: clk: qcom: gpucc-qcm2290: Update GDSC *wait_val values and flags
FROMLIST: clk: qcom: gpucc-qcm2290: Park RCG's clk source at XO during disable
FROMLIST: clk: qcom: gpucc-qcm2290: Move to the latest common qcom_cc_probe() model
FROMLIST: clk: qcom: dispcc-qcm2290: Update GDSC *wait_val values and flags
FROMLIST: clk: qcom: dispcc-qcm2290: Switch to DT index based clk lookup
FROMLIST: clk: qcom: dispcc-qcm2290: Move to the latest common qcom_cc_probe() model
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra GPU clock controller
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra Display clock controller
FROMLIST: dt-bindings: clock: qcom,qcm2290-dispcc: Add DSI1 PHY and sleep clocks
FROMLIST: clk: qcom: gcc-qcm2290: Keep the critical clocks always-on from probe
clk: qcom: Revert older series Shikra GPUCC/DISPCC changes
FROMLIST: PCI: qcom: Add D3cold support
FROMLIST: PCI: dwc: Use common D3cold eligibility helper in suspend path
FROMLIST: PCI: qcom: Power down PHY via PARF_PHY_CTRL before disabling rails/clocks
FROMLIST: PCI: qcom: Add .get_ltssm() helper
FROMLIST: PCI: host-common: Add helper to determine host bridge D3cold eligibility
FROMLIST: PCI: dwc: Fail dw_pcie_host_init() if dw_pcie_wait_for_link() returns -ETIMEDOUT
FROMLIST: PCI: dwc: Rework the error print of dw_pcie_wait_for_link()
FROMLIST: PCI: dwc: Rename and move ltssm_status_string() to pcie-designware.c
FROMLIST: PCI: dwc: Return -EIO from dw_pcie_wait_for_link() if device is not active
FROMLIST: PCI: dwc: Return -ENODEV from dw_pcie_wait_for_link() if device is not found
QCLINUX: arm64: dts: qcom: Fix GPIO free and acquire logic
