### PR TITLE
firmware-qcom-boot-x7181: Update boot to 00015

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00012.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00012.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6ad9222c475a7d544b92bd5038f5f06c1b3e4ac69a19e7468cf0e5b849d60dfe"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00015.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00015.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "6b12777ac79ec40665bc9aa5772d6f63a85306d4ecbdc66bcbb9ae2ec3797374"


### PR DESCRIPTION
Changes for the IQX7181(Hamoa):
Known fixes:
feat: add support for advanced secure applications and improve handling of system services 
feat: improve power management coordination for better efficiency during low‑power states 
fix: resolve system configuration and startup issues affecting stability and hardware initialization 
fix: address reliability issues in communication interfaces and timing mechanisms 
security: improve system security handling and isolation to ensure safer operation 
chore: clean up outdated components and standardize configurations for better maintainability 
feat: improve system recovery by adding retry and rollback if startup fails 
feat: reduce power usage during startup with better low‑power hardware support 
fix: ensure all required files are properly loaded during startup to avoid boot issues 
security: strengthen protection of system partitions during startup to prevent unsafe access 
chore: clean up and standardize boot settings for more stable and reliable behavior


Note: This is also required for the Wrynose branch