### PR TITLE
image_types_qcom: install KVM uefi_dtbs variant into qcomflash for iq-x7181/x5121

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -144,7 +144,18 @@ create_qcomflash_pkg() {
         # SPI-NOR firmware, partition bins, CDT etc.
         if [ -d "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" ]; then
             install -d spinor
-            find "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor" -maxdepth 1 -type f -exec install -m 0644 {} spinor \;
+            # spinor boot firmware
+            for bfw in `find ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor -maxdepth 1 -type f \
+                    \( -name '*.bin' -o \
+                       -name '*.elf' -o \
+                       -name '*.fv'  -o \
+                       -name '*.lzma' -o \
+                       -name '*.mbn' -o \
+                       -name '*.melf' -o \
+                       -name '*.xz' -o \
+                       -name 'qsahara_*.xml' \)` ; do
+                install -m 0644 ${bfw} spinor
+            done
 
             # partition bins/xml files
             if [ -n "${QCOM_PARTITION_FILES_SUBDIR_SPINOR}" ]; then

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -153,7 +153,8 @@ create_qcomflash_pkg() {
                        -name '*.mbn' -o \
                        -name '*.melf' -o \
                        -name '*.xz' -o \
-                       -name 'qsahara_*.xml' \)` ; do
+                       -name 'qsahara_*.xml' \) \
+                    ! -name 'uefi_dtbs*.xz'` ; do
                 install -m 0644 ${bfw} spinor
             done
 
@@ -165,6 +166,12 @@ create_qcomflash_pkg() {
             # cdt file
             if [ -n "${QCOM_CDT_FILE}" ]; then
                 install -m 0644 ${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor/${QCOM_CDT_FILE}.bin spinor/cdt.bin
+            fi
+
+            # uefi dtb
+            if [ -n "${QCOM_UEFI_DTB}" ] && \
+                    [ -f "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor/${QCOM_UEFI_DTB}" ]; then
+                install -m 0644 "${DEPLOY_DIR_IMAGE}/${QCOM_BOOT_FILES_SUBDIR}/spinor/${QCOM_UEFI_DTB}" spinor/uefi_dtbs.xz
             fi
 
             # dtb image

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -37,6 +37,9 @@ IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 # XBL Config selection
 QCOM_XBL_CONFIG ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "xbl_config_kvm.elf", "xbl_config.elf", d)}"
 
+# UEFI DTB selection
+QCOM_UEFI_DTB ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "uefi_dtbs_kvm.xz", "uefi_dtbs.xz", d)}"
+
 # Android boot image settings
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "4096"


### PR DESCRIPTION
On iq-x7181-evk / iq-x5121-evk, KVM boot needs `uefi_dtbs_kvm.xz` instead of `uefi_dtbs.xz`. The spinor bulk-copy pulled both variants into the qcomflash package with no indication of which to use.

Add `QCOM_UEFI_DTB` to select the variant by the `kvm` MACHINE_FEATURE and install only that one as `uefi_dtbs.xz`, make sure the package always carries the right DTB under a stable name.

example build command:
```
kas build meta-qcom/ci/iq-x7181-evk.yml:meta-qcom/ci/qcom-distro-kvm.yml
```