### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260615.1 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260615
-SRCREV ?= "360986b713f88d182fb17fdf5decedf665a77834"
+# tag:qcom-6.18.y-20260615.1
+SRCREV ?= "5086fd78561b5f1a8824806decd2e9bf2cfe3d6f"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260615.1

Changelog:

QCLINUX: arm64: dts: qcom: talos: Add GMSL deserializer and sensor
FROMLIST: misc: fastrpc: map ADSP remote heap into remoteproc IOMMU domain
QCLINUX: qcom.config: Enable Intel IXGBE driver
Revert "net: stmmac: dwmac-qcom-ethqos: Use max frequency for clk_ptp_ref"
Revert "FROMLIST: arm64: dts: qcom: monaco: fix wrong connection for the replicator"
WORKAROUND: arm64: dts: qcom: Add qref supply for PCIe PHYs
WORKAROUND: phy: qcom: qmp-pcie: add x1e80100 qref supplies
FROMLIST: PCI: qcom: Set max OPP before DBI access during resume
FROMLIST: arm64: dts: qcom: monaco-evk-emmc: Remove explicit UFS disablement