### PR TITLE
recipes-connectivity: Update sigma-dut revision

### DIFF
--- a/recipes-connectivity/sigma-dut/sigma-dut_git.bb
+++ b/recipes-connectivity/sigma-dut/sigma-dut_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://README;md5=e877b35748195c6ab87bf2d1ebed9a89"
 SRC_URI = "git://github.com/qualcomm/sigma-dut.git;branch=master;protocol=https"
 
 PV = "1.11+git"
-SRCREV = "0f1913a10a122188984e1b18c0ff3aa0733df7ab"
+SRCREV = "89d3c0271c1000932475467c70f529b67157a386"
 
 DEPENDS = "libnl"
 


### PR DESCRIPTION
Include upstream sigma-dut commit 89d3c0271c10
("sta_scan: Handle FAIL-BUSY in get_wpa_ssid_bssid()").

During certification test cases, sigma-dut can issue a scan command while wpa_supplicant internal scan is ongoing and returns FAIL-BUSY. Instead of directly failing the testcase, wait for scan completion and retry the scan command once.