### PR TITLE
sensors: upgrade 1.2.1 -> 2.0.2

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_2.0.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_2.0.2.bb
@@ -5,13 +5,14 @@ validate sensor services functionality through the Sensinghub Interface."
 LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom-2;md5=f33ba334514c4dfabc6ab7377babb377"
 
-PBT_BUILD_DATE = "260514.1"
-SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "507652592b326bfeb1b31c4c37f61a5173439bd3dffa7ded72b675f834ea11bb"
+PBT_BUILD_DATE = "260806"
+SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.qli.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
+SRC_URI[sha256sum] = "e3299ed5dba4c76c6efe1914134942aea0445f40011bf11116470de2ae0a20c6"
 
 S = "${UNPACKDIR}"
 
 DEPENDS = "glib-2.0 protobuf-camx sensinghub qmi-framework libdiag fastrpc"
+RDEPENDS:${PN} += "rpmsgexport"
 
 inherit systemd
 
@@ -28,15 +29,18 @@ do_install() {
     install -d ${D}${sysconfdir}/sensors/config
     install -d ${D}${sysconfdir}/sensors/registry
     install -d ${D}${systemd_system_unitdir}
+    install -d ${D}${sysconfdir}/udev/rules.d
 
     # Install binaries
     install -m 0755 ${S}/usr/bin/* ${D}${bindir}/
 
     # Install library
     oe_libinstall -C ${S}/usr/lib -so libsensinghubapiprop ${D}${libdir}
+    oe_libinstall -C ${S}/usr/lib -so libsensinghubapipropc ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshQmiIDL ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshSession ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsnsdiaglog ${D}${libdir}
+    oe_libinstall -C ${S}/usr/lib -so libsnsdiaglog-c ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libUSTANative ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libSEESalt ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsns_direct_channel_stub ${D}${libdir}
@@ -46,6 +50,7 @@ do_install() {
     install -m 0644 ${S}/etc/sensors/sns_reg_config ${D}${sysconfdir}/sensors/
     install -m 0644 ${S}/etc/sensors/config/* ${D}${sysconfdir}/sensors/config/
     install -m 0644 ${S}/etc/sensors/registry/sns_reg_version ${D}${sysconfdir}/sensors/registry/
+    install -m 0644 ${S}/etc/udev/rules.d/99-rpmsg.rules ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${S}${systemd_system_unitdir}/sscrpcd.service ${D}${systemd_system_unitdir}/sscrpcd.service
 
     # Install pkgconfig

--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_2.0.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/qcom-sensors-binaries_2.0.2.bb
@@ -5,9 +5,9 @@ validate sensor services functionality through the Sensinghub Interface."
 LICENSE = "LicenseRef-LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom-2;md5=f33ba334514c4dfabc6ab7377babb377"
 
-PBT_BUILD_DATE = "260514.1"
-SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
-SRC_URI[sha256sum] = "507652592b326bfeb1b31c4c37f61a5173439bd3dffa7ded72b675f834ea11bb"
+PBT_BUILD_DATE = "260811.1"
+SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/sensors.qli.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-sensors-prebuilts_${PV}_armv8a.tar.gz"
+SRC_URI[sha256sum] = "344209231dd07d25c83e890b08ec4013392184f1badb41da8fb5c8a885ecacc1"
 
 S = "${UNPACKDIR}"
 
@@ -34,9 +34,11 @@ do_install() {
 
     # Install library
     oe_libinstall -C ${S}/usr/lib -so libsensinghubapiprop ${D}${libdir}
+    oe_libinstall -C ${S}/usr/lib -so libsensinghubapipropc ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshQmiIDL ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libQshSession ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsnsdiaglog ${D}${libdir}
+    oe_libinstall -C ${S}/usr/lib -so libsnsdiaglog-c ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libUSTANative ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libSEESalt ${D}${libdir}
     oe_libinstall -C ${S}/usr/lib -so libsns_direct_channel_stub ${D}${libdir}

--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_2.2.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_2.2.3.bb
@@ -4,11 +4,11 @@ HOMEPAGE = "https://github.com/qualcomm/sensinghub"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9701d0ef17353f1d05d7b74c8712ebbd"
 
-SRCREV = "c08dcfa05a39aaf7d9b7f3241f612d29a2df1073"
+SRCREV = "6d7e56b85a518a514585efddec5e4a349e13d37d"
 
 SRC_URI = "git://github.com/qualcomm/sensinghub.git;protocol=https;branch=main;tag=v${PV}"
 
-DEPENDS = "protobuf protobuf-native glib-2.0"
+DEPENDS = "protobuf protobuf-native glib-2.0 nanopb-runtime nanopb-generator-native"
 
 inherit autotools pkgconfig
 

--- a/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_2.2.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/sensors/sensinghub_2.2.3.bb
@@ -4,11 +4,11 @@ HOMEPAGE = "https://github.com/qualcomm/sensinghub"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9701d0ef17353f1d05d7b74c8712ebbd"
 
-SRCREV = "c08dcfa05a39aaf7d9b7f3241f612d29a2df1073"
+SRCREV = "6d7e56b85a518a514585efddec5e4a349e13d37d"
 
 SRC_URI = "git://github.com/qualcomm/sensinghub.git;protocol=https;branch=main;tag=v${PV}"
 
-DEPENDS = "protobuf-camx protobuf-camx-native glib-2.0"
+DEPENDS = "protobuf-camx protobuf-camx-native glib-2.0 nanopb-runtime nanopb-generator-native"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
Upgraded sensor binaries from 1.2.1 to 2.0.2 and migrated
protobuf implementation to a nanopb-based implementation.