### PR TITLE
ci: update lava-test-plans and testkit refs to pick up test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "d02dbbca3e35c3f29dce5aa4c1eac506103f821d"
+  LAVA_TEST_PLANS_REF: "c84869fd7c27eb9869f63098d3686e0a3ce09153"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.06.10"
+  TESTKIT_REF: "testkit-2026.06.21"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
Bump LAVA_TEST_PLANS_REF and TESTKIT_REF to testkit-2026.06.21 to pull in stability fixes since 2026.06.10: exclude WiFi, audio and adsp_remoteproc on affected platforms to unblock pre-merge, fix hotplug to handle transient EBUSY CPUs, improve Bluetooth adapter selection and logging, fix WiFi_OnOff recovery to avoid false BT device-tree matches, and fix soccp remoteproc status check.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>