### PR TITLE
diag-router: bump up diag-router version

### DIFF
--- a/recipes-test/diag-router/diag-router_1.0.3.bb
+++ b/recipes-test/diag-router/diag-router_1.0.3.bb
@@ -1,12 +1,12 @@
 SUMMARY = "Prebuilt Qualcomm diagnostic router application"
 DESCRIPTION = "Prebuilt routing application for diagnostic traffic"
 LICENSE = "LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://usr/share/doc/diag-router/NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=7a5da794b857d786888bbf2b7b7529c8"
+LIC_FILES_CHKSUM = "file://usr/share/doc/diag-router/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
 SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/core-technologies.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/diag-router_15.0+really${PV}_armv8a.tar.gz"
 
-PBT_BUILD_DATE = "251127"
-SRC_URI[sha256sum] = "18c7fbe1e3cd6ef470cee7fa17210419795060c5ac1e092e14af204580e2908a"
+PBT_BUILD_DATE = "260616"
+SRC_URI[sha256sum] = "88277ae47fb6febd04e2531b1e46027a3416ce540ba78c9e92d0abdbadbc9c94"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Bump up diag-router version from 1.0.2 to 1.0.3.

- Add support for LMCU