### PR TITLE
redis: disable auto-start on boot

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-extended/redis/redis_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-extended/redis/redis_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE:${PN}:qcom = "disable"


### PR DESCRIPTION
Disable Redis service from being enabled by default during system boot. Redis is not required for all use cases and auto-starting it can lead to unnecessary resource usage.

The service can still be enabled or started manually when needed.

Reference discussion: https://github.com/qualcomm-linux/meta-qcom/issues/2301