### PR TITLE
iq-x7181-evk: iq-x5121-evk: declare TPM2 machine feature

### DIFF
--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-purwa.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci tpm2"
 
 KERNEL_DEVICETREE ?= " \
     qcom/purwa-iot-evk.dtb \

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-hamoa.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci tpm2"
 
 QCOM_DTB_DEFAULT ?= "hamoa-iot-evk"
 


### PR DESCRIPTION
These changes are necessary to provide the complete TPM stack and enable dTPM‑based features to function correctly on iq-x7181-evk & iq-x5121-evk targets.
dTPM: ST33HTPH2X32AHE4