### PR TITLE
linux-qcom-next: update to tag qcom-next-7.1-rc7-20260618

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -14,8 +14,8 @@ LINUX_VERSION ?= "7.0+7.1-rc7"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.1-rc7-20260617
-SRCREV ?= "8dba9258929fce68a7b0d148c2a461ba2159f930"
+# tag: qcom-next-7.1-rc7-20260618
+SRCREV ?= "6548ba1da92711e1ba186d9d469388c9f64e654a"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Changelog :
FROMLIST: arm64: dts: qcom: monaco-evk-emmc: Remove explicit UFS disablement 
soc: qcom: llcc: Skip ECC interrupt setup on Shikra, pre-configured by DSF