### PR TITLE
ci: add shikra-evk to qcom-distro boot test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk"
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "ed4ac266438d0d9be521a6bd5498c6816ba718c5"
+  LAVA_TEST_PLANS_REF: "1d5707eec220248e0b4e7a039c545aba4d3e3deb"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.06.21"
+  TESTKIT_REF: "testkit-2026.07.12"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
Enable boot testing for shikra-evk as first step of CI bring-up. Pre-merge tests excluded until boot is confirmed stable.

Dependency on:
- https://jira-dc4.qualcomm.com/jira/browse/OSTT-674 
-  device onboarding in LAVA pool
- https://github.com/qualcomm-linux/lava-test-plans/pull/69 merged as a part of [PR#73](https://github.com/qualcomm-linux/lava-test-plans/pull/73)

All dependencies have been resolve moving to ready state.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>