### PR TITLE
ci: base.lock: update meta-selinux to include latest selinux policies

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -15,7 +15,7 @@ overrides:
         meta-audioreach:
             commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
         meta-selinux:
-            commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
+            commit: 1c3a699f363167571ab39fecb0fe6f56691a4e20
         meta-updater:
             commit: f0e1ccafaa877d2781ed953236981dac57439dc8
         meta-security:


### PR DESCRIPTION
Includes:
1c3a699 refpolicy: update to latest git rev