### PR TITLE
adreno: Update to 1.877.2

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.877.2.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.877.2.bb
@@ -10,8 +10,8 @@ LIC_FILES_CHKSUM = "file://NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=4ceffe94cb40cdce6
 
 # no top-level dir in the archive, unpack to subdir to prevent UNPACKDIR pollution
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/gfx-adreno.le.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8a.tar.gz;subdir=${BP}"
-PBT_BUILD_DATE = "260608"
-SRC_URI[sha256sum] = "771b20cd2bfbbef08f707af6ff8c765027c8351cf24c767d9698ca9acda2c599"
+PBT_BUILD_DATE = "260702"
+SRC_URI[sha256sum] = "0bdc3a737f7529b9673bd8c895ddf823b40f0f3708ed1c345f0bb21a088a37b7"
 
 # These are listed here in order to identify RDEPENDS
 DEPENDS += " glib-2.0 libdrm \
@@ -89,7 +89,9 @@ do_install () {
         cp ${S}/etc/OpenCL/vendors/adrenocl.icd ${D}${sysconfdir}/OpenCL/vendors/
     else
         rm  ${D}${libdir}/libOpenCL_*.so* \
-            ${D}${libdir}/libCB*.so*
+            ${D}${libdir}/libCB*.so* \
+            ${D}${libdir}/libkcl*.so* \
+            ${D}${libdir}/libkernelmanager*.so*
     fi
 
     install -d ${D}${sysconfdir}/modprobe.d
@@ -112,6 +114,8 @@ FILES:${PN}-vulkan = "${libdir}/libvulkan_*.so.* \
                       ${datadir}/vulkan/icd.d/adrenovk.json"
 FILES:${PN}-cl = "${libdir}/libOpenCL_*.so.* \
                   ${libdir}/libCB.so.1 \
+                  ${libdir}/libkcl.so.1 \
+                  ${libdir}/libkernelmanager.so.1 \
                   ${sysconfdir}/OpenCL/vendors/adrenocl.icd"
 FILES:${PN} = ""
 


### PR DESCRIPTION
Update qcom-adreno version from 1.855.5 to 1.877.2

CHANGES for 1.877.2:
* Vulkan:
  * Enable VK_EXT_external_memory_dma_buf on Linux targets and add
    zwp_linux_dmabuf protocol support for Wayland DMA-BUF buffer sharing.
  * Add B10G10R10A2_UNORM and B8G8R8A8_UNORM_SRGB as new Linux surface formats
    required by gnome-shell and graphics benchmarks.
  * Implement dynamic selection between DRI3 and DRIless presentation paths,
    with correct compositeAlpha flag handling for Wayland swapchain format
    selection.
  * Fix OOM error propagation during Wayland surface initialization, resolve
    X11 window resize event handling and XCB pixmap resource leaks.
* OpenGL ES:
  * Enable DRI3 presentation by default with an environment toggle
    (DISABLE_DRI3) and robust fallback to improve Linux desktop display
    performance.
  * Refactor Wayland buffer backend and wl_drm protocol handling.
  * Add zwp protocol integration to improve Wayland interoperability.
  * Fix GBM buffer object CPU mapping validation and align GBM buffer
    mapping/unmapping behavior to prevent invalid memory access.
  * Fix zwp_linux_buffer_params_v1 resource leak after immediate buffer
    creation and free XCB pixmap after PresentBuffer to prevent X server
    resource exhaustion.
  * Reduce display pipeline stalls by polling and picking the first free buffer
    under DRI3, and use correct graphics usage bits for DMA buffer alignment.
* OpenCL:
  * Upgrade qcs615 OpenCL version to 3.0.
  * Add libkcl.so.1 and libkernelmanager.so.1 new libraries to support
    cl_qcom_ml_ops extension for qcs9100, qcs8300 and qcm6490.
  * Add CL_QCOM_NV21 image format support for A8X targets.
  * Fix OpenCL CTS runtime program compilation issues.