### PR TITLE
Update the meta-lts-mixins layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -5,7 +5,7 @@ overrides:
         oe-core:
             commit: 06dd66e6220e5ce4ed4b9af4d8231ae5f0a8ce80
         meta-lts-mixins:
-            commit: 348a9eaaf3991e2329d0cef14dce23fabaef9191
+            commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
@@ -68,7 +68,6 @@ PACKAGE_BEFORE_PN =+ "\
     ${PN}-qcom-sa8775p-ride-gdsp \
     ${PN}-qcom-sdm845-hdk-adsp \
     ${PN}-qcom-sdm845-hdk-cdsp \
-    ${PN}-qcom-shikra-cqs-evk-cdsp \
     ${PN}-qcom-sm8750-mtp-adsp \
     ${PN}-qcom-sm8750-mtp-cdsp \
     ${PN}-radxa-dragon-q6a-adsp \
@@ -86,6 +85,12 @@ PACKAGE_BEFORE_PN =+ "\
     ${PN}-thundercomm-rb5-sdsp \
     ${PN}-thundercomm-rubikpi3-adsp \
     ${PN}-thundercomm-rubikpi3-cdsp \
+"
+# Dependent packages are only available from the lts-linux-firmware-mixins
+# layer and thus can't be enabled by default. Enable it for Qualcomm machines,
+# which also force enable the updated linux-firmware version.
+PACKAGES:append:qcom = " \
+    ${PN}-qcom-shikra-cqs-evk-cdsp \
 "
 
 LICENSE:${PN} = "dspso-WHENCE"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260622.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260622.bb
@@ -13,7 +13,7 @@ LICENSE = " \
 LIC_FILES_CHKSUM = "\
     file://LICENSE.qcom;md5=56e86b6c508490dadc343f39468b5f5e \
     file://LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0 \
-    file://WHENCE;md5=7033ed3790855866a84dedb1a5a215d4 \
+    file://WHENCE;md5=ba0674c526f9fdc6f687dc13cb432f31 \
     file://conf.d/hexagon-dsp-binaries-qualcomm-iq9075-evk.yaml;endline=2;md5=077232564320a8fce4ea446daad3d726 \
 "
 NO_GENERIC_LICENSE[dspso-qcom] = "LICENSE.qcom"
@@ -24,7 +24,7 @@ SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk;tag=${PV} \
 "
 
-SRCREV = "f4021ba695bc1335666561d4f96fd3844cf88c45"
+SRCREV = "2ba83638b373c0a6bbb7ecb32f5e2b9dfca2c4ce"
 
 inherit allarch
 
@@ -90,7 +90,9 @@ PACKAGE_BEFORE_PN =+ "\
 # layer and thus can't be enabled by default. Enable it for Qualcomm machines,
 # which also force enable the updated linux-firmware version.
 PACKAGES:append:qcom = " \
+    ${PN}-qcom-shikra-cqm-evk-cdsp \
     ${PN}-qcom-shikra-cqs-evk-cdsp \
+    ${PN}-qcom-shikra-iqs-evk-cdsp \
 "
 
 LICENSE:${PN} = "dspso-WHENCE"
@@ -125,7 +127,9 @@ LICENSE:${PN}-qcom-sa8775p-ride-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-sa8775p-ride-gdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-sdm845-hdk-adsp = "dspso-qcom"
 LICENSE:${PN}-qcom-sdm845-hdk-cdsp = "dspso-qcom"
+LICENSE:${PN}-qcom-shikra-cqm-evk-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-shikra-cqs-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-shikra-iqs-evk-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-sm8750-mtp-adsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-sm8750-mtp-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-radxa-dragon-q6a-adsp = "dspso-qcom"
@@ -181,7 +185,9 @@ RDEPENDS:${PN}-qcom-qcs8300-ride-gdsp = "${PN}-conf linux-firmware-qcom-qcs8300-
 RDEPENDS:${PN}-qcom-sa8775p-ride-adsp = "${PN}-conf linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
 RDEPENDS:${PN}-qcom-sa8775p-ride-cdsp = "${PN}-conf linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
 RDEPENDS:${PN}-qcom-sa8775p-ride-gdsp = "${PN}-conf linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-shikra-cqm-evk-cdsp = "${PN}-qcom-shikra-cqs-evk-cdsp"
 RDEPENDS:${PN}-qcom-shikra-cqs-evk-cdsp = "${PN}-conf linux-firmware-qcom-shikra-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-shikra-iqs-evk-cdsp = "${PN}-qcom-shikra-cqs-evk-cdsp"
 RDEPENDS:${PN}-qcom-sm8750-mtp-adsp = "${PN}-conf linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
 RDEPENDS:${PN}-qcom-sm8750-mtp-cdsp = "${PN}-conf linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
 RDEPENDS:${PN}-radxa-dragon-q6a-adsp = "${PN}-conf linux-firmware-qcom-qcs6490-radxa-dragon-q6a-audio (= 1:${PV})"
