### PR TITLE
camera-service: upgrade 0.1.1 -> 1.0.2

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.2.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/qualcomm/camera-service"
 
 SRC_URI = "git://github.com/qualcomm/camera-service;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "da1e17853fd675fed85984ecf19e22708a05a825"
+SRCREV = "666344262e69a6c2c5e1df9e9e52b3e74c2f4a33"
 
 # Limit this recipe to ARMv8 (aarch64) only, because it depends
 # on camxcommon-headers which is explicitly restricted to ARMv8 (aarch64).


### PR DESCRIPTION
Upgrade camera-service recipes tag from 0.1.1 to 1.0.1

Highlights:
- Fix duplicate client ID issue
- support for offline camera
- Fix out-of-bound ion_meta_fd access
- Expose camera feature capabilities via API
- Improve cam_server runtime directory handling
- Set OCL_ICD_FILENAMES via environment variable
- Remove compile-time dependency for system section count, avoiding the need to rebuild qmmf camera metadata library for different metadata configurations

Changes in 1.0.2:
- Reverted OCL_ICD_FILENAMES handling
- Removed support for offline jpeg encode feature due to chiofflinepostproclib library missing from CAMX.