### PR TITLE
Enable Glymur camx DTB compilation for linux-qcom-next kernel

### DIFF
--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -17,6 +17,11 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/glymur-staging.dtbo \
 "
 
+# These DTs are not upstreamed and currently exist only in linux-qcom-next kernel
+KERNEL_DEVICETREE:append:pn-linux-qcom-next = " \
+    qcom/glymur-crd-camx.dtbo \
+"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-glymur-crd-firmware \
     packagegroup-glymur-crd-hexagon-dsp-binaries \

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -213,3 +213,4 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
 # ---------- glymur ----------
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
+FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"


### PR DESCRIPTION
Downstream camera DTB is not included in the final image
when building linux-qcom-next, kernel for the glymur crd 
board. This prevents the downstream camera stack from being
enabled at boot, even though the kernel supports it.

Include the downstream camera DTB so it is packaged into
the final image and downstream camera functionality is
available for the Glymur crd.

Add multi-DTB support for camx overlay to enable downstream
camera for Glymur crd (glymur-crd-camx).