### PR TITLE
Update boot to 00130 for QCS9100 and QCS8300

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00128.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "9f32e0c45bcbfe2bf05e540c1be974180e7b4432d9cb20d63c903b5d426cd2ab"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00130.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00130.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "e202c36dd5b5dcb81a3014dca3cafaef0044d71dda5e3a8adbb355655b4b2a81"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00128.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "1d2c6a05abe05af7a2376fd1bd983725661631b43eff188fa227a90042ab99ac"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00130.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00130.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "4e4fe94a4dad8a31319b6e1aca28d089f8a363db81aaf0bb3ef8fc8c6e7d187b"


### PR DESCRIPTION
This PR updates boot for QCS8300 and  QCS9100.

 As part of this update, revert support for several features that have
 been found to cause system crashes during multiple reboot cycles.
    
The following features of the Real-Time Subsystem (RTSS) have been
reverted:
    - Sleep and Power Controller
    - Image OTA Update Support
    - Watchdog Timer Support
    - Fast-boot Support
    
These features exhibit instability under stress conditions involving
repeated reboots. They will be re-introduced once the root cause of
the crashes has been identified and resolved.