### PR TITLE
fit-dtb-compatible: add Kodiak CAMX EL2/KVM combo

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -203,6 +203,14 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-el2kvm] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-el2kvm] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-staging] = \
     "qcs6490-rb3gen2 qcs5430-fps-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-staging] = \


### PR DESCRIPTION
Add FIT_DTB_COMPATIBLE entries for the Kodiak CAMX EL2/KVM boot configurations so the bootloader can select the FIT configuration that stacks the camx overlay on top of the base DTB and kodiak-el2 overlay.

Covers qcs5430 (fps-camx), qcs6490 (vision-mezzanine-camx), and their subtype2 variants.