### PR TITLE
README: add wrynose CI status badges alongside master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # meta-qcom
 
-[![Build on push](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?label=Build%20on%20push)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml)
-[![Nightly Build](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?label=Nightly%20Build)](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml)
+[![Build on push (master)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?label=Build%20on%20push%20(master))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml)
+[![Nightly Build (master)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?label=Nightly%20Build%20(master))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml)
+
+[![Build on push (wrynose)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?branch=wrynose&label=Build%20on%20push%20(wrynose))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml?query=branch%3Awrynose)
+[![Nightly Build (wrynose)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?branch=wrynose&label=Nightly%20Build%20(wrynose))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml?query=branch%3Awrynose)
 
 ## Introduction
 


### PR DESCRIPTION
The "Build on push" and "Nightly Build" badges track the repository default branch (master). Add separate wrynose-labelled badges so the README also surfaces the wrynose LTS branch CI status without replacing the master badges.

Use branch=wrynose on the shields.io image URLs so the new badges report that branch's status, and query=branch:wrynose on the workflow links so clicking through opens the runs filtered to wrynose.