### PR TITLE
ci: performance: enable NM wait-online override

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -4,3 +4,5 @@ header:
 local_conf_header:
   cmdline-perf: |
     KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"
+    # Do not wait for NetworkManager startup-complete in wait-online.
+    NETWORKMANAGER_WAIT_ONLINE_WAIT_FOR_STARTUP = "0"


### PR DESCRIPTION
Enable the NetworkManager wait-online override only for performance builds by setting:

    NETWORKMANAGER_WAIT_ONLINE_WAIT_FOR_STARTUP = "0"

This keeps the generic distro behavior unchanged while applying the boot-time optimization in performance profile.