### PR TITLE
selinux: Add Container, Wayland, and Docker policy updates

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-container-Allow-access-to-etc-cdi-for-CDI-configurat.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-container-Allow-access-to-etc-cdi-for-CDI-configurat.patch
@@ -1,0 +1,41 @@
+From 9ff44d61ab0e41a9bcdb30bbaf8654e037db85a5 Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Tue, 16 Jun 2026 17:37:41 +0300
+Subject: [PATCH 2/2] container: Allow access to /etc/cdi for CDI configuration
+
+Containerd requires access to /etc/cdi to load Container Device
+Interface (CDI) configuration files. Without proper permissions,
+containers fail to read the CDI specs, resulting in errors such as:
+
+  CDI: error associated with spec file /etc/cdi:
+  failed to monitor for changes: permission denied
+
+avc:  denied  { watch } for  pid=918 comm="containerd"
+path="/etc/cdi" dev="sda2" ino=1566137 scontext=system_u:system_r:dockerd
+type=SYSCALL msg=audit(83241.927:148): arch=c00000b7 syscall=27
+success=no exit=-13 a0=9 a1=6c64631b2870 a2=fc6 a3=0 items=0 ppid=1
+pid=918 auid=4294967295 uid=0 gtype=PROCTITLE msg=audit(83241.927:148):
+proctitle="/usr/bin/containerd"
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1163]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/services/container.fc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/services/container.fc b/policy/modules/services/container.fc
+index 010387a3a..812b46cee 100644
+--- a/policy/modules/services/container.fc
++++ b/policy/modules/services/container.fc
+@@ -40,6 +40,7 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
+ 
+ /etc/containers(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+ /etc/cni(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
++/etc/cdi(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+ /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+ /etc/containerd(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+ 
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-wayland-Add-wayland_stream_connect-interface.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-wayland-Add-wayland_stream_connect-interface.patch
@@ -1,0 +1,69 @@
+From 3e8e659a6d10595a267393087ec5d0ce225483e1 Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 19 Jun 2026 13:30:02 +0300
+Subject: [PATCH 3/3] wayland: Add wayland_stream_connect interface
+
+Add a new interface, wayland_stream_connect(), to allow domains
+to connect to a Wayland compositor via an UNIX stream socket.
+
+This interface grants the necessary permissions to search the
+user runtime directory and establish a stream connection to
+Wayland compositor sockets labeled with wayland_runtime_t.
+
+Typical usage includes enabling confined domains (such as
+container runtimes or applications) to communicate with the
+Wayland display server.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1166]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/session/wayland.fc |  1 +
+ policy/modules/session/wayland.if | 27 +++++++++++++++++++++++++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/policy/modules/session/wayland.fc b/policy/modules/session/wayland.fc
+index 73151efba..64b18ca04 100644
+--- a/policy/modules/session/wayland.fc
++++ b/policy/modules/session/wayland.fc
+@@ -1 +1,2 @@
+ /run/user/%{USERID}/wayland-.*	-s	gen_context(system_u:object_r:wayland_runtime_t,s0)
++/run/wayland-[0-9]+		-s	gen_context(system_u:object_r:wayland_runtime_t,s0)
+diff --git a/policy/modules/session/wayland.if b/policy/modules/session/wayland.if
+index 2812dcb30..e2eab0b49 100644
+--- a/policy/modules/session/wayland.if
++++ b/policy/modules/session/wayland.if
+@@ -99,3 +99,30 @@ interface(`wayland_client_sandboxed_domain',`
+ 
+ 	typeattribute $1 wayland_client_sandboxed;
+ ')
++
++#########################################
++## <summary>
++##	Connect to the Wayland compositor
++##	using an UNIX domain stream socket.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`wayland_stream_connect',`
++	gen_require(`
++		attribute wayland_compositor;
++		type wayland_runtime_t;
++	')
++
++	files_search_runtime($1)
++
++	stream_connect_pattern(
++		$1,
++		wayland_runtime_t,
++		wayland_runtime_t,
++		wayland_compositor
++	)
++')
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-docker-Allow-dockerd-to-connect-to-pulseaudio-and-wa.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-docker-Allow-dockerd-to-connect-to-pulseaudio-and-wa.patch
@@ -1,0 +1,54 @@
+From 804f69979eacd40f38af15df538a4a22437b355f Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 19 Jun 2026 13:43:44 +0300
+Subject: [PATCH 4/4] docker: Allow dockerd to connect to pulseaudio and
+ wayland sockets
+
+Add optional policy support to allow the Docker daemon (dockerd_t)
+to connect to user session services over UNIX stream sockets.
+
+This introduces:
+  - pulseaudio_stream_connect(dockerd_t)
+  - wayland_stream_connect(dockerd_t)
+
+These interfaces enable dockerd to communicate with PulseAudio and
+Wayland compositor sockets located under /run/user/$UID, which is
+required for certain container workloads that need access to the
+host audio or graphical display.
+
+Both permissions are wrapped in optional_policy blocks to ensure
+they are only enabled when the corresponding PulseAudio and Wayland
+policy modules are present.
+
+This change improves compatibility with containerized desktop
+applications while preserving modular policy design.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1167]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/services/docker.te | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/policy/modules/services/docker.te b/policy/modules/services/docker.te
+index f40713d12..5214ee4a0 100644
+--- a/policy/modules/services/docker.te
++++ b/policy/modules/services/docker.te
+@@ -61,6 +61,14 @@ container_stream_connect_system_containers(dockerd_t)
+ # docker manages key.json in /etc/docker
+ container_manage_config_files(dockerd_t)
+ 
++optional_policy(`
++	pulseaudio_stream_connect(dockerd_t)
++')
++
++optional_policy(`
++	wayland_stream_connect(dockerd_t)
++')
++
+ # In btrfs mode, docker creates subvolumes which are unlabeled
+ # in /var/lib/docker/btrfs/subvolumes. The files inside will
+ # become labeled with a file transition, but the subvolume
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -2,4 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
+    file://0002-container-Allow-access-to-etc-cdi-for-CDI-configurat.patch \
+    file://0003-wayland-Add-wayland_stream_connect-interface.patch \
+    file://0004-docker-Allow-dockerd-to-connect-to-pulseaudio-and-wa.patch \
 "


### PR DESCRIPTION
Introduce a set of SELinux policy updates to improve support for containerized workloads requiring access to host configuration, audio, and graphical services.

The following changes are included:

  - Container: Allow access to /etc/cdi for CDI (Container Device Interface) configuration, enabling container runtimes to discover and use device plugins.

  - Wayland: Add a new interface, wayland_stream_connect(), to allow confined domains to connect to Wayland compositor sockets over UNIX stream sockets.

  - Docker: Add optional policy to allow dockerd_t to connect to PulseAudio and Wayland sockets via:
      * pulseaudio_stream_connect(dockerd_t)
      * wayland_stream_connect(dockerd_t)

    These permissions are wrapped in optional_policy blocks and are
    only enabled when the corresponding modules are present.

These changes collectively improve integration of containerized applications with desktop environments (audio and display) while preserving modular SELinux policy design.

Note that granting dockerd access to user session services may have security implications and should only be enabled for environments that require GUI or audio-enabled containers.