### PR TITLE
qcom-common: relax initramfs size limitations

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -55,6 +55,7 @@ SERIAL_CONSOLES ?= "115200;ttyMSM0"
 # so this image would fit.
 INITRAMFS_MAXSIZE = "655360"
 # This initramfs is bigger than the others
+INITRAMFS_MAXSIZE:pn-initramfs-test-full-image = "983040"
 INITRAMFS_MAXSIZE:pn-initramfs-kerneltest-full-image = "983040"
 
 # Use systemd-boot as the EFI bootloader


### PR DESCRIPTION
Debug builds generate so ineffective and unoptimized code that it makes generated initramfs-test-full-image images exceed the 640 MiB limitation set inside the repository. Bump the INITRAMFS_MAXSIZE for the image to account for the code growth.