### PR TITLE
Add QCM6490-IDP specific firmware packagegroups

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -16,8 +16,8 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    packagegroup-rb3gen2-firmware \
-    packagegroup-rb3gen2-hexagon-dsp-binaries \
+    packagegroup-qcm6490-idp-firmware \
+    packagegroup-qcm6490-idp-hexagon-dsp-binaries \
     qairt-sdk-hexagon-v68 \
     qcom-fastcv-binaries-thundercomm-rb3gen2-dsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-qcm6490-idp.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcm6490-idp.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Packages for the QCM6490-IDP platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-qcm6490-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6750 linux-firmware-qcom-qcm6490-wifi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn6750', '', d)} \
+    camxfirmware-kodiak \
+    linux-firmware-lt9611uxc \
+    linux-firmware-qcom-qcm6490-audio \
+    linux-firmware-qcom-qcm6490-compute \
+    linux-firmware-qcom-qcm6490-ipa \
+    linux-firmware-qcom-qcm6490-qupv3fw \
+    linux-firmware-qcom-vpu \
+"
+
+RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-qcm6490-idp-adsp \
+    hexagon-dsp-binaries-qcom-qcm6490-idp-cdsp \
+"


### PR DESCRIPTION
For QCM6490-IDP stop using the shared packagegroup-rb3gen2 which lacks IPA firmware support. Define and use QCM6490-IDP specific firmware and Hexagon DSP packagegroups.