### PR TITLE
Revert "[Backport Wrynose] Disable FIT and pack dtb in UKI as temp workaround to enable lava test on IQ-X7181 EVK"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       devices_premerge: "iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-hamoa.inc
 
 MACHINE_FEATURES += "efi pci"
 
-QCOM_DTB_DEFAULT ?= "hamoa-iot-evk"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \
                       qcom/hamoa-iot-evk-camera-imx577.dtbo \

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -18,7 +18,6 @@ KERNEL_DEVICETREE = ""
 KERNEL_DEVICETREE:glymur-crd = "${QCOM_DTB_DEFAULT}.dtb"
 KERNEL_DEVICETREE:kaanapali-mtp = "${QCOM_DTB_DEFAULT}.dtb"
 KERNEL_DEVICETREE:sm8750-mtp = "${QCOM_DTB_DEFAULT}.dtb"
-KERNEL_DEVICETREE:iq-x7181-evk = "${QCOM_DTB_DEFAULT}.dtb"
 
 setup_efi_folder() {
     # Move EFI content from packages expecting /boot to be the ESP location


### PR DESCRIPTION
Reverts qualcomm-linux/meta-qcom#2451

Observed bootup issue from nightly build 605, the first nightly build after enable post merge lava test.