### PR TITLE
Update qcom / edk2 boot firmware to 00128

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "bdbc6aa0390f5c78059e0d9f2c70f8bc0695b350d1a8a47d65c9c758847050f2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00128.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "541e9439e34a8910fca6f12b0141f57001a278bf48b386662869aebba20b216b"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "25b19ccc56d6e4133df15b7b5ac9353357efc66cbf17e9f84d0a459724e0e3e0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00128.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "a322c3a2abae3376c0bb8b01daf3e50827f87cf0abbe6a29a0c8e410f9db002a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a94a26782bdcef18599fcc098fee77db50154ac31126dae86847c32205b224e6"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00128.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "9f32e0c45bcbfe2bf05e540c1be974180e7b4432d9cb20d63c903b5d426cd2ab"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6bcc47460e2127c6bf1ebda1726e87659820dadeceb68f15c52aed80086b64a2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00128.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "1d2c6a05abe05af7a2376fd1bd983725661631b43eff188fa227a90042ab99ac"


### PR DESCRIPTION
This PR updates boot for QCM6490, QCS8300, QCS9100 and QCS615.

QCS8300 Known fixes:
feat: add IQ-8275 EVK AC simulation support for AA SKU validation
feat: update virtualization configuration and remove GearVM dependency
fix: resolve crypto memory leaks observed during secure B2B DSQB execution
fix: improve secure firmware stability across TZ core and service components
chore: update SafeRTOS storage configuration with SPINOR reliability enhancements

QCS615 Known fixes:
feat: add platform-specific key sequence support for recovery and debug flows
feat: align secure service accessibility with latest boot architecture requirements
fix: improve boot-time handling of platform key events
chore: synchronize Talos boot configuration with common QLI firmware updates

QCS9100 Known fixes:
feat: add XBL_SEC to U-Boot handoff support for Snagboot workflows
feat: update virtualization configuration and disable obsolete GearVM support
fix: resolve AC policy-related boot failures on Mulsanne hardware
fix: revert boot-time optimization changes causing stability and boot regressions
fix: address crypto memory leaks in secure firmware processing paths
chore: update FreeRTOS/SafeRTOS integration and storage subsystem configuration

QCS6490 known fixes:
feat: enable KVM-based HLOS client and remoteproc support for virtualization use cases
feat: expose UefiSecApp services via SMCInvoke interface for HLOS access
fix: integrate ARM TLBI errata workaround to improve memory-management reliability
fix: address reboot stability issues related to PSCI power-management flows
chore: align boot firmware with latest QLI virtualization architecture updates