### PR TITLE
ci: fix test result reporting after re-runs and PR updates

### DIFF
--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -45,7 +45,28 @@ runs:
           INPUTS_SUMMARY_TITLE: ${{ inputs.summary_title }}
         run: |
           set -x
-          INPUT=$(for TESTJOB in $(find "${GITHUB_WORKSPACE}" -name "${INPUTS_PREFIX}.json")
+          # When a failed LAVA job is re-run, GitHub keeps the original failed
+          # job's "<distro>-test-job-<id>" artifact AND adds a new artifact for the
+          # re-submitted job (LAVA assigns a fresh, higher id). Both get downloaded
+          # here, so without de-duplication the stale failed job is counted again
+          # and the summary reports phantom failures even after a green re-run.
+          # Keep only the newest LAVA job (highest id) per device + test, keyed by
+          # (requested_device_type, description) which is stable across re-runs of
+          # the same job. The fields are read from the saved job-detail JSON.
+          declare -A KEEP_FILE
+          declare -A KEEP_ID
+          for TESTJOB in $(find "${GITHUB_WORKSPACE}" -name "${INPUTS_PREFIX}.json")
+          do
+              KEY=$(jq -r '"\(.requested_device_type)@@\(.description)"' "${TESTJOB}")
+              JOB_ID=$(jq -r '.id' "${TESTJOB}")
+              if [ -z "${KEEP_ID[$KEY]:-}" ] || [ "${JOB_ID}" -gt "${KEEP_ID[$KEY]}" ]; then
+                  KEEP_ID["$KEY"]="${JOB_ID}"
+                  KEEP_FILE["$KEY"]="${TESTJOB}"
+              fi
+          done
+          TESTJOBS=$(printf '%s\n' "${KEEP_FILE[@]}")
+
+          INPUT=$(for TESTJOB in ${TESTJOBS}
           do
               JOB_ID=$(cat "$TESTJOB" | jq ".id")
               JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"
@@ -148,7 +169,7 @@ runs:
           echo "" >> "${INPUTS_SUMMARY_FILE_NAME}"
           echo "| Job ID | Device | State | Health |" >> "${INPUTS_SUMMARY_FILE_NAME}"
           echo "| ---- | ---- | ---- | ---- |" >> "${INPUTS_SUMMARY_FILE_NAME}"
-          for TESTJOB in $(find "${GITHUB_WORKSPACE}" -name "${INPUTS_PREFIX}.json")
+          for TESTJOB in ${TESTJOBS}
           do
               JOB_ID=$(cat "${TESTJOB}" | jq ".id")
               JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -84,7 +84,7 @@ runs:
               TEST_RESULTS=$(for SUITE in $(echo "$JOB_SUITES" | jq -r -c ".results[]")
               do
                   if [ "${JOB_TYPE}" = "test" ]; then
-                      if [ "${JOB_STATE}" = "Finished" ] && [ ${JOB_HEALTH} = "Complete" ]; then
+                      if [ "${JOB_STATE}" = "Finished" ]; then
                           SUITE_NAME=$(echo "$SUITE" | jq -r ".name")
                           SUITE_ID=$(echo "$SUITE" | jq -r ".id")
                           SUITE_TESTS=$(curl -s "https://lava.infra.foundries.io/api/v0.2/jobs/$JOB_ID/suites/$SUITE_ID/tests/")

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,6 +8,15 @@ on:
     types:
       - completed
 
+# Cancel an in-flight test run for a PR when a newer commit (re)triggers the
+# build. This stops an orphaned commit's run from continuing to publish the
+# "Test Results" check and PR comment after the PR head has moved on, so the
+# only surviving results belong to the current head. Re-running failed jobs on
+# an existing run keeps the same run id and is therefore not cancelled.
+concurrency:
+  group: test-pr-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   pull-requests: write
@@ -93,6 +102,10 @@ jobs:
         with:
           file-path: pr-comment.txt
           pr-number: ${{ steps.pr_comment_prep.outputs.pr_number }}
+          # Update a single tagged comment per PR instead of posting a new one on
+          # every run, so the PR shows one current result instead of accumulating
+          # stale comments (one per run / per superseded commit).
+          comment-tag: test-results
 
   publish-test-results:
     uses: ./.github/workflows/publish-results.yml


### PR DESCRIPTION
Fix the "Test Results" check which can contain failures even after a fully green re-run by dropping stale re-run jobs and aborting older runs after the PR gets updated.