### PR TITLE
[Wrynose] Pin meta-qcom-distro SHA for GA readiness

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -10,6 +10,8 @@ overrides:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
+        meta-qcom-distro:
+            commit: b2e5c1c48acd84dd6f76bce5da91870d921ef075
         meta-openembedded:
             commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
         meta-virtualization:


### PR DESCRIPTION
With QLI 2.0 GA release around the corner, pin the meta-qcom-distro commit to ensure reproducible builds. This lock can be removed post GA release to simplify the build process.