### PR TITLE
ci/test-oe-nogl: drop the patch applied upstream

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -30,7 +30,7 @@ repos:
     branch: main
 
   meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach

--- a/ci/test-oe-nogl.yml
+++ b/ci/test-oe-nogl.yml
@@ -6,10 +6,6 @@ header:
 repos:
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-oe:
 


### PR DESCRIPTION
The commit 29f2ed33a64a ("Revert "ci/qcom-distro: fix building MariaDB for Glymur"") dropped the patch
0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch, but didn't update the separate test-oe-nogl.yml, which is also using that patch.

Fixes: 7a82ae52a531 ("ci: base.lock: update layers to latest  (#2461)")