### PR TITLE
Fix Yocto Project Compatibility requirements

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -299,6 +299,14 @@ jobs:
           # Additional builds for specific machines
           - machine: qcom-armv8a
             distro:
+                name: qcom-distro-nomixin
+                yamlfile: ':ci/qcom-distro-nomixin.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: qcom-armv8a
+            distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -17,10 +17,6 @@ repos:
     layers:
       meta:
 
-  meta-lts-mixins:
-    url: https://git.yoctoproject.org/meta-lts-mixins
-    branch: wrynose/linux-firmware
-
   bitbake:
     url: https://github.com/openembedded/bitbake
     branch: "2.18"

--- a/ci/oe-selftest.sh
+++ b/ci/oe-selftest.sh
@@ -63,8 +63,6 @@ BUILDDIR="$(mktemp -p "$WORK_DIR" -d -t build-oe-selftest-XXXX)"
 cd "$WORK_DIR/oe-core"
 . ./oe-init-build-env "$BUILDDIR"
 
-# Add the lts-linux-firmware-mixin layer
-bitbake-layers add-layer "$WORK_DIR/meta-lts-mixins"
 # Add the meta-qcom layer
 bitbake-layers add-layer "$REPO_DIR"
 

--- a/ci/qcom-distro-nomixin.yml
+++ b/ci/qcom-distro-nomixin.yml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+distro: qcom-distro
+
+defaults:
+  repos:
+    branch: wrynose
+
+repos:
+  meta-qcom-distro:
+    url: https://github.com/qualcomm-linux/meta-qcom-distro
+
+  meta-openembedded:
+    url: https://github.com/openembedded/meta-openembedded
+    patches:
+      plain:
+        repo: meta-qcom
+        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
+    layers:
+      meta-filesystems:
+      meta-gnome:
+      meta-multimedia:
+      meta-networking:
+      meta-oe:
+      meta-python:
+      meta-xfce:
+
+  meta-virtualization:
+    url: https://git.yoctoproject.org/git/meta-virtualization
+
+  meta-audioreach:
+    url: https://github.com/AudioReach/meta-audioreach
+    branch: master
+
+  meta-selinux:
+    url: https://git.yoctoproject.org/meta-selinux
+
+  meta-updater:
+    url: https://github.com/uptane/meta-updater
+
+  meta-security:
+    url: https://git.yoctoproject.org/meta-security
+    layers:
+      .:
+      meta-tpm:
+
+local_conf_header:
+  virtualization:
+    SKIP_META_VIRT_SANITY_CHECK = "1"
+
+target:
+  - qcom-multimedia-image
+  - qcom-multimedia-proprietary-image
+  - qcom-container-orchestration-image
+  - qcom-networking-image

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -2,57 +2,10 @@
 
 header:
   version: 14
-
-distro: qcom-distro
-
-defaults:
-  repos:
-    branch: wrynose
+  includes:
+  - ci/qcom-disto-nomixin.yml
 
 repos:
-  meta-qcom-distro:
-    url: https://github.com/qualcomm-linux/meta-qcom-distro
-
-  meta-openembedded:
-    url: https://github.com/openembedded/meta-openembedded
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
-    layers:
-      meta-filesystems:
-      meta-gnome:
-      meta-multimedia:
-      meta-networking:
-      meta-oe:
-      meta-python:
-      meta-xfce:
-
-  meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
-
-  meta-audioreach:
-    url: https://github.com/AudioReach/meta-audioreach
-    branch: master
-
-  meta-selinux:
-    url: https://git.yoctoproject.org/meta-selinux
-
-  meta-updater:
-    url: https://github.com/uptane/meta-updater
-
-  meta-security:
-    url: https://git.yoctoproject.org/meta-security
-    layers:
-      .:
-      meta-tpm:
-
-local_conf_header:
-  virtualization:
-    SKIP_META_VIRT_SANITY_CHECK = "1"
-
-target:
-  - qcom-multimedia-image
-  - qcom-multimedia-proprietary-image
-  - qcom-container-orchestration-image
-  - qcom-networking-image
+  meta-lts-mixins:
+    url: https://git.yoctoproject.org/meta-lts-mixins
+    branch: wrynose/linux-firmware

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,8 +13,8 @@ BBFILE_COLLECTIONS += "qcom"
 BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "6"
 
