### PR TITLE
Fix meta-selinux commit SHA mismatch

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -15,7 +15,7 @@ overrides:
         meta-audioreach:
             commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
         meta-selinux:
-            commit: 1c3a699f363167571ab39fecb0fe6f56691a4e20
+            commit: 1c30b4eddcef9e0594dd15c15e1f675e2a0c93a2
         meta-updater:
             commit: f0e1ccafaa877d2781ed953236981dac57439dc8
         meta-security:


### PR DESCRIPTION
The current meta-selinux commit 1c3a699, points to the wrynose branch, while the meta-qcom tracks master branch. This mismatch is causing KAS setup failures. Replace it with the corresponding master commit 1c30b4e to ensure consistent builds.