### PR TITLE
rpmsgexport: add recipe for rpmsgexport

### DIFF
--- a/recipes-support/rpmsg-export/rpmsgexport_git.bb
+++ b/recipes-support/rpmsg-export/rpmsgexport_git.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Qualcomm RPMSGEXPORT application"
+HOMEPAGE = "https://github.com/linux-msm/rpmsgexport.git"
+SECTION = "devel"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ff273e1fd41fa52668171e0817c89724"
+
+SRCREV = "ad7cc961b28a4b52b5178da9356c2f482a8d3e84"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
+
+inherit meson


### PR DESCRIPTION
Add a recipe for rpmsgexport [1], an upstream utility that creates rpmsg endpoint character devices by issuing RPMSG_CREATE_EPT_IOCTL on the rpmsg control device (/dev/rpmsg_ctrl*).

The recipe uses the meson build system, which properly inherits toolchain CFLAGS and LDFLAGS from the environment.

[1] https://github.com/linux-msm/rpmsgexport