### PR TITLE
linux-qcom-next: update to tag qcom-next-7.1-20260628

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -10,12 +10,12 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "7.0+7.1-rc7"
+LINUX_VERSION ?= "7.1"
 
 PV = "${LINUX_VERSION}+git"
 
-# tag: qcom-next-7.1-rc7-20260618
-SRCREV ?= "6548ba1da92711e1ba186d9d469388c9f64e654a"
+# tag: qcom-next-7.1-20260628
+SRCREV ?= "19b282f417584cfe14ce6a262122c51553d026ec"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.1-20260628, which corresponds to kernel version v7.1


| Topic Branch | SHA | Commits |
|-----------|-----|---------:|
| tech/bsp/clk | `d93e583e313921d6cd1b0a0d3e01f00aa9d23c67` | 21 |
| tech/bsp/devfreq | `a0c2f214c89b578a9732844ad8996b65e82ddc77` | 6 |
| tech/bsp/ec | `643c24b2b397b497d80baf7b4dea28a0a59de898` | 2 |
| tech/bsp/soc-infra | `6aff3e676829cbb71b8e6a0c9df504a45ff63955` | 25 |
| tech/bsp/pinctrl | `3f1acf892d6623a15a7245d398ae04bb6d1e9f50` | 1 |
| tech/bsp/remoteproc | `a7b9b6d8b0ef8713aea096ed6c6c0fa74db2ed25` | 10 |
| tech/bus/peripherals | `feb0c221d6900081c2f227b8585157abb36e84ed` | 8 |
| tech/bus/pci/all | `7650854561a3b71938cf20b7d9ed3a6e55966730` | 26 |
| tech/bus/pci/phy | `aaf8ef1234f456bd05343c235d7ad0b921a97220` | 4 |
| tech/bus/usb/dwc | `e929e6d4fe8556b3d25732242a7e516947983723` | 3 |
| tech/bus/usb/phy | `984aa89de0ab9645f8e95840cc3b1ce55526c853` | 36 |
| tech/debug/hwtracing | `25c6a748cd3b64e815a8ee8c741a7adcf3852618` | 30 |
| tech/pmic/misc | `a2dd2bbca77dc159e6110fee5fa71660559ea778` | 7 |
| tech/mem/iommu | `2831e573df248b887fed74f001867f3eaa65223c` | 7 |
| tech/mm/audio/all | `cab3357f188207843476df34b2a294a9009efa5b` | 10 |
| tech/mm/camss | `fdc4e57b94e7dfa5b53a8c330d26bab4547e0e10` | 34 |
| tech/mm/drm | `a26c405598210c707fd28360ca760d6a0ff08ed2` | 69 |
| tech/mm/fastrpc | `835302484651c37288d4cc31be9c28b0b30914f8` | 11 |
| tech/mm/video | `1bc33f67c8213cac9149dac47391bd919b8bdc16` | 166 |
| tech/mm/gpu | `f67b88829bc0f50af8e77e67616063322813b7ad` | 6 |
| tech/net/ath | `954361eb6eed2428790b6553b9cc983371b85300` | 22 |
| tech/net/phy | `a3602e9cbd3dd4519ddc446ddba1261fe4e156bd` | 1 |
| tech/net/bluetooth | `c8f5ae933208bd131ea6f40ae17a628c3808aae4` | 1 |
| tech/pm/power | `2d42c35af66ed0db002e2d2d8481719dd05b804b` | 9 |
| tech/pm/thermal | `3f033cbfa8a76a10568dbbe3d1699852f6288851` | 7 |
| tech/security/crypto | `53b86cb8093496677ecec437ec247e7de318b973` | 15 |
| tech/security/ice | `c72a252d7e3aa1d09049959716d01583c0b8c24b` | 18 |
| tech/storage/all | `6a34168ee0709f9806be1a07788b8c52fce6d229` | 4 |
| tech/all/dt/qcs6490 | `abb8a3a200a280c06eead183a3a34d544b209d34` | 22 |
| tech/all/dt/qcs9100 | `fe7da88ba31ac516a58c0b91af04ab3f64bfd6aa` | 23 |
| tech/all/dt/qcs8300 | `fddb0125a8ed5b36740cb1e07c02551f69c8749d` | 24 |
| tech/all/dt/qcs615 | `277da5daa2951397d4addf7a04b640696367d68c` | 11 |
| tech/all/dt/agatti | `c828f10cd2c53b7ff2cc061e73b239973ee17bc6` | 1 |
| tech/all/dt/hamoa | `f0704343b673887d4b6300333415ca1f456c90cc` | 31 |
| tech/all/dt/glymur | `7712b8410bd96cfcc0b42b9de76815f60bdb45c6` | 35 |
| tech/all/dt/kaanapali | `f1c20f5f555faee1f86b259a3262550cd5ac7e33` | 18 |
| tech/all/dt/pakala | `d7f29faab25794e50a846cbae1bc4bd450c80c14` | 9 |
| tech/all/config | `71f787f97ad8ec57ab4232bf72a8ba2f935114d2` | 72 |
| tech/overlay/dt | `587d3d550747ef6824f14fbcf149f290760102a7` | 60 |
| tech/all/workaround | `d29701b01f8032d6e6df0ab3afbb20a8c5cf68c0` | 25 |
| tech/mproc/all | `0aa90b7d45babe6116bcbb3006ae4636256b6e0f` | 3 |
| tech/noup/debug/all | `cbdd4bbfa24a682d76769d4c1c66bb67b262ae4d` | 26 |
| tech/hwe/unoq | `b2ea57bfc5f97af1b5f7b0d750ae315c60921580` | 5 |
| early/hwe/shikra/drivers | `5caf8f513db4e5db1b3475ae23f97cd1db63a23e` | 175 |
| early/hwe/shikra/dt | `95e145ff6aa294bcccc110350c14949ae3f26dc7` | 107 |
