### PR TITLE
[Backport wrynose] ci: base.lock: update meta-audioreach layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -15,7 +15,7 @@ overrides:
         meta-virtualization:
             commit: 959a211fbba059689a1c3a1b24fe0abb9224281a
         meta-audioreach:
-            commit: aeb4ca3af42ab593497647c8ed98807c18495b16
+            commit: 6ae81980821608396386ca74c549e27f459ab6bc
         meta-selinux:
             commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:


### PR DESCRIPTION
Backport of #2412 to wrynose