### PR TITLE
Add compatible support for qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo and board-subtype

### DIFF
--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -79,6 +79,8 @@ FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype13] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine qcs6490-rb3gen2-industrial-mezzanine-m2-cologne"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -10,6 +10,7 @@ MACHINE_FEATURES += "efi m2connector pci tpm2 phone"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       qcom/qcs6490-rb3gen2-industrial-mezzanine.dtbo \
+                      qcom/qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo \
                       qcom/qcs6490-rb3gen2-vision-mezzanine.dtbo \
                       "
 


### PR DESCRIPTION
Update qcom-metadata.dts and qcom-next-fitimage.its

Add compatible support for qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo
and board-subtype entry in qcom-metadata.dts