### PR TITLE
[wrynose] ci: update lava-test-plans and testkit refs to pick up test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "d02dbbca3e35c3f29dce5aa4c1eac506103f821d"
+  LAVA_TEST_PLANS_REF: "c84869fd7c27eb9869f63098d3686e0a3ce09153"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.06.10"
+  TESTKIT_REF: "testkit-2026.06.21"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
Backport https://github.com/qualcomm-linux/meta-qcom/pull/2574.