### PR TITLE
CI: Fix meta-virtualization repository URL

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -30,7 +30,7 @@ repos:
     branch: main
 
   meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach

--- a/ci/test-oe-nogl.yml
+++ b/ci/test-oe-nogl.yml
@@ -6,10 +6,6 @@ header:
 repos:
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-oe:
 


### PR DESCRIPTION
The "/git/" URL format used for meta-virtualization is deprecated  and causing fetcher failures. Fix this by updating the repository URL to the standard form.