### PR TITLE
Add Qcom SDX75 SoC and IDP board support

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -417,6 +417,14 @@ jobs:
                 type: u-boot-qcom-fit-6.18
                 dirname: "_linux-qcom-6.18_u-boot-qcom-fit"
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml:ci/kernel-fit-image.yml"
+          - machine: sdx75-idp
+            distro:
+                name: nodistro
+                yamlfile: ""
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}

--- a/ci/sdx75-idp.yml
+++ b/ci/sdx75-idp.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: sdx75-idp
+
+target:
+  - core-image-minimal

--- a/conf/machine/include/qcom-sdx75.inc
+++ b/conf/machine/include/qcom-sdx75.inc
@@ -1,0 +1,20 @@
+SOC_FAMILY = "sdx75"
+require conf/machine/include/qcom-common.inc
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-qcom-next"
+
+DEFAULTTUNE = "cortexa55"
+require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
+
+KERNEL_IMAGETYPE = "Image"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    qrtr \
+    rmtfs \
+    tqftpserv \
+    pd-mapper \
+"
+
+# UBI filesystem settings
+IMAGE_FSTYPES = "ubi"
+QCOM_BOOTIMG_PAGE_SIZE ?= "4096"

--- a/conf/machine/sdx75-idp.conf
+++ b/conf/machine/sdx75-idp.conf
@@ -1,0 +1,13 @@
+#@TYPE: Machine
+#@NAME: Qualcomm SDX75 IDP
+#@DESCRIPTION: Machine configuration for Qualcomm SDX75 IDP board
+
+require conf/machine/include/qcom-sdx75.inc
+
+KERNEL_DEVICETREE ?= " \
+    qcom/sdx75-idp.dtb \
+"
+
+# UBI filesystem parameters for NAND flash
+MKUBIFS_ARGS ?= "-m 4096 -e 253952 -c 1024"
+UBINIZE_ARGS ?= "-m 4096 -p 262144"


### PR DESCRIPTION
Qcom SDX75 is the modem SoC supported in mainline kernel. This PR adds the SoC and IDP reference board support. This board features NAND as the storage medium as like its predecessor SDX55. Hence, added the necessary UBI configurations as well.