### PR TITLE
ci/base: apply a patch, fixing the IGT build failures

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -18,6 +18,9 @@ repos:
       kern-tools-conditional-deps:
         repo: meta-qcom
         path: patches/oe-core/0001-kern-tools-bump-SRCREV-for-conditional-depends-on-X-.patch
+      fix-igt-pause:
+        repo: meta-qcom
+        path: patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
     layers:
       meta:
 

--- a/patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
+++ b/patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
@@ -1,0 +1,79 @@
+From 78ff59dae35b5803ccfd9c3814f20166c414f767 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Fri, 26 Jun 2026 23:09:09 +0300
+Subject: [PATCH] igt-gpu-tools: fix build on non-x86 platforms
+
+The "pause" assembly mnemonic is only available on IA-32 platforms,
+breaking e.g. debug IGT builds on ARM / AArch64. Guard this inline
+assembly with the preprocessor checks, making sure that other platforms
+don't see the invalid assembly.
+
+FAILED: [code=1] tests/amdgpu/amd_basic.p/amd_basic.c.o
+Assembler messages:
+{standard input}:3702: Error: unknown mnemonic `pause' -- `pause'
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/r/20260626201256.112352-1-dmitry.baryshkov@oss.qualcomm.com/]
+---
+ ...t-pause-mnemonic-only-on-x86-x86_64-.patch | 36 +++++++++++++++++++
+ .../igt-gpu-tools/igt-gpu-tools_2.4.bb        |  1 +
+ 2 files changed, 37 insertions(+)
+ create mode 100644 meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch
+
+diff --git a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch
+new file mode 100644
+index 000000000000..1fdaad7b0c66
+--- /dev/null
++++ b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch
+@@ -0,0 +1,36 @@
++From dc072dc0fc680a055d0cdf5adfdccbab6d0566d6 Mon Sep 17 00:00:00 2001
++From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++Date: Fri, 26 Jun 2026 22:34:06 +0300
++Subject: [PATCH] lib/amdgpu: insert pause mnemonic only on x86 / x86_64
++ platforms
++
++The "pause" assembly mnemonic is only available on IA-32 platforms,
++breaking e.g. debug IGT builds on ARM / AArch64. Guard this inline
++assembly with the preprocessor checks, making sure that other platforms
++don't see the invalid assembly.
++
++FAILED: [code=1] tests/amdgpu/amd_basic.p/amd_basic.c.o
++Assembler messages:
++{standard input}:3702: Error: unknown mnemonic `pause' -- `pause'
++
++Upstream-Status: Pending [for internal clearance]
++Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++---
++ tests/amdgpu/amd_basic.c | 2 ++
++ 1 file changed, 2 insertions(+)
++
++diff --git a/tests/amdgpu/amd_basic.c b/tests/amdgpu/amd_basic.c
++index 3ad023472136..e5475f337549 100644
++--- a/tests/amdgpu/amd_basic.c
+++++ b/tests/amdgpu/amd_basic.c
++@@ -703,8 +703,10 @@ static int wait_for_value64(volatile uint64_t *ptr, uint64_t expected,
++ 		/* Sleep if interval specified, otherwise tight loop */
++ 		if (check_interval_ns > 0)
++ 			nanosleep(&sleep_time, NULL);
+++#if defined(x86_64) || defined(i386)
++ 		else
++ 			__asm__ __volatile__("pause" ::: "memory"); /* CPU hint for spin-wait */
+++#endif
++ 	}
++ }
++ 
+diff --git a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
+index 32a3a3cc48c9..f5f5b3b87316 100644
+--- a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
++++ b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
+@@ -13,6 +13,7 @@ SRCREV = "e6b603e4984e4ce30fe1cc2705734d0f130e0550"
+ 
+ SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https;branch=master;tag=v${PV} \
+            file://0001-lib-meson.build-do-not-hardcode-the-build-directory-.patch \
++           file://0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch \
+            "
+ 
+ DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl elfutils alsa-lib json-c bison-native pciutils jansson"
+-- 
+2.47.3
+


### PR DESCRIPTION
Temporarily pick up a patch fixing the IGT build failure in debug builds.

Fixes: 7a82ae52a531 ("ci: base.lock: update layers to latest  (#2461)")
Link: https://lore.kernel.org/r/20260626201256.112352-1-dmitry.baryshkov@oss.qualcomm.com/