### PR TITLE
README: track wrynose branch in CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # meta-qcom
 
-[![Build on push](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?label=Build%20on%20push)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml)
-[![Nightly Build](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?label=Nightly%20Build)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml)
+[![Build on push](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?branch=wrynose&label=Build%20on%20push)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml?query=branch%3Awrynose)
+[![Nightly Build](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?branch=wrynose&label=Nightly%20Build)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml?query=branch%3Awrynose)
 
 ## Introduction
 


### PR DESCRIPTION
The "Build on push" and "Nightly Build" badges defaulted to the repository default branch (master). On the wrynose LTS branch they should reflect wrynose CI status instead.

Add branch=wrynose to the shields.io image URLs so the badges report this branch's status, and query=branch:wrynose to the workflow links so clicking through opens the runs filtered to wrynose.