### PR TITLE
camx: Add camxlib-kodiak-skel and camxlib-lemans-skel as runtime dependency

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.24.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.24.bb
@@ -70,7 +70,7 @@ do_install:append() {
 }
 
 PACKAGE_BEFORE_PN += "camx-kodiak chicdk-kodiak ${PN}-skel"
-RDEPENDS:${PN} += "chicdk-kodiak"
+RDEPENDS:${PN} += "chicdk-kodiak ${PN}-skel"
 RDEPENDS:${PN}-dev += "camxcommon-headers-dev"
 RRECOMMENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual-opencl-icd', '', d)} sensinghub qcom-sensors-binaries"
 

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
@@ -24,6 +24,7 @@ do_install:append() {
 
 RPROVIDES:${PN} = "camxlib-monaco"
 PACKAGE_BEFORE_PN += "camx-nhx ${PN}-skel"
+RDEPENDS:${PN} += "${PN}-skel"
 RRECOMMENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual-opencl-icd', '', d)}"
 
 FILES:camx-nhx = "\


### PR DESCRIPTION
Include ${PN}-skel in RDEPENDS:${PN} to ensure required skel package components are pulled in during runtime.

qli-2.0 GA Critical Fix