### PR TITLE
Update OpenGL/OpenCL dependencies in camxlib

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.24.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.24.bb
@@ -20,8 +20,12 @@ SRC_URI[chicdk.sha256sum] = "8adc152ebdb6d0a105f9b4f8ccaae0bfde9f05058605ebcc07b
 
 S = "${UNPACKDIR}"
 
-DEPENDS += "glib-2.0 fastrpc protobuf-camx libxml2 virtual/egl virtual/libgles2 qmi-framework sensinghub qcom-sensors-binaries \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
+DEPENDS += "glib-2.0 fastrpc protobuf-camx libxml2 qmi-framework sensinghub qcom-sensors-binaries"
+
+DEPENDS += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virtual/libgles2', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual/libopencl1', '', d)} \
+"
 
 # This package is currently only used and tested on ARMv8 (aarch64) machines.
 # Therefore, builds for other architectures are not necessary and are explicitly excluded.
@@ -36,6 +40,20 @@ do_install:append() {
     install -d ${D}${datadir}/doc/chicdk-kodiak
 
     cp -r ${S}/usr/lib/* ${D}${libdir}
+
+    # Remove OpenCL-dependent libraries when opencl is not enabled.
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'false', 'true', d)}; then
+        rm -f ${D}${libdir}/camx/kodiak/*.cl
+        rm -f ${D}${libdir}/camx/kodiak/lib_algo_svhdr*
+        rm -f ${D}${libdir}/camx/kodiak/camera/components/libshdr3*
+        rm -f ${D}${libdir}/camx/kodiak/camera/components/libbanding_correction*
+    fi
+
+    # Remove OpenGL/EGL-dependent libraries when opengl is not enabled.
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'false', 'true', d)}; then
+        rm -f ${D}${libdir}/camx/kodiak/camera/components/libiwarp*
+    fi
+
     # copy Deep Learning based binary
     cp -r ${S}/usr/share/camx ${D}${datadir}
     # copy skel file

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
@@ -8,7 +8,8 @@ SRC_URI[camx.sha256sum] = "b84903c48932462e4373934c7c10d311b8ad80f5ff822375de300
 SRC_URI[chicdk.sha256sum] = "e563a96bc45f4685d0b7514400a1a81d07cb1b48c3dc2bef19438a48f2d09986"
 SRC_URI[camxcommon.sha256sum] = "91d79a5530f926571e6921bd38b8eb22d7b223867cd2d375d28441e2282c88c1"
 
-DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual/libopencl1', '', d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virtual/libgles2', '', d)}"
 
 do_install:append() {
     # Copy json only when /etc folder exists in ${S}
@@ -20,6 +21,13 @@ do_install:append() {
     cp -r ${S}/usr/share/camx ${D}${datadir}
     # copy skel file
     cp -r ${S}/usr/share/qcom ${D}${datadir}
+
+    # Remove OpenCL-dependent libraries when opencl is not enabled.
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'false', 'true', d)}; then
+        rm -f ${D}${libdir}/camx/${PLATFORM}/*.cl
+        rm -f ${D}${libdir}/camx/${PLATFORM}/libmctf_cl_program.bin
+        rm -f ${D}${libdir}/camx/${PLATFORM}/libmctfengine_stub*
+    fi
 }
 
 RPROVIDES:${PN} = "camxlib-monaco"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.27.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.27.bb
@@ -8,4 +8,11 @@ SRC_URI[camx.sha256sum] = "bab2573930951360e58eca159eec8c5777043eb6c1c57725dffae
 SRC_URI[chicdk.sha256sum] = "9b08fe81bc9177826fe5d9aff185de16bdb216cab20304bfea60a8c8a5c2eb48"
 SRC_URI[camxcommon.sha256sum] = "9e8a7b595242916962bb018f2dffc3136c399f1bf80b0aecd91f4ac97f6293f9"
 
-DEPENDS += "virtual/egl virtual/libgles2 ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'qcom-adreno virtual/libopencl1', '', d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual/libopencl1', '', d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virtual/libgles2', '', d)}"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'opengl opencl', 'false', 'true', d)}; then
+        rm -f ${D}${libdir}/camx/${PLATFORM}/camera/components/libiwarp*
+    fi
+}


### PR DESCRIPTION

camxlib-kodiak: guard OpenGL/OpenCL dependencies
Replace unconditional dependency on OpenGL (EGL/GLES2) and
OpenCL libraries with DISTRO_FEATURES-based guards.
This ensures the dependencies are enabled only when
opengl/opencl features are present, allowing camx to build
successfully in configurations where these features are disabled.

camxlib-lemans: Updated OpenGL/OpenCL dependency handling
Introduce DISTRO_FEATURES-based handling for OpenCL and
OpenGL (EGL/GLES2) dependencies.
Added guard logic to remove OpenCL/OpenGL dependent libs
when opengl/opencl distro features are disabled.
This ensures camx builds successfully when opengl/opencl
features are disabled and aligns with Yocto best practices
for optional GPU/compute components.

camxlib-talos: Updated OpenGL/OpenCL dependency handling
Introduce DISTRO_FEATURES-based handling for OpenCL and
OpenGL (EGL/GLES2) dependencies.
Added guard logic to remove OpenCL/OpenGL dependent libs
when opengl/opencl distro features are disabled.
This ensures camx builds successfully when opengl/opencl
features are disabled and aligns with Yocto best practices
for optional GPU/compute components.


qli-2.0 GA Critical Fix