### PR TITLE
Handle proprietary licences for the firmware / Heaxgon packages

### DIFF
--- a/classes-recipe/nhlos-license.bbclass
+++ b/classes-recipe/nhlos-license.bbclass
@@ -1,0 +1,35 @@
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: MIT
+#
+# If specified, NHLOS_LICENSE and NHLOS_LICENSE_MD5 specify the licence file
+# (and the checksum) for the NHLOS binaries.
+
+NHLOS_LICENSE ??= ""
+NHLOS_LICENSE_MD5 ??= ""
+
+# LICENSE needs to be set directly as base.bbclass verified it before the
+# anonymous python function has a chance to kick in.
+LICENSE = "${@ 'NHLOS-${BPN}' if d.getVar('NHLOS_LICENSE') else 'CLOSED'}"
+
+def handle_nhlos_license(d, pkgs):
+    if d.getVar("NHLOS_LICENSE"):
+        pn = d.getVar('BPN')
+        d.setVarFlag("NO_GENERIC_LICENSE", f"NHLOS-{pn}", '${NHLOS_LICENSE}')
+        d.appendVar('SRC_URI', ' file://${NHLOS_LICENSE}')
+        d.appendVar('LIC_FILES_CHKSUM', ' file://${NHLOS_LICENSE};md5=${NHLOS_LICENSE_MD5}')
+        d.appendVar('PACKAGE_BEFORE_PN', ' ${PN}-license')
+
+        for pkg in pkgs:
+            # Depend on the main package to get the license file
+            d.appendVar("RDEPENDS:" + pkg, " ${PN}-license")
+
+install_nhlos_license() {
+    if [ -n "${NHLOS_LICENSE}" ] ; then
+        install -d ${D}${datadir}/${BPN}
+        install -m 0644 ${NHLOS_LICENSE} ${D}${datadir}/${BPN}
+    fi
+}
+
+FILES:${PN}-license = "${@ '${datadir}/${BPN}' if d.getVar('NHLOS_LICENSE') else ''}"

--- a/recipes-bsp/firmware/firmware-qcom-nhlos.inc
+++ b/recipes-bsp/firmware/firmware-qcom-nhlos.inc
@@ -2,6 +2,9 @@
 # Include the file to be able to dissect the image using handle_nonhlos_image()
 # If NHLOS_URI is defined, the image will be dissected automatically
 #
+# If specified, NHLOS_LICENSE and NHLOS_LICENSE_MD5 specify the licence file
+# (and the checksum) for the NHLOS binaries.
+#
 # Additionally PROPRIETARY_URI can be specified. Its contents will be used to
 # provide additional firmware files (like Adreno or IPA), which are not a part
 # of NON-HLOS.bin.
@@ -17,6 +20,12 @@ DEPENDS += "pil-squasher-native mtools-native"
 # Conditionally populate SRC_URI. We have to do it here rather than in python
 # script to let base.bbclass to pick up dependencies
 SRC_URI += "${NHLOS_URI} ${PROPRIETARY_URI}${@ ';subdir=proprietary' if d.getVar('PROPRIETARY_URI') != '' else '' }"
+
+inherit nhlos-license
+
+python() {
+    handle_nhlos_license(d, d.getVar("SPLIT_FIRMWARE_PACKAGES").split())
+}
 
 unpack_nhlos_image() {
     mkdir -p ${B}/firmware
@@ -51,6 +60,8 @@ do_compile:prepend() {
 
 do_install:prepend() {
     if [ -n "${NHLOS_URI}${PROPRIETARY_URI}" ] ; then
+        install_nhlos_license
+
         install -d ${D}${FW_QCOM_PATH}
 
         for fw in ${FW_QCOM_LIST} ; do

--- a/recipes-bsp/firmware/firmware-qcom.inc
+++ b/recipes-bsp/firmware/firmware-qcom.inc
@@ -43,9 +43,7 @@ python() {
     pn = d.getVar("PN")
     insanes = d.getVar("INSANE_SKIP:%s" % pn)
     for pkg in d.getVar("SPLIT_FIRMWARE_PACKAGES").split():
-        # Depend on the main package to get the license file
-        d.appendVar("RDEPENDS:" + pkg, " " + pn)
-        # and append the INSANE_SKIP of the main package to pass QA
+        # append the INSANE_SKIP of the main package to pass QA
         d.appendVar("INSANE_SKIP:" + pkg, " " + insanes)
     if d.getVar("FW_QCOM_NAME") == "unset" and d.getVar("SPLIT_FIRMWARE_PACKAGES") != "":
         bb.error("%s: split firmware-qcom packages engaged, but FW_QCOM_NAME is not defined" % pn)

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sdm845-hdk.bb
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso-qcom-sdm845-hdk.bb
@@ -14,10 +14,10 @@ LICENSE = "CLOSED"
 DEPENDS = "firmware-${DSP_PKG_NAME}"
 S = "${UNPACKDIR}"
 
-require hexagon-dspso.inc
-
 # Only package SLPI binaries, ADSP and CDSP are provided by
 # hexagon-dsp-binaries
-PACKAGES = " \
+DSPSO_PACKAGES = " \
     hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
 "
+
+require hexagon-dspso.inc

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -36,6 +36,12 @@ PACKAGES:append = " \
     ${DSPSO_PACKAGES} \
 "
 
+inherit nhlos-license
+
+python() {
+    handle_nhlos_license(d, d.getVar("DSPSO_PACKAGES").split())
+}
+
 RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "${DSPSO_CONFIG}"
 RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "${DSPSO_CONFIG}"
 RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "${DSPSO_CONFIG}"
@@ -101,6 +107,9 @@ do_compile:prepend() {
 }
 
 do_install:prepend() {
+    if [ -n "${DSPSO_URI}" ] ; then
+        install_nhlos_license
+    fi
     if [ -f "${B}/${BPN}.yaml" ] ; then
         install -d ${D}${DSP_QCOM_CONF_D_PATH}
         install -m 0644 ${B}/${BPN}.yaml ${D}${DSP_QCOM_CONF_D_PATH}

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -7,6 +7,12 @@ DSPSO_SOC ?= "unknown"
 DSPSO_VENDOR ?= "Qualcomm"
 DSPSO_DEVICE ?= "Unknown"
 
+DSPSO_PACKAGES ?= " \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp \
+    hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
+"
+
 # Conditionally populate SRC_URI. We have to do it here rather than in python
 # script to let base.bbclass to pick up dependencies
 SRC_URI += "${DSPSO_URI}"
@@ -25,11 +31,9 @@ DEPENDS += "e2fsprogs-native"
 
 inherit allarch
 
-PACKAGES = " \
+PACKAGES:append = " \
     hexagon-dsp-binaries-${DSP_PKG_NAME}-config \
-    hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp \
-    hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp \
-    hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp \
+    ${DSPSO_PACKAGES} \
 "
 
 RDEPENDS:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "${DSPSO_CONFIG}"


### PR DESCRIPTION
While it's not infrequent for the vendor to not define a proper licensing terms for the firmware files and Hexagon DSP binaries in some cases it is possible to establish those. Add infrastructure to declare the licence for firmware packages.