### PR TITLE
Bump the lts-linux-firmware-mixin layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -5,7 +5,7 @@ overrides:
         oe-core:
             commit: 06dd66e6220e5ce4ed4b9af4d8231ae5f0a8ce80
         meta-lts-mixins:
-            commit: 348a9eaaf3991e2329d0cef14dce23fabaef9191
+            commit: 11dcf7de2b3cf74fd11049684903b73206a69df6
         bitbake:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260519.bb
@@ -68,7 +68,6 @@ PACKAGE_BEFORE_PN =+ "\
     ${PN}-qcom-sa8775p-ride-gdsp \
     ${PN}-qcom-sdm845-hdk-adsp \
     ${PN}-qcom-sdm845-hdk-cdsp \
-    ${PN}-qcom-shikra-cqs-evk-cdsp \
     ${PN}-qcom-sm8750-mtp-adsp \
     ${PN}-qcom-sm8750-mtp-cdsp \
     ${PN}-radxa-dragon-q6a-adsp \
@@ -86,6 +85,12 @@ PACKAGE_BEFORE_PN =+ "\
     ${PN}-thundercomm-rb5-sdsp \
     ${PN}-thundercomm-rubikpi3-adsp \
     ${PN}-thundercomm-rubikpi3-cdsp \
+"
+# Dependent packages are only available from the lts-linux-firmware-mixins
+# layer and thus can't be enabled by default. Enable it for Qualcomm machines,
+# which also force enable the updated linux-firmware version.
+PACKAGES:append:qcom = " \
+    ${PN}-qcom-shikra-cqs-evk-cdsp \
 "
 
 LICENSE:${PN} = "dspso-WHENCE"

--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -3,9 +3,14 @@ SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
 inherit packagegroup
 
 QCOM_M2_WIFI_FIRMWARE = " \
-    linux-firmware-ath12k-qcc2072 \
     linux-firmware-ath12k-qcn9274 \
     linux-firmware-ath12k-wcn7850 \
+"
+# This package is only available from the lts-linux-firmware-mixins layer and
+# thus can't be enabled by default. Enable it for Qualcomm machines, which also
+# force enable the updated linux-firmware version.
+QCOM_M2_WIFI_FIRMWARE:append:qcom = " \
+    linux-firmware-ath12k-qcc2072 \
 "
 
 QCOM_M2_BT_FIRMWARE = " \

--- a/recipes-kernel/linux-firmware/linux-firmware_20260519.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_20260519.bbappend
@@ -1,0 +1,2 @@
+DEFAULT_PREFERENCE:qcom = "1"
+DEFAULT_PREFERENCE:class-devupstream:qcom = "-1"


### PR DESCRIPTION
Bumpt the linux-firmware mixin layer to the YP compatible revision.