### PR TITLE
[wrynose] ci/base.lock: update meta-oe and meta-virt

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -11,9 +11,9 @@ overrides:
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
         meta-openembedded:
-            commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
+            commit: a43f0d532c399458cae44ce66f3799a220fbb497
         meta-virtualization:
-            commit: 959a211fbba059689a1c3a1b24fe0abb9224281a
+            commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
         meta-audioreach:
             commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
         meta-selinux:


### PR DESCRIPTION
Keep base layers aligned with 6.0.1.

Relevant changes for meta-openembedded:
- a43f0d532c README: update listed maintainer
- 34debec4d8 layer.conf: remove dead BBFILES_DYNAMIC entry for clang-layer
- 7d1f4b0940 kmscon: fix zlib cross-compiling errors
- 74c663dd4e nodejs: upgrade 22.22.2 -> 22.22.3
- a1ffc4960b imagemagick: upgrade 7.1.2-22 -> 7.1.2-23
- 0537a67fc8 pipewire: update 1.6.3 -> 1.6.5
- ed946592da dnsmasq: fix CVE-2026-5172
- b81fd0e23e dnsmasq: fix CVE-2026-4893
- be8d0f006a dnsmasq: fix CVE-2026-4892
- 81572e132c dnsmasq: fix CVE-2026-4891
- 82dc5548d5 lldpd: upgrade 1.0.21 -> 1.0.22
- c51bb39ebf postgresql: upgrade 17.8 -> 17.10
- 61931269ec uriparser: upgrade 1.0.1 -> 1.0.2
- 343e59e762 uriparser: upgrade 1.0.0 -> 1.0.1
- 915cca7078 bit7z: upgrade 4.0.11 -> 4.0.12
- f9eea94890 imagemagick: upgrade 7.1.2-21 -> 7.1.2-22
- 38c0ee7d23 swagger-ui: upgrade 5.32.5 -> 5.32.6
- d8cfc583c3 swagger-ui: upgrade 5.32.2 -> 5.32.5
- 815a038905 python3-django: upgrade 6.0.4 -> 6.0.5
- 9148bf8e3d python3-django: upgrade 5.2.13 -> 5.2.14
- be10315436 python3-huey: upgrade 3.0.0 -> 3.0.1
- 4dc835862b python3-typeguard: upgrade 4.5.1 -> 4.5.2
- eff6fc8cd9 python3-tzdata: upgrade 2026.1 -> 2026.2
- 0f94b8aa14 python3-inline-snapshot: upgrade 0.32.6 -> 0.32.7
- 009207f76f neatvnc: upgrade 0.9.5 -> 0.9.6
- ca24d4cbb3 localsearch: upgrade 3.11.0 -> 3.11.1
- 563d2c514f Update README.md example with new branch name.

Relevant changes for meta-virtualization:
- 781735b9 openvswitch: re-enable ptest
- 4b9ba41f openvswitch: update to v3.7.1-tip
- 7797bcc5 kubernetes: upgrade to 1.35.5
- b9deaf7d skopeo: upgrade v1.22.0 -> v1.22.2
- d805e74d buildah: update to v1.43.1