### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260626 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260615.1
-SRCREV ?= "5086fd78561b5f1a8824806decd2e9bf2cfe3d6f"
+# tag:qcom-6.18.y-20260626
+SRCREV ?= "8c49474603c0b1c278b8fe00ac4e735b92d78ce9"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260626

Changelog:
FROMLIST: ASoC: qcom: q6apm-dai: fallback to BUFFER_BYTES_MAX without reserved memory
FROMLIST: ASoC: qcom: q6apm-dai: fix carveout buffer sizing and SCM assignment
QCLINUX: prune.config: Enable the TI DP83867 PHY driver
PENDING: arm64: dts: qcom: shikra-cqs-evk: Enable display
PENDING: arm64: defconfig: Enable ILI7807S DSI panel driver
PENDING: arm64: dts: qcom: shikra-cqm-evk: Enable display and add ili7807s panel
PENDING: arm64: dts: qcom: shikra: Add MDSS display subsystem
FROMGIT: arm64: defconfig: Enable configs for Arduino VENTUNO Q
FROMLIST: arm64: defconfig: Enable Qualcomm PM4125 audio codec as module
FROMLIST: arm64: dts: qcom: shikra: fix interrupt specifier cell count
FROMGIT: dt-bindings: display/msm: qcm2290-mdss: Fix missing ranges in example
BACKPORT: arm64: dts: qcom: agatti: Fix IOMMU DT properties
FROMGIT: dt-bindings: media: venus: Fix iommus property
FROMGIT: dt-bindings: display: msm: qcm2290-mdss: Fix iommus property
Revert "Add Shikra (QCM2390) display support for CQS and CQM targets (#679)"
PENDING: iommu: arm-smmu: Add ACTLR settings for missing MDSS devices for new Shikra platform
PENDING: soc: qcom: pd-mapper: Add shikra PD support for CQM/CQS/IQS
FROMLIST: arm64: dts: qcom: qcm6490-idp: add and enable IPA node
PENDING: arm64: dts: qcom: shikra-cqs-evk: Enable display
PENDING: arm64: defconfig: Enable ILI7807S DSI panel driver
PENDING: arm64: dts: qcom: shikra-cqm-evk: Enable display and add ili7807s panel
PENDING: arm64: dts: qcom: shikra: Add MDSS display subsystem
PENDING: soc: qcom: llcc: Skip ECC interrupt setup on Shikra, pre-configured by DSF
PENDING: arm64: dts: qcom: shikra: Add gpio-reserved-ranges to tlmm
FROMLIST: soc: qcom: llcc: Add configuration data for Shikra SoC
FROMLIST: ASoC: qcom: q6apm-dai: add carveout SCM assignment for mDSP buffers
FROMLIST: arm64: dts: qcom: shikra: Add MDSP carveout memory and update APM DAIs memory regions
FROMLIST: dt-bindings: sound: qcom,q6apm-dai: add memory-region property
FROMLIST: ASoC: qcom: qdsp6: generalize GPR service domain
FROMLIST: ASoC: qcom: q6apm-dai: add VMID-based SCM assignment
FROMGIT: ASoC: qcom: q6apm: Add support for early buffer mapping on DSP
PENDING: arm64: dts: qcom: shikra: Add Adreno SMMU node
PENDING: arm64: dts: qcom: shikra: Add GPU cooling
PENDING: arm64: dts: qcom: shikra: Add A704 GPU support
FROMLIST: arm64: defconfig: Enable Qualcomm QAIF and WSA885X-I2C drivers
FROMLIST: arm64: dts: qcom: shikra-iqs-evk: Enable sound card support
FROMLIST: arm64: dts: qcom: shikra-cqs-evk: Enable sound card support
FROMLIST: arm64: dts: qcom: shikra-cqm-evk: Enable sound card support
FROMLIST: arm64: dts: qcom: shikra: Add soundwire and macro nodes
FROMLIST: arm64: dts: qcom: shikra: Add gpr node
FROMLIST: arm64: dts: qcom: shikra: Add QAIF CPU node for audio
FROMLIST: dt-bindings: sound: qcom,q6apm-dai: add optional qcom,vmid
FROMLIST: ASoC: dt-bindings: qcom,apr: Add modem_apps GLINK channel for shikra
PENDING: arm64: dts: qcom: shikra-iqs-evk: Add TC9563 PCIe switch node for PCIe
PENDING: arm64: dts: qcom: shikra-cqs-evk: Add TC9563 PCIe switch node for PCIe
PENDING: arm64: dts: qcom: shikra-cqm-evk: Add TC9563 PCIe switch node for PCIe
PENDING: arm64: dts: qcom: shikra: Add PCIe PHY and controller nodes
PENDING: PCI/pwrctrl: tc9563: Add API to control endpoint power and reset
PENDING: PCI: qcom: Add support for Shikra PCIe controller
PENDING: phy: qcom: qmp-pcie: Add QMP PCIe PHY support for Shikra
PENDING: dt-bindings: PCI: Add bindings for endpoint gpios
PENDING: dt-bindings: PCI: qcom: Document the Shikra PCIe Controller
PENDING: dt-bindings: phy: sc8280xp-qmp-pcie: Document Shikra PCIe phy
FROMLIST: ASoC: qcom: sc8280xp: add Shikra EVK machine variants
FROMLIST: ASoC: dt-bindings: qcom,sm8250: add Shikra sound card compatibles
FROMLIST: ASoC: qcom: sc8280xp: add TDM hw_params support
FROMLIST: ASoC: qcom: common: add DAI-node TDM slot helpers
FROMLIST: ASoC: qcom: q6prm: add Audio IF clock IDs
FROMLIST: dt-bindings: sound: qcom,q6dsp-lpass-ports: add Audio IF clocks
FROMLIST: ASoC: qcom: q6apm-lpass-dais: add TDM DAI operations
FROMLIST: ASoC: qcom: qdsp6: add topology-driven Audio IF support
FROMLIST: ASoC: qcom: sc8280xp: ASoC: qcom: sc8280xp: enhance machine driver for board-specific config
FROMLIST: ASoC: qcom: q6apm-lpass-dais: Add MI2S clock control
FROMLIST: ASoC: dt-bindings: qcom,q6apm-lpass-dais: Document DAI subnode
PENDING: arm64: dts: qcom: shikra: add reboot-mode support
FROMLIST: soundwire: qcom: add EE-aware register layout and cpu selection
FROMLIST: dt-bindings: soundwire: qcom: add qcom,swr-master-ee-val property
FROMGIT: soundwire: qcom: adding support for v3.1.0
FROMGIT: dt-bindings: soundwire: qcom: Document v3.1.0 version of IP block
FROMGIT: soundwire: qcom: prepare for v3.x
FROMLIST: ASoC: qcom: lpass-va-macro: Add shikra compatible
FROMLIST: ASoC: qcom: lpass-rx-macro: Add shikra compatible
FROMLIST: ASoC: qcom: Add Shikra QAIF support
FROMLIST: ASoC: qcom: Add QAIF IRQ handling, suspend/resume and platform register
FROMLIST: ASoC: qcom: Add QAIF PCM operations
FROMLIST: ASoC: qcom: Add QAIF regmap, DT parsing and platform init
FROMLIST: ASoC: qcom: lpass-cpu: Use asoc_qcom_of_xlate_dai_name helper
FROMLIST: ASoC: qcom: Add generic of_xlate_dai_name helper to common
FROMLIST: arm64: dts: qcom: Add changes for usb on IQS platform
PENDING: arm64: dts: qcom: Add typec role switching changes to shikra
FROMLIST: arm64: dts: qcom: Add USB changes for Shikra
FROMLIST: arm64: dts: qcom: shikra-iqs-evk: Enable both ethernet ports
FROMLIST: arm64: dts: qcom: shikra-cqs-evk: Enable ethernet0
FROMLIST: arm64: dts: qcom: shikra-cqm-evk: Enable ethernet0
FROMLIST: arm64: dts: qcom: shikra: Add ethernet nodes
FROMLIST: net: stmmac: qcom-ethqos: add Shikra EMAC support
FROMLIST: net: stmmac: qcom-ethqos: add per-platform NOC clock voting
FROMLIST: net: stmmac: qcom-ethqos: fix RGMII_ID mode to use DLL bypass
FROMLIST: net: stmmac: qcom-ethqos: convert ethqos_rgmii_macro_init() to void
FROMLIST: dt-bindings: net: qcom,ethqos: add qcom,shikra-ethqos compatible
BACKPORT: net: stmmac: qcom-ethqos: use read_poll_timeout_atomic()
BACKPORT: net: stmmac: qcom-ethqos: add rgmii set/clear functions
BACKPORT: net: stmmac: qcom-ethqos: use u32 for rgmii read/write/update
Revert "FROMLIST: net: stmmac: Inverse the phy-mode definition"
FROMLIST: ASoC: qcom: Add QAIF AIF DAI ops
FROMLIST: ASoC: qcom: Add QAIF CIF (CDC DMA) DAI ops
FROMLIST: ASoC: qcom: Add QAIF shared data structures and variant interface
FROMLIST: ASoC: qcom: Add QAIF hardware register map
FROMLIST: ASoC: codecs: add Qualcomm WSA885X I2C codec driver
FROMLIST: dt-bindings: sound: add qcom,wsa885x-i2c
WORKAROUND: usb: dwc3: qcom: Add support to keep GDSC On during host mode bus suspend
WORKAROUND: clk: qcom: gcc: Use gdsc_synced_poweroff_disable for USB GDSC's
FROMLIST: swiotlb: introduce Kconfig option for compile-time default pool size
WORKAROUND: clk: qcom: gdsc: Conditionally disable GDSC if synced_poweroff flag is set
FROMLIST: clk: qcom: gdsc: Add custom disable callback for GX GDSC
FROMLIST: MAINTAINERS: Add Qualcomm QAIF driver entry
FROMLIST: dt-bindings: sound: Add Qualcomm QAIF binding
FROMLIST: dt-bindings: sound: Add Qualcomm QAIF DAI ID header
FROMLIST: ASoC: dt-bindings: qcom: Add Shikra rx and va macro codecs
PENDING: arm64: dts: enable iris driver for hamoa kvm
FROMLIST: arm64: dts: qcom: Add PMIC thermal support for Shikra IQ2390S SoM platform
FROMLIST: arm64: dts: qcom: Add PMIC thermal support for Shikra CQ2390M SoM platform
FROMLIST: arm64: dts: qcom: pm8005: Add temp alarm node
FROMLIST: arm64: dts: qcom: pm4125: Add VADC and temp alarm nodes
FROMLIST: dt-bindings: arm-smmu: Document GPU SMMU for Shikra SoC
FROMLIST: drm/msm/adreno: Add support for A704 GPU
FROMLIST: dt-bindings: display/msm/gpu: Add support for A704 GPU
QCLINUX: arm64: configs: qcom: Enable SCHED_CLASS_EXT (sched_ext)
FROMLIST: thermal: qcom: add support for PMIC5 Gen3 ADC thermal monitoring
FROMLIST: iio: adc: qcom-spmi-adc5-gen3: Share SDAM0 IRQ with ADC_TM auxiliary driver
FROMLIST: iio: adc: Add support for QCOM PMIC5 Gen3 ADC
FROMLIST: dt-bindings: iio: adc: Add support for QCOM PMIC5 Gen3 ADC
FROMLIST: dt-bindings: iio: adc: Split out QCOM VADC channel properties
FROMLIST: arm64: dts: qcom: monaco-pmics: Add ADC support for PMM8620AU
FROMLIST: arm64: dts: qcom: lemans-pmics: Add ADC support for PMM8654au
FROMLIST: arm64: dts: qcom: Add header file for ADC5 Gen3 channel macros
FROMLIST: thermal: qcom: Add support for Qualcomm MBG thermal monitoring
FROMLIST: dt-bindings: thermal: Add Qualcomm MBG thermal monitor support
FROMLIST: arm64: dts: qcom: Enable SD card for Shikra EVK
FROMLIST: arm64: dts: qcom: Add SD Card support for Shikra SoC
QCLINUX: arm64: dts: qcom: Monaco: Add RTSS Mailbox device tree overlay
QCLINUX: arm64: dts: qcom: lemans: Add RTSS Mailbox device tree overlay
QCLINUX: dt-bindings: mailbox: qcom-ipcc: Add RTSS client IDs