### PR TITLE
ci: add fragment to perform builds without OpenGL and OpenCL

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -299,6 +299,14 @@ jobs:
           # Additional builds for specific machines
           - machine: qcom-armv8a
             distro:
+                name: nodistro-nogl
+                yamlfile: ':ci/test-oe-nogl.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: qcom-armv8a
+            distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:

--- a/ci/test-oe-nogl.yml
+++ b/ci/test-oe-nogl.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+repos:
+  meta-openembedded:
+    url: https://github.com/openembedded/meta-openembedded
+    patches:
+      plain:
+        repo: meta-qcom
+        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
+    layers:
+      meta-oe:
+
+local_conf_header:
+  nogl: |
+    DISTRO_FEATURES:remove = "opengl"

--- a/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
@@ -32,7 +32,7 @@ COMPATIBLE_MACHINE:aarch64 = "(.*)"
 PACKAGE_BEFORE_PN += " \
     ${PN}-common \
     ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', '${PN}-gles1 ${PN}-gles2 ${PN}-egl', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', '${PN}-vulkan', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl vulkan', '${PN}-vulkan', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${PN}-cl', '', d)} \
 "
 
@@ -47,7 +47,7 @@ RDEPENDS:${PN}-dev += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'opencl
 
 RDEPENDS:${PN} = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'qcom-adreno-egl', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'qcom-adreno-vulkan', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl vulkan', 'qcom-adreno-vulkan', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno-cl', '', d)} \
 "
 
@@ -74,7 +74,7 @@ do_install () {
             ${D}${libdir}/libEGL_*.so*
     fi
 
-    if ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'true', 'false', d)}; then
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opengl vulkan', 'true', 'false', d)}; then
         install -d ${D}${datadir}/vulkan/icd.d
         cp ${S}/usr/share/vulkan/icd.d/adrenovk.json ${D}${datadir}/vulkan/icd.d/
     else

--- a/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
@@ -29,7 +29,12 @@ COMPATIBLE_MACHINE = "^$"
 # qcom-armv8a machine.
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
 
-PACKAGE_BEFORE_PN += " ${PN}-common ${PN}-gles1 ${PN}-gles2 ${PN}-egl ${PN}-vulkan ${PN}-cl"
+PACKAGE_BEFORE_PN += " \
+    ${PN}-common \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', '${PN}-gles1 ${PN}-gles2 ${PN}-egl', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', '${PN}-vulkan', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${PN}-cl', '', d)} \
+"
 
 RPROVIDES:${PN}-egl += "virtual-egl-icd"
 RPROVIDES:${PN}-cl += "virtual-opencl-icd"
@@ -49,30 +54,43 @@ RDEPENDS:${PN} = " \
 ALLOW_EMPTY:${PN} = "1"
 
 do_install () {
-    if ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'true', 'false', d)}; then
-        install -d ${D}${includedir}/CL
-        cp ${S}/usr/include/CL/cl_ext_qcom.h ${D}${includedir}/CL/
-    fi
-
     install -d ${D}/${libdir}
     cp -r ${S}/usr/lib/* ${D}/${libdir}/
 
-    if ! ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'true', 'false', d)}; then
-        rm ${D}/${libdir}/libeglSubDriverX11.so*
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'true', 'false', d)}; then
+        install -d ${D}${datadir}/glvnd/egl_vendor.d
+        cp ${S}/usr/share/glvnd/egl_vendor.d/10_adreno.json ${D}${datadir}/glvnd/egl_vendor.d/
+
+        if ! ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'true', 'false', d)}; then
+            rm ${D}${libdir}/libeglSubDriverX11.so*
+        fi
+
+        if ! ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'true', 'false', d)}; then
+            rm ${D}${libdir}/libeglSubDriverWayland.so*
+        fi
+    else
+        rm  ${D}${libdir}/libeglSubDriver*.so* \
+            ${D}${libdir}/libGLES*.so* \
+            ${D}${libdir}/libEGL_*.so*
     fi
 
-    if ! ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'true', 'false', d)}; then
-        rm ${D}/${libdir}/libeglSubDriverWayland.so*
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'true', 'false', d)}; then
+        install -d ${D}${datadir}/vulkan/icd.d
+        cp ${S}/usr/share/vulkan/icd.d/adrenovk.json ${D}${datadir}/vulkan/icd.d/
+    else
+        rm ${D}${libdir}/libvulkan_*.so*
     fi
 
-    install -d ${D}${datadir}/glvnd/egl_vendor.d
-    cp ${S}/usr/share/glvnd/egl_vendor.d/10_adreno.json ${D}${datadir}/glvnd/egl_vendor.d/
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'true', 'false', d)}; then
+        install -d ${D}${includedir}/CL
+        cp ${S}/usr/include/CL/cl_ext_qcom.h ${D}${includedir}/CL/
 
-    install -d ${D}${datadir}/vulkan/icd.d
-    cp ${S}/usr/share/vulkan/icd.d/adrenovk.json ${D}${datadir}/vulkan/icd.d/
-
-    install -d ${D}${sysconfdir}/OpenCL/vendors
-    cp ${S}/etc/OpenCL/vendors/adrenocl.icd ${D}${sysconfdir}/OpenCL/vendors/
+        install -d ${D}${sysconfdir}/OpenCL/vendors
+        cp ${S}/etc/OpenCL/vendors/adrenocl.icd ${D}${sysconfdir}/OpenCL/vendors/
+    else
+        rm  ${D}${libdir}/libOpenCL_*.so* \
+            ${D}${libdir}/libCB*.so*
+    fi
 
     install -d ${D}${sysconfdir}/modprobe.d
     cp ${S}/etc/modprobe.d/qcom-adreno.conf ${D}/${sysconfdir}/modprobe.d/qcom-adreno.conf

--- a/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.855.5.bb
@@ -14,7 +14,8 @@ PBT_BUILD_DATE = "260608"
 SRC_URI[sha256sum] = "771b20cd2bfbbef08f707af6ff8c765027c8351cf24c767d9698ca9acda2c599"
 
 # These are listed here in order to identify RDEPENDS
-DEPENDS += " glib-2.0 libdrm virtual/libgbm msm-gbm-backend \
+DEPENDS += " glib-2.0 libdrm \
+             ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/libgbm msm-gbm-backend', '', d)} \
              ${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', '', d)} \
              ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
              ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxcb libx11 xcb-util-image', '', d)}"

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -50,9 +50,12 @@ PACKAGE_INSTALL_openembedded-layer += " \
     makedumpfile \
     mbw \
     ncurses-terminfo-base \
-    pipewire-tools \
     sysbench \
     tinymembench \
     tiobench \
     whetstone \
+"
+
+PACKAGE_INSTALL_multimedia-layer += " \
+    pipewire-tools \
 "

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -21,7 +21,7 @@ PACKAGE_INSTALL += " \
     util-linux \
     util-linux-chrt \
     util-linux-lsblk \
-    weston-examples \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'weston-examples', '', d)} \
 "
 
 PACKAGE_INSTALL:append:aarch64 = " \


### PR DESCRIPTION
There are recipes (like CamX) which have hidden dependencies on OpenGL and OpenCL. Verify that those recipes don't break the build for the GL-less distributions.