### PR TITLE
ci/qcom-distro.yml: Enable meta-ai layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -22,3 +22,5 @@ overrides:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
             commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257
+        meta-ai:
+            commit: 23558d82906f6babdcf8e4575e51575e2dcac0bf

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -29,6 +29,10 @@ repos:
       meta-python:
       meta-xfce:
 
+  meta-ai:
+    url: https://github.com/qualcomm-linux/meta-ai
+    branch: main
+
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
 


### PR DESCRIPTION
Currently there is no support for building AI/ML inference runtimes in the CI configuration.

Add meta-ai, which is a standalone layer that hosts AI/ML recipes like onnx, onnxruntime, llama and tflite, to the CI configuration and pin it to a specific commit in base.lock.yml for reproducible builds.