### PR TITLE
qwes service: upgrade 1.0 -> 1.1

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/qwes/qwes_1.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/qwes/qwes_1.1.bb
@@ -6,10 +6,10 @@ the store and optionally load QcWES TA to provide these features."
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260409"
+PBT_BUILD_DATE = "260620"
 
-SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/sec-userspace.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qwes_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "2fc38e033aa32e59a1749017526d29e9ad71f38f168ff652383eb06a05be3985"
+SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/sec-userspace.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qwes_1.0_armv8a.tar.gz"
+SRC_URI[sha256sum] = "7bb20daa916e4b13e54948ab90af92e9c2e6129cc22da1a23b924adb3f0610d4"
 
 S = "${UNPACKDIR}"
 
@@ -22,16 +22,24 @@ DEPENDS += "curl minkipc qmi-framework glibc"
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
 
+PACKAGES += "${PN}-ta"
+
 SYSTEMD_SERVICE:${PN} = "qwesd.service"
 
 do_install() {
     install -d ${D}${bindir}
     install -d ${D}${systemd_system_unitdir}
     install -d ${D}${docdir}/${BPN}
+    install -d ${D}${nonarch_base_libdir}/qtee-tas
 
     # Install binaries
     install -m 0755 ${S}/usr/bin/* ${D}${bindir}/
     install -m 0644 ${S}/usr/lib/systemd/system/qwesd.service ${D}${systemd_system_unitdir}/qwesd.service
     install -m 0644 ${S}/usr/share/doc/${BPN}/NOTICE.txt ${D}${docdir}/${BPN}
     install -m 0644 ${S}/usr/share/doc/${BPN}/LICENSE.qcom-2 ${D}${docdir}/${BPN}
+    cp -R ${S}/lib/qtee-tas/* ${D}${nonarch_base_libdir}/qtee-tas/
 }
+
+FILES:${PN}-ta += "${nonarch_base_libdir}/qtee-tas"
+RDEPENDS:${PN} = "${PN}-ta"
+INSANE_SKIP:${PN}-ta += "arch"


### PR DESCRIPTION
The QWES daemon currently attempts to load the QWES TA from obsolete or legacy firmware locations. This change updates the TA loading logic to check for machine-specific paths under /lib/qtee-tas fo the TAs.
This ensures the daemon can correctly locate TA binaries.

Changes Made:
Updated QWES daemon TA search logic
Added support for machine-specific TA paths under /lib/qtee-tas
Upgraded the source tarball to include the latest path resolution changes