### PR TITLE
workflows: track only master in push/pr/repolinter branch filters

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - master
-      - wrynose
     paths-ignore:
       - '**/*.md'
       - '.github/.markdownlint.yaml'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - wrynose
 
 permissions:
   checks: write

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -2,9 +2,9 @@ name: QuIC Organization Repolinter
 
 on:
   push:
-    branches: [ master, wrynose ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, wrynose ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
For push and pull_request events, GitHub runs the workflow file from the pushed branch (push) or the PR's base branch (pull_request). The master copies of these workflows therefore only ever evaluate for master, so the "wrynose" entry in their branch filters is unreachable dead config.

Drop it and list only master, matching what markdownlint.yml already does. The wrynose branch carries its own copies listing only wrynose.