### PR TITLE
u-boot-qcom: enable EFI runtime variable store for efivar

### DIFF
--- a/recipes-bsp/u-boot/files/efi-rt-volatile-store.cfg
+++ b/recipes-bsp/u-boot/files/efi-rt-volatile-store.cfg
@@ -1,0 +1,10 @@
+# Allow SetVariable at runtime on U-Boot's in-RAM EFI variable store so the
+# OS can write EFI variables via efivarfs. With this enabled U-Boot also
+# advertises EFI_RT_SUPPORTED_SET_VARIABLE and exposes the RTStorageVolatile
+# and VarToFile variables, which userspace tools such as efivar use to persist
+# runtime changes back to the ubootefi.var store on the ESP across reboots.
+#
+# EFI_RT_VOLATILE_STORE depends on EFI_VARIABLE_FILE_STORE; select it
+# explicitly so the option is not silently dropped if that default changes.
+CONFIG_EFI_VARIABLE_FILE_STORE=y
+CONFIG_EFI_RT_VOLATILE_STORE=y

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -13,6 +13,7 @@ SRCBRANCH = "nobranch=1"
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"
 SRC_URI += " \
     file://disable-eficapsule-tool.cfg \
+    file://efi-rt-volatile-store.cfg \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'file://tfa-optee.cfg', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'kvm', 'file://gunyah-exit.cfg', '', d)} \
 "


### PR DESCRIPTION
Enable CONFIG_EFI_RT_VOLATILE_STORE so U-Boot supports SetVariable at runtime on its in-RAM EFI variable backend. With this U-Boot advertises EFI_RT_SUPPORTED_SET_VARIABLE in the RT properties table and creates the RTStorageVolatile and VarToFile EFI variables.

These variables are what userspace needs to persist runtime EFI variable changes: RTStorageVolatile names the variable store file relative to the ESP (ubootefi.var) and VarToFile holds the binary dump of the variables to write back. The efivar SetVariableRT backport in oe-core uses them to sync changes to the ESP so they survive reboots; without this option SetVariable at runtime returns EFI_UNSUPPORTED and efivar cannot work.

CONFIG_EFI_RT_VOLATILE_STORE depends on CONFIG_EFI_VARIABLE_FILE_STORE, so select that explicitly in the fragment to keep the option from being silently dropped should the dependency default ever change.