### PR TITLE
firmware-qcom: make split packages installable

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom.inc
+++ b/recipes-bsp/firmware/firmware-qcom.inc
@@ -43,9 +43,7 @@ python() {
     pn = d.getVar("PN")
     insanes = d.getVar("INSANE_SKIP:%s" % pn)
     for pkg in d.getVar("SPLIT_FIRMWARE_PACKAGES").split():
-        # Depend on the main package to get the license file
-        d.appendVar("RDEPENDS:" + pkg, " " + pn)
-        # and append the INSANE_SKIP of the main package to pass QA
+        # append the INSANE_SKIP of the main package to pass QA
         d.appendVar("INSANE_SKIP:" + pkg, " " + insanes)
     if d.getVar("FW_QCOM_NAME") == "unset" and d.getVar("SPLIT_FIRMWARE_PACKAGES") != "":
         bb.error("%s: split firmware-qcom packages engaged, but FW_QCOM_NAME is not defined" % pn)


### PR DESCRIPTION
Since the commit 77e6f4504d9b ("firmware-qcom-nhlos: make sure that meta firmware package is empty") the main package in the split firmware doesn't have any files and thus is skipped by OE. All split firmware packages depend on PN, which can't be fond. Drop the manual dependency, making all split packages installable again.

Closes #2504 