### PR TITLE
camxlib-lemans: Reuse bitml  skel binary via symlink

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
@@ -55,7 +55,8 @@ FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${CAMX_OPENCL
 # - Library files are Pre-stripped  (already-stripped)
 # - skel binaries/library are not AArch64 (arch mismatch)      (arch)
 # - Files are installed under /usr/share (non-libdir path) (libdir)
-INSANE_SKIP:${PN}-skel += " arch libdir already-stripped"
+# - .so symlink is used for runtime DSP usage, not a dev artifact (dev-so)
+INSANE_SKIP:${PN}-skel += " arch libdir already-stripped dev-so"
 
 # Preserve ${PN}-skel naming to avoid ambiguity in package identification.
 DEBIAN_NOAUTONAME:${PN}-skel = "1"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.27.bb
@@ -21,6 +21,9 @@ do_install:append() {
     cp -r ${S}/usr/share/camx ${D}${datadir}
     # copy skel file
     cp -r ${S}/usr/share/qcom ${D}${datadir}
+    install -d ${D}${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp
+    ln -sr ${D}${datadir}/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp/libbitml_nsp_73nb_skel.so \
+        ${D}${datadir}/qcom/qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp/libbitml_nsp_73nb_skel.so
 
     # Remove OpenCL-dependent libraries when opencl is not enabled.
     if ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'false', 'true', d)}; then


### PR DESCRIPTION
camxlib-lemans: Skip dev-so QA for skel package

Skip dev-so QA for ${PN}-skel since skel binaries use .so names for runtime DSP usage and are not development symlinks.
Yocto dev-so QA check treats .so files as development artifacts,  which leads to false QA failures for ${PN}-skel. Extend INSANE_SKIP to include dev-so so that these runtime skel binaries are handled correctly.

camxlib-lemans: Reuse bitml skel binary via symlink

Add symlink for libbitml_nsp_73nb_skel.so in qcs8300 path to reuse sa8775p DSP skel binary and avoid duplication.
Reuse the existing sa8775p skel binary by creating a symlink in the qcs8300 path instead of installing a separate instance. This avoids duplication while keeping the expected filesystem layout for DSP runtime.