### PR TITLE
[Backport wrynose] linux-qcom-6.18 : update to tag qcom-6.18.y-20260615 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260611
-SRCREV ?= "d58ad5c480fa06f04fff90d42ad0367ea093bc7f"
+# tag:qcom-6.18.y-20260615
+SRCREV ?= "360986b713f88d182fb17fdf5decedf665a77834"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Backport https://github.com/qualcomm-linux/meta-qcom/pull/2462 to wrynose.