### PR TITLE
ci: drop redundant linux-qcom-6.18 kernel fragment

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -350,33 +350,33 @@ jobs:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit
             distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: iq-9075-evk
             distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: iq-615-evk
             distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit-open-fw
             distro:
                 name: qcom-distro-kvm

--- a/ci/linux-qcom-6.18.yml
+++ b/ci/linux-qcom-6.18.yml
@@ -1,7 +1,0 @@
-header:
-  version: 14
-
-local_conf_header:
-  kernelprovider: |
-    PREFERRED_PROVIDER_virtual/kernel = "linux-qcom"
-    PREFERRED_VERSION_virtual/kernel = "6.18%"


### PR DESCRIPTION
On the wrynose branch 6.18 is already the default linux-qcom kernel, so pinning PREFERRED_VERSION_virtual/kernel = "6.18%" via ci/linux-qcom-6.18.yml is redundant.

Remove the fragment and update the four u-boot-qcom build matrix entries in build-yocto.yml to compose only :ci/u-boot-qcom.yml, renaming the kernel type and dirname accordingly. The affected build/artifact names change from <machine>/qcom-distro_linux-qcom-6.18_u-boot-qcom to <machine>/qcom-distro_u-boot-qcom. The separate RT fragment ci/linux-qcom-rt-6.18.yml is left untouched.