### PR TITLE
Bump meta-qcom-distro revision for default Weston background

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -11,7 +11,7 @@ overrides:
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
         meta-qcom-distro:
-            commit: b2e5c1c48acd84dd6f76bce5da91870d921ef075
+            commit: 775dc8c710f382ef8183000e7f0d40bc7dcf61cc
         meta-openembedded:
             commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
         meta-virtualization:


### PR DESCRIPTION
Update meta-qcom-distro revision to commit 775dc8c to include the default Qualcomm background image for Weston for enhanced user experience.