@@ -236,7 +242,9 @@ FILES:${PN}-qcom-sa8775p-ride-cdsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-R
 FILES:${PN}-qcom-sa8775p-ride-gdsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp*"
 FILES:${PN}-qcom-sdm845-hdk-adsp = "${datadir}/qcom/sdm845/Qualcomm/SDM845-HDK/dsp/adsp"
 FILES:${PN}-qcom-sdm845-hdk-cdsp = "${datadir}/qcom/sdm845/Qualcomm/SDM845-HDK/dsp/cdsp*"
+FILES:${PN}-qcom-shikra-cqm-evk-cdsp = "${datadir}/qcom/shikra/Qualcomm/Shikra-CQM-EVK/dsp/cdsp"
 FILES:${PN}-qcom-shikra-cqs-evk-cdsp = "${datadir}/qcom/shikra/Qualcomm/Shikra-CQS-EVK/dsp/cdsp"
+FILES:${PN}-qcom-shikra-iqs-evk-cdsp = "${datadir}/qcom/shikra/Qualcomm/Shikra-IQS-EVK/dsp/cdsp"
 FILES:${PN}-qcom-sm8750-mtp-adsp = "${datadir}/qcom/sm8750/Qualcomm/SM8750-MTP/dsp/adsp"
 FILES:${PN}-qcom-sm8750-mtp-cdsp = "${datadir}/qcom/sm8750/Qualcomm/SM8750-MTP/dsp/cdsp*"
 FILES:${PN}-radxa-dragon-q6a-adsp = "${datadir}/qcom/qcs6490/radxa/dragon-q6a/dsp/adsp"
@@ -291,6 +299,7 @@ INSANE_SKIP:${PN}-thundercomm-rubikpi3-adsp = "arch libdir file-rdeps textrel"
 SKIP_FILEDEPS:${PN}-qcom-glymur-crd-adsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-glymur-crd-cdsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-hamoa-iot-evk-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-hamoa-iot-evk-cdsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-adsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-cdsp = "1"
 SKIP_FILEDEPS:${PN}-qcom-qcs8300-ride-adsp = "1"

--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -3,9 +3,14 @@ SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
 inherit packagegroup
 
 QCOM_M2_WIFI_FIRMWARE = " \
-    linux-firmware-ath12k-qcc2072 \
     linux-firmware-ath12k-qcn9274 \
     linux-firmware-ath12k-wcn7850 \
+"
+# This package is only available from the lts-linux-firmware-mixins layer and
+# thus can't be enabled by default. Enable it for Qualcomm machines, which also
+# force enable the updated linux-firmware version.
+QCOM_M2_WIFI_FIRMWARE:append:qcom = " \
+    linux-firmware-ath12k-qcc2072 \
 "
 
 QCOM_M2_BT_FIRMWARE = " \

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,4 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# use latest version of linux-firmware from the lts-linux-firmware-mixin layer
+DEFAULT_PREFERENCE:layer-lts-linux-firmware-mixin:qcom = "1"
+
 # To make the layer pass yocto-check-layer only inherit update-alternatives when building for qualcomm
 ALTERNATIVES_CLASS = ""
 ALTERNATIVES_CLASS:qcom = "update-alternatives"


### PR DESCRIPTION
In order to make the meta-lts-mixins/wrynose/linux-firmware layer
Yocto Project Compatible, the layer no more provide linux-firmware
by default unless that is explicitly stated in the variable DEFAULT_PREFERENCE.
The default setting in mxin layer is now DEFAULT_PREFERENCE to "-1".

Relevant changes for meta-lts-mixins:
- 6ad95d0 linux-firmware: upgrade 20260519 -> 20260622
- d4a9842 drop LTS_LINUX_FIRMWARE_MIXIN_DEFAULT_PREFERENCE and use just DEFAULT_PREFERENCE
- 7d003ac README: add LTS_LINUX_FIRMWARE_MIXIN_DEFAULT_PREFERENCE
- 2145371 linux-firmware: add LTS_LINUX_FIRMWARE_MIXIN_DEFAULT_PREFERENCE
- 6b8dd8b layer.conf: add LTS_LINUX_FIRMWARE_MIXIN_DEFAULT_PREFERENCE
- 11dcf7d SECURITY.md: describe security policy and pointers
- 9cab569 linux-firmware: set DEFAULT_PREFERENCE to "-1"
- b9d53c1 layer.conf: use the same priority as OE-Core

Fix https://github.com/qualcomm-linux/meta-qcom/issues/2457