### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "c88627275da8d6280d959e3b58c8e39390aec0a5"
+SRCREV = "9fe48574e774207e11c495d5d323ecadff7ff805"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Shoudi Li (1):
    platforms/iq-x7181-evk: add persist partition for iq-x7181-evk

Vivek Puar (1):
    platforms/shikra-evk: fill keymint.mbn and tools.fv with zeros