### PR TITLE
workflows/compile: fix deploy_dir artifacts for publishing

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Stage build artifacts for publishing
         shell: bash
         run: |
+          set -x
           # The upload-private-artifact-action runs from a container that
           # expects file to be relative to our PWD. deploy_dir is outside
           # that, so we move things around:
@@ -173,14 +174,14 @@ jobs:
           mkdir -p $uploads_dir
           if [ -d $deploy_dir ]; then
             # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
-            find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
+            find $deploy_dir/ -maxdepth 1 -type l -exec cp -v --dereference {} $uploads_dir/ \;
             # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
             # Copy *.efi, *.efi and *.vfat as they are useful for debugging
-            find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
+            find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp -v {} $uploads_dir/ \;
           fi
-          cp buildstats* kas-build.yml $uploads_dir/
+          cp -v buildstats* kas-build.yml $uploads_dir/
           if [ -d $deploy_dir/../../sdk ]; then
-            cp $deploy_dir/../../sdk/* $uploads_dir/
+            cp -v $deploy_dir/../../sdk/* $uploads_dir/
           fi
         env:
           INPUTS_MACHINE: ${{ inputs.machine }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -169,19 +169,21 @@ jobs:
           # The upload-private-artifact-action runs from a container that
           # expects file to be relative to our PWD. deploy_dir is outside
           # that, so we move things around:
-          deploy_dir=../kas/build/tmp/deploy/images/${INPUTS_MACHINE}
+          deploy_dir=../kas/build/tmp/deploy
+          images_dir=$deploy_dir/images/${INPUTS_MACHINE}
+          sdk_dir=$deploy_dir/sdk
           uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
           mkdir -p $uploads_dir
-          if [ -d $deploy_dir ]; then
+          if [ -d $images_dir ]; then
             # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
-            find $deploy_dir/ -maxdepth 1 -type l -exec cp -v --dereference {} $uploads_dir/ \;
+            find $images_dir/ -maxdepth 1 -type l -exec cp -v --dereference {} $uploads_dir/ \;
             # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
             # Copy *.efi, *.efi and *.vfat as they are useful for debugging
-            find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp -v {} $uploads_dir/ \;
+            find $images_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp -v {} $uploads_dir/ \;
           fi
           cp -v buildstats* kas-build.yml $uploads_dir/
-          if [ -d $deploy_dir/../../sdk ]; then
-            cp -v $deploy_dir/../../sdk/* $uploads_dir/
+          if [ -d $sdk_dir ]; then
+            cp -v $sdk_dir/* $uploads_dir/
           fi
         env:
           INPUTS_MACHINE: ${{ inputs.machine }}


### PR DESCRIPTION
To improve debug of the staging artifacts step:
- trace bash commands
- run cp with verbose

The (sdk_dir) path depends on component (deploy_dir) path, and
therefore it doesn't exist when the (deploy_dir) also doesn't exist.
However, this isn't true because the (sdk_dir) can exist even when the
(deploy_dir) path doesn't exist.

Set (deploy_dir) to the real bitbake deploy and add a new (images_dirs)
and (sdk_dir) and these without dependencies on each other.

Partially fix https://github.com/qualcomm-linux/meta-qcom/issues/1984