-LAYERDEPENDS_qcom = "core lts-linux-firmware-mixin"
-LAYERRECOMMENDS_qcom = "openembedded-layer meta-arm"
+LAYERDEPENDS_qcom = "core"
+LAYERRECOMMENDS_qcom = "openembedded-layer meta-arm lts-linux-firmware-mixin"
 LAYERSERIES_COMPAT_qcom = "wrynose"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,6 +24,8 @@ BBFILES_DYNAMIC += " \
     meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    lts-linux-firmware-mixin:${LAYERDIR}/dynamic-layers/lts-linux-firmware-mixin/*/*/*.bb \
+    lts-linux-firmware-mixin:${LAYERDIR}/dynamic-layers/lts-linux-firmware-mixin/*/*/*.bbappend \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     qcom-distro:${LAYERDIR}/dynamic-layers/qcom-distro/*/*/*.bb \

--- a/dynamic-layers/lts-linux-firmware-mixin/recipes-kernel/linux-firmware/linux-firmware_20260519.bbappend
+++ b/dynamic-layers/lts-linux-firmware-mixin/recipes-kernel/linux-firmware/linux-firmware_20260519.bbappend
@@ -1,0 +1,1 @@
+DEFAULT_PREFERENCE:qcom = "1"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries/0001-conf-add-links-for-QCM6490-IDP.patch
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries/0001-conf-add-links-for-QCM6490-IDP.patch
@@ -1,0 +1,41 @@
+From 9957e017831ae90142ad2be4fc828a7160db7390 Mon Sep 17 00:00:00 2001
+From: Sairamreddy Bojja <sbojja@qti.qualcomm.com>
+Date: Mon, 13 Apr 2026 12:41:13 +0530
+Subject: [PATCH] conf: add links for QCM6490 IDP
+
+Add links for QCM6490 IDP platform based on RB3 Gen2.
+
+Signed-off-by: Sairamreddy Bojja <sbojja@qti.qualcomm.com>
+Upstream-Status: Backport [https://github.com/linux-msm/hexagon-dsp-binaries/commit/9957e017831ae90142ad2be4fc828a7160db7390]
+---
+ conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml | 5 +++++
+ config.txt                                            | 4 ++++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml
+
+diff --git a/conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml b/conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml
+new file mode 100644
+index 000000000000..aa2a4123fe4b
+--- /dev/null
++++ b/conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml
+@@ -0,0 +1,5 @@
++# SPDX-License-Identifier: MIT
++# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++machines:
++  Qualcomm Technologies, Inc. QCM6490 IDP:
++    DSP_LIBRARY_PATH: qcm6490/Qualcomm/QCM6490-IDP/dsp
+diff --git a/config.txt b/config.txt
+index a7640e4bf61f..8d3624dfc71c 100644
+--- a/config.txt
++++ b/config.txt
+@@ -94,3 +94,7 @@ Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gd
+ Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp1
+ Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp0
+ Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp1
++
++# QCM6490 IDP
++Link: qcm6490/Thundercomm/RB3gen2/dsp/adsp      qcm6490/Qualcomm/QCM6490-IDP/dsp/adsp
++Link: qcm6490/Thundercomm/RB3gen2/dsp/cdsp      qcm6490/Qualcomm/QCM6490-IDP/dsp/cdsp
+-- 
+2.53.0
+

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260410.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260410.bb
@@ -22,6 +22,7 @@ NO_GENERIC_LICENSE[dspso-WHENCE] = "WHENCE"
 
 SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk;tag=${PV} \
+    file://0001-conf-add-links-for-QCM6490-IDP.patch \
 "
 
 SRCREV = "123bddd9cc886b61ece87d7d63b9ceed0654d3a1"
@@ -54,6 +55,8 @@ PACKAGE_BEFORE_PN =+ "\
     ${PN}-qcom-iq9075-evk-gdsp \
     ${PN}-qcom-kaanapali-mtp-adsp \
     ${PN}-qcom-kaanapali-mtp-cdsp \
+    ${PN}-qcom-qcm6490-idp-adsp \
+    ${PN}-qcom-qcm6490-idp-cdsp \
     ${PN}-qcom-qcs615-ride-adsp \
     ${PN}-qcom-qcs615-ride-cdsp \
     ${PN}-qcom-qcs8300-ride-adsp \
@@ -101,6 +104,8 @@ LICENSE:${PN}-qcom-iq9075-evk-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-iq9075-evk-gdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-kaanapali-mtp-adsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-kaanapali-mtp-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcm6490-idp-adsp = "dspso-qcom"
+LICENSE:${PN}-qcom-qcm6490-idp-cdsp = "dspso-qcom"
 LICENSE:${PN}-qcom-qcs615-ride-adsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-qcs615-ride-cdsp = "dspso-qcom-2"
 LICENSE:${PN}-qcom-qcs8300-ride-adsp = "dspso-qcom-2"
@@ -154,6 +159,8 @@ RDEPENDS:${PN}-qcom-iq9075-evk-gdsp = "${PN}-conf linux-firmware-qcom-sa8775p-ge
 RDEPENDS:${PN}-qcom-iq9075-evk-gdsp += "${PN}-qcom-sa8775p-ride-gdsp"
 RDEPENDS:${PN}-qcom-kaanapali-mtp-adsp = "${PN}-conf linux-firmware-qcom-kaanapali-audio (= 1:${PV})"
 RDEPENDS:${PN}-qcom-kaanapali-mtp-cdsp = "${PN}-conf linux-firmware-qcom-kaanapali-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcm6490-idp-adsp = "${PN}-thundercomm-rb3gen2-adsp"
+RDEPENDS:${PN}-qcom-qcm6490-idp-cdsp = "${PN}-thundercomm-rb3gen2-cdsp"
 RDEPENDS:${PN}-qcom-qcs615-ride-adsp = "${PN}-conf linux-firmware-qcom-qcs615-audio (= 1:${PV})"
 RDEPENDS:${PN}-qcom-qcs615-ride-cdsp = "${PN}-conf linux-firmware-qcom-qcs615-compute (= 1:${PV})"
 RDEPENDS:${PN}-qcom-qcs8300-ride-adsp = "${PN}-conf linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
@@ -202,6 +209,8 @@ FILES:${PN}-qcom-iq9075-evk-cdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/
 FILES:${PN}-qcom-iq9075-evk-gdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp*"
 FILES:${PN}-qcom-kaanapali-mtp-adsp = "${datadir}/qcom/kaanapali/Qualcomm/Kaanapali-MTP/dsp/adsp*"
 FILES:${PN}-qcom-kaanapali-mtp-cdsp = "${datadir}/qcom/kaanapali/Qualcomm/Kaanapali-MTP/dsp/cdsp*"
+FILES:${PN}-qcom-qcm6490-idp-adsp = "${datadir}/qcom/qcm6490/Qualcomm/QCM6490-IDP/dsp/adsp"
+FILES:${PN}-qcom-qcm6490-idp-cdsp = "${datadir}/qcom/qcm6490/Qualcomm/QCM6490-IDP/dsp/cdsp"
 FILES:${PN}-qcom-qcs615-ride-adsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/adsp"
 FILES:${PN}-qcom-qcs615-ride-cdsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/cdsp*"
 FILES:${PN}-qcom-qcs8300-ride-adsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260410.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260410.bb
@@ -1,0 +1,283 @@
+SUMMARY = "Hexagon DSP binaries for Qualcomm hardware"
+DESCRIPTION = "Hexagon DSP binaries is a package distributed alongside the \
+Linux firmware release. It contains libraries and executables to be used \
+with the corresponding DSP firmware using the FastRPC interface in order \
+to provide additional functionality by the DSPs."
+
+LICENSE = " \
+    dspso-WHENCE \
+    & dspso-qcom \
+    & dspso-qcom-2 \
+    & MIT \
+"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE.qcom;md5=56e86b6c508490dadc343f39468b5f5e \
+    file://LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0 \
+    file://WHENCE;md5=84a238ca84b2b4db57cf6f829d317721 \
+    file://conf.d/hexagon-dsp-binaries-qualcomm-iq9075-evk.yaml;endline=2;md5=077232564320a8fce4ea446daad3d726 \
+"
+NO_GENERIC_LICENSE[dspso-qcom] = "LICENSE.qcom"
+NO_GENERIC_LICENSE[dspso-qcom-2] = "LICENSE.qcom-2"
+NO_GENERIC_LICENSE[dspso-WHENCE] = "WHENCE"
+
+SRC_URI = " \
+    git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk;tag=${PV} \
+"
+
+SRCREV = "123bddd9cc886b61ece87d7d63b9ceed0654d3a1"
+
+inherit allarch
+
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_install () {
+	oe_runmake install 'DESTDIR=${D}'
+}
+
+PACKAGE_BEFORE_PN =+ "\
+    ${PN}-conf \
+    ${PN}-qcom-arduino-monza-adsp \
+    ${PN}-qcom-arduino-monza-cdsp \
+    ${PN}-qcom-arduino-monza-gdsp \
+    ${PN}-qcom-db820c-adsp \
+    ${PN}-qcom-glymur-crd-adsp \
+    ${PN}-qcom-glymur-crd-cdsp \
+    ${PN}-qcom-hamoa-iot-evk-adsp \
+    ${PN}-qcom-hamoa-iot-evk-cdsp \
+    ${PN}-qcom-iq8275-evk-adsp \
+    ${PN}-qcom-iq8275-evk-cdsp \
+    ${PN}-qcom-iq8275-evk-gdsp \
+    ${PN}-qcom-iq9075-evk-adsp \
+    ${PN}-qcom-iq9075-evk-cdsp \
+    ${PN}-qcom-iq9075-evk-gdsp \
+    ${PN}-qcom-kaanapali-mtp-adsp \
+    ${PN}-qcom-kaanapali-mtp-cdsp \
+    ${PN}-qcom-qcs615-ride-adsp \
+    ${PN}-qcom-qcs615-ride-cdsp \
+    ${PN}-qcom-qcs8300-ride-adsp \
+    ${PN}-qcom-qcs8300-ride-cdsp \
+    ${PN}-qcom-qcs8300-ride-gdsp \
+    ${PN}-qcom-sa8775p-ride-adsp \
+    ${PN}-qcom-sa8775p-ride-cdsp \
+    ${PN}-qcom-sa8775p-ride-gdsp \
+    ${PN}-qcom-sdm845-hdk-adsp \
+    ${PN}-qcom-sdm845-hdk-cdsp \
+    ${PN}-qcom-sm8750-mtp-adsp \
+    ${PN}-qcom-sm8750-mtp-cdsp \
+    ${PN}-radxa-dragon-q6a-adsp \
+    ${PN}-radxa-dragon-q6a-cdsp \
+    ${PN}-thundercomm-db845c-adsp \
+    ${PN}-thundercomm-db845c-cdsp \
+    ${PN}-thundercomm-db845c-sdsp \
+    ${PN}-thundercomm-rb1-adsp \
+    ${PN}-thundercomm-rb2-adsp \
+    ${PN}-thundercomm-rb2-cdsp \
+    ${PN}-thundercomm-rb3gen2-adsp \
+    ${PN}-thundercomm-rb3gen2-cdsp \
+    ${PN}-thundercomm-rb5-adsp \
+    ${PN}-thundercomm-rb5-cdsp \
+    ${PN}-thundercomm-rb5-sdsp \
+    ${PN}-thundercomm-rubikpi3-adsp \
+    ${PN}-thundercomm-rubikpi3-cdsp \
+"
+
+LICENSE:${PN} = "dspso-WHENCE"
+LICENSE:${PN}-conf = "MIT"
+LICENSE:${PN}-qcom-arduino-monza-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-arduino-monza-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-arduino-monza-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-db820c-adsp = "dspso-qcom"
+LICENSE:${PN}-qcom-glymur-crd-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-glymur-crd-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-hamoa-iot-evk-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-hamoa-iot-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq8275-evk-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq8275-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq8275-evk-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-iq9075-evk-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-kaanapali-mtp-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-kaanapali-mtp-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs615-ride-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs615-ride-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs8300-ride-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs8300-ride-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-qcs8300-ride-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sa8775p-ride-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sa8775p-ride-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sa8775p-ride-gdsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sdm845-hdk-adsp = "dspso-qcom"
+LICENSE:${PN}-qcom-sdm845-hdk-cdsp = "dspso-qcom"
+LICENSE:${PN}-qcom-sm8750-mtp-adsp = "dspso-qcom-2"
+LICENSE:${PN}-qcom-sm8750-mtp-cdsp = "dspso-qcom-2"
+LICENSE:${PN}-radxa-dragon-q6a-adsp = "dspso-qcom"
+LICENSE:${PN}-radxa-dragon-q6a-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-db845c-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-db845c-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-db845c-sdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb1-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb2-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb2-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb3gen2-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb3gen2-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-cdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rb5-sdsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rubikpi3-adsp = "dspso-qcom"
+LICENSE:${PN}-thundercomm-rubikpi3-cdsp = "dspso-qcom"
+
+RDEPENDS:${PN}-qcom-arduino-monza-adsp = "${PN}-conf linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-arduino-monza-adsp += "${PN}-qcom-qcs8300-ride-adsp"
+RDEPENDS:${PN}-qcom-arduino-monza-cdsp = "${PN}-conf linux-firmware-qcom-qcs8300-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-arduino-monza-cdsp += "${PN}-qcom-qcs8300-ride-cdsp"
+RDEPENDS:${PN}-qcom-arduino-monza-gdsp = "${PN}-conf linux-firmware-qcom-qcs8300-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-arduino-monza-gdsp += "${PN}-qcom-qcs8300-ride-gdsp"
+RDEPENDS:${PN}-qcom-db820c-adsp = "${PN}-conf linux-firmware-qcom-apq8096-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-glymur-crd-adsp = "${PN}-conf linux-firmware-qcom-glymur-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-glymur-crd-cdsp = "${PN}-conf linux-firmware-qcom-glymur-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-hamoa-iot-evk-adsp = "${PN}-conf linux-firmware-qcom-x1e80100-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-hamoa-iot-evk-cdsp = "${PN}-conf linux-firmware-qcom-x1e80100-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-adsp = "${PN}-conf linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-adsp += "${PN}-qcom-qcs8300-ride-adsp"
+RDEPENDS:${PN}-qcom-iq8275-evk-cdsp = "${PN}-conf linux-firmware-qcom-qcs8300-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-cdsp += "${PN}-qcom-qcs8300-ride-cdsp"
+RDEPENDS:${PN}-qcom-iq8275-evk-gdsp = "${PN}-conf linux-firmware-qcom-qcs8300-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq8275-evk-gdsp += "${PN}-qcom-qcs8300-ride-gdsp"
+RDEPENDS:${PN}-qcom-iq9075-evk-adsp = "${PN}-conf linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-adsp += "${PN}-qcom-sa8775p-ride-adsp"
+RDEPENDS:${PN}-qcom-iq9075-evk-cdsp = "${PN}-conf linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-cdsp += "${PN}-qcom-sa8775p-ride-cdsp"
+RDEPENDS:${PN}-qcom-iq9075-evk-gdsp = "${PN}-conf linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-iq9075-evk-gdsp += "${PN}-qcom-sa8775p-ride-gdsp"
+RDEPENDS:${PN}-qcom-kaanapali-mtp-adsp = "${PN}-conf linux-firmware-qcom-kaanapali-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-kaanapali-mtp-cdsp = "${PN}-conf linux-firmware-qcom-kaanapali-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs615-ride-adsp = "${PN}-conf linux-firmware-qcom-qcs615-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs615-ride-cdsp = "${PN}-conf linux-firmware-qcom-qcs615-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs8300-ride-adsp = "${PN}-conf linux-firmware-qcom-qcs8300-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs8300-ride-cdsp = "${PN}-conf linux-firmware-qcom-qcs8300-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-qcs8300-ride-gdsp = "${PN}-conf linux-firmware-qcom-qcs8300-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-adsp = "${PN}-conf linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-cdsp = "${PN}-conf linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sa8775p-ride-gdsp = "${PN}-conf linux-firmware-qcom-sa8775p-generalpurpose (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sm8750-mtp-adsp = "${PN}-conf linux-firmware-qcom-sa8775p-audio (= 1:${PV})"
+RDEPENDS:${PN}-qcom-sm8750-mtp-cdsp = "${PN}-conf linux-firmware-qcom-sa8775p-compute (= 1:${PV})"
+RDEPENDS:${PN}-radxa-dragon-q6a-adsp = "${PN}-conf linux-firmware-qcom-qcs6490-radxa-dragon-q6a-audio (= 1:${PV})"
+RDEPENDS:${PN}-radxa-dragon-q6a-cdsp = "${PN}-conf linux-firmware-qcom-qcs6490-radxa-dragon-q6a-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-adsp = "${PN}-conf linux-firmware-qcom-sdm845-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-cdsp = "${PN}-conf linux-firmware-qcom-sdm845-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-db845c-sdsp = "${PN}-conf linux-firmware-qcom-sdm845-thundercomm-db845c-sensors (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb1-adsp = "${PN}-conf linux-firmware-qcom-qcm2290-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb2-adsp = "${PN}-conf linux-firmware-qcom-qrb4210-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb2-cdsp = "${PN}-conf linux-firmware-qcom-qrb4210-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb3gen2-adsp = "${PN}-conf linux-firmware-qcom-qcm6490-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb3gen2-cdsp = "${PN}-conf linux-firmware-qcom-qcm6490-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-adsp = "${PN}-conf linux-firmware-qcom-sm8250-audio (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-cdsp = "${PN}-conf linux-firmware-qcom-sm8250-compute (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rb5-sdsp = "${PN}-conf linux-firmware-qcom-sm8250-thundercomm-rb5-sensors (= 1:${PV})"
+RDEPENDS:${PN}-thundercomm-rubikpi3-adsp = "${PN}-conf linux-firmware-qcom-qcs6490-thundercomm-rubikpi3-audio (= 1:${PV})"
+
+# Keep the base package empty so that one can choose which files
+# to include and do not pull all of them all in.
+FILES:${PN} = ""
+ALLOW_EMPTY:${PN} = "1"
+
+FILES:${PN}-conf = "${datadir}/qcom/conf.d"
+
+FILES:${PN}-qcom-arduino-monza-adsp = "${datadir}/qcom/qcs8300/Arduino/Monza/dsp/adsp"
+FILES:${PN}-qcom-arduino-monza-cdsp = "${datadir}/qcom/qcs8300/Arduino/Monza/dsp/cdsp*"
+FILES:${PN}-qcom-arduino-monza-gdsp = "${datadir}/qcom/qcs8300/Arduino/Monza/dsp/gdsp*"
+FILES:${PN}-qcom-db820c-adsp = "${datadir}/qcom/apq8096/Qualcomm/db820c/dsp/adsp"
+FILES:${PN}-qcom-glymur-crd-adsp = "${datadir}/qcom/glymur/Qualcomm/Glymur-CRD/dsp/adsp*"
+FILES:${PN}-qcom-glymur-crd-cdsp = "${datadir}/qcom/glymur/Qualcomm/Glymur-CRD/dsp/cdsp*"
+FILES:${PN}-qcom-hamoa-iot-evk-adsp = "${datadir}/qcom/x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp/adsp*"
+FILES:${PN}-qcom-hamoa-iot-evk-cdsp = "${datadir}/qcom/x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp/cdsp*"
+FILES:${PN}-qcom-iq8275-evk-adsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp"
+FILES:${PN}-qcom-iq8275-evk-cdsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp*"
+FILES:${PN}-qcom-iq8275-evk-gdsp = "${datadir}/qcom/qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp*"
+FILES:${PN}-qcom-iq9075-evk-adsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp"
+FILES:${PN}-qcom-iq9075-evk-cdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp*"
+FILES:${PN}-qcom-iq9075-evk-gdsp = "${datadir}/qcom/sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp*"
+FILES:${PN}-qcom-kaanapali-mtp-adsp = "${datadir}/qcom/kaanapali/Qualcomm/Kaanapali-MTP/dsp/adsp*"
+FILES:${PN}-qcom-kaanapali-mtp-cdsp = "${datadir}/qcom/kaanapali/Qualcomm/Kaanapali-MTP/dsp/cdsp*"
+FILES:${PN}-qcom-qcs615-ride-adsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/adsp"
+FILES:${PN}-qcom-qcs615-ride-cdsp = "${datadir}/qcom/qcs615/Qualcomm/QCS615-RIDE/dsp/cdsp*"
+FILES:${PN}-qcom-qcs8300-ride-adsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp"
+FILES:${PN}-qcom-qcs8300-ride-cdsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp*"
+FILES:${PN}-qcom-qcs8300-ride-gdsp = "${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp*"
+FILES:${PN}-qcom-sa8775p-ride-adsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp"
+FILES:${PN}-qcom-sa8775p-ride-cdsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp*"
+FILES:${PN}-qcom-sa8775p-ride-gdsp = "${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp*"
+FILES:${PN}-qcom-sdm845-hdk-adsp = "${datadir}/qcom/sdm845/Qualcomm/SDM845-HDK/dsp/adsp"
+FILES:${PN}-qcom-sdm845-hdk-cdsp = "${datadir}/qcom/sdm845/Qualcomm/SDM845-HDK/dsp/cdsp*"
+FILES:${PN}-qcom-sm8750-mtp-adsp = "${datadir}/qcom/sm8750/Qualcomm/SM8750-MTP/dsp/adsp"
+FILES:${PN}-qcom-sm8750-mtp-cdsp = "${datadir}/qcom/sm8750/Qualcomm/SM8750-MTP/dsp/cdsp*"
+FILES:${PN}-radxa-dragon-q6a-adsp = "${datadir}/qcom/qcs6490/radxa/dragon-q6a/dsp/adsp"
+FILES:${PN}-radxa-dragon-q6a-cdsp = "${datadir}/qcom/qcs6490/radxa/dragon-q6a/dsp/cdsp"
+FILES:${PN}-thundercomm-db845c-adsp = "${datadir}/qcom/sdm845/Thundercomm/db845c/dsp/adsp"
+FILES:${PN}-thundercomm-db845c-cdsp = "${datadir}/qcom/sdm845/Thundercomm/db845c/dsp/cdsp"
+FILES:${PN}-thundercomm-db845c-sdsp = "${datadir}/qcom/sdm845/Thundercomm/db845c/dsp/sdsp"
+FILES:${PN}-thundercomm-rb1-adsp = "${datadir}/qcom/qcm2290/Thundercomm/RB1/dsp/adsp"
+FILES:${PN}-thundercomm-rb2-adsp = "${datadir}/qcom/qrb4210/Thundercomm/RB2/dsp/adsp"
+FILES:${PN}-thundercomm-rb2-cdsp = "${datadir}/qcom/qrb4210/Thundercomm/RB2/dsp/cdsp"
+FILES:${PN}-thundercomm-rb3gen2-adsp = "${datadir}/qcom/qcm6490/Thundercomm/RB3gen2/dsp/adsp"
+FILES:${PN}-thundercomm-rb3gen2-cdsp = "${datadir}/qcom/qcm6490/Thundercomm/RB3gen2/dsp/cdsp"
+FILES:${PN}-thundercomm-rb5-adsp = "${datadir}/qcom/sm8250/Thundercomm/RB5/dsp/adsp"
+FILES:${PN}-thundercomm-rb5-cdsp = "${datadir}/qcom/sm8250/Thundercomm/RB5/dsp/cdsp"
+FILES:${PN}-thundercomm-rb5-sdsp = "${datadir}/qcom/sm8250/Thundercomm/RB5/dsp/sdsp"
+FILES:${PN}-thundercomm-rubikpi3-adsp = "${datadir}/qcom/qcs6490/Thundercomm/RubikPi3/dsp/adsp"
+FILES:${PN}-thundercomm-rubikpi3-cdsp = "${datadir}/qcom/qcs6490/Thundercomm/RubikPi3/dsp/cdsp"
+
+INSANE_SKIP:${PN}-qcom-db820c-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-glymur-crd-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-glymur-crd-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-hamoa-iot-evk-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-hamoa-iot-evk-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-kaanapali-mtp-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-kaanapali-mtp-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs615-ride-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs615-ride-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs8300-ride-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs8300-ride-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-qcs8300-ride-gdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-sa8775p-ride-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-sa8775p-ride-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-sa8775p-ride-gdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-sm8750-mtp-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-qcom-sm8750-mtp-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-radxa-dragon-q6a-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-radxa-dragon-q6a-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-db845c-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-db845c-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-db845c-sdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb1-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb2-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb2-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb3gen2-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb3gen2-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb5-adsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb5-cdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rb5-sdsp = "arch libdir file-rdeps textrel"
+INSANE_SKIP:${PN}-thundercomm-rubikpi3-adsp = "arch libdir file-rdeps textrel"
+
+SKIP_FILEDEPS:${PN}-qcom-glymur-crd-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-glymur-crd-cdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-hamoa-iot-evk-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-kaanapali-mtp-cdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-qcs8300-ride-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-qcs8300-ride-cdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-qcs8300-ride-gdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-sa8775p-ride-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-sa8775p-ride-cdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-sa8775p-ride-gdsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-sm8750-mtp-adsp = "1"
+SKIP_FILEDEPS:${PN}-qcom-sm8750-mtp-cdsp = "1"
+SKIP_FILEDEPS:${PN}-radxa-dragon-q6a-adsp = "1"
+SKIP_FILEDEPS:${PN}-radxa-dragon-q6a-cdsp = "1"
+SKIP_FILEDEPS:${PN}-thundercomm-db845c-sdsp = "1"
+SKIP_FILEDEPS:${PN}-thundercomm-rb2-cdsp = "1"
+SKIP_FILEDEPS:${PN}-thundercomm-rb3gen2-cdsp = "1"
+SKIP_FILEDEPS:${PN}-thundercomm-rb5-cdsp = "1"

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
@@ -303,3 +303,7 @@ SKIP_FILEDEPS:${PN}-thundercomm-db845c-sdsp = "1"
 SKIP_FILEDEPS:${PN}-thundercomm-rb2-cdsp = "1"
 SKIP_FILEDEPS:${PN}-thundercomm-rb3gen2-cdsp = "1"
 SKIP_FILEDEPS:${PN}-thundercomm-rb5-cdsp = "1"
+
+# This version depends on the linux-firmware package only available in the
+# meta-lts-mixins layer.
+DEFAULT_PREFERENCE = "${@bb.utils.contains("BBFILE_COLLECTIONS", "lts-linux-firmware-mixin", "1", "-1", d)}"

--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -2,8 +2,12 @@ SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
 
 inherit packagegroup
 
-QCOM_M2_WIFI_FIRMWARE = " \
+QCOM_M2_MIXIN_WIFI_FIRMWARE = " \
     linux-firmware-ath12k-qcc2072 \
+"
+
+QCOM_M2_WIFI_FIRMWARE = " \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'lts-linux-firmware-mixin', '${QCOM_M2_MIXIN_WIFI_FIRMWARE}', '', d)} \
     linux-firmware-ath12k-qcn9274 \
     linux-firmware-ath12k-wcn7850 \
 "


### PR DESCRIPTION
It's required that YP Compatible layers don't depend on non-compatible layers. Also the wrynose/linux-firmware branch of the mixins is not a part of the Yocto Autobuilder. Make sure that meta-qcom layer builds without the extra layers.

Closes #2457 
 