### PR TITLE
Update revision of rmtfs to latest commit

### DIFF
--- a/recipes-support/rmtfs/rmtfs_1.3.bb
+++ b/recipes-support/rmtfs/rmtfs_1.3.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 
 inherit systemd
 
-SRCREV = "44facf5694036ebda53fd09c9535774982df5247"
-SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https;tag=v1.1.1"
+SRCREV = "b30a3eb38f9af283f18dbd3c7755653efc52c094"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https;tag=v${PV}"
 DEPENDS = "qmic-native qrtr udev"
 
 do_install () {


### PR DESCRIPTION
 Update recipe to bring in commits which execute the service only after
 /dev/qcom_rmtfs_mem1 is created and doesn't start it if the node doesn't exist(indicating modemless device).

Fixes #2582