### PR TITLE
README.md: provide commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,18 +114,14 @@ Use the helper scripts for CI parity whenever possible.
 
 ## 6) Pull request / contribution workflow
 
-Follow the repository `README.md` contribution flow:
+Follow the contribution workflow documented in
+[CONTRIBUTING.md](CONTRIBUTING.md):
 
 1. Target branch: **master**.
 2. Fork `qualcomm-linux/meta-qcom`, create a topic branch, implement changes.
 3. Rebase on latest upstream `master`.
 4. Open a GitHub pull request.
 5. Use PR discussion for review iteration.
-
-Important:
-
-- Follow Yocto submission guidance referenced in README:
-  [Preparing Changes for Submission](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#preparing-changes-for-submission)
 
 Before opening/updating a PR, run CI-equivalent checks in this order:
 
@@ -137,39 +133,20 @@ ci/kas-container-shell-helper.sh ci/oe-selftest.sh
 
 ## 7) Commit message best practices (project style)
 
-Use the style seen in recent history:
+Follow the commit subject and message requirements documented in
+[CONTRIBUTING.md](CONTRIBUTING.md): an atomic change per commit, a
+`recipe-name: summary of the changes` subject, a plain-English body that
+explains the problem before the imperative actions, and the mandatory
+`Signed-off-by` (and, when applicable, `Assisted-by`) trailers.
 
-- `component: imperative summary` (preferred when scoped), e.g.
-  - `ci/qcom-distro: Include meta-dpdk layer`
-  - `fit-dtb-compatible: drop SoC version suffixes from compatible strings`
-  - `debug.yml: enable FTrace settings in kernel cmdline`
-- Or concise imperative summary when cross-cutting, e.g.
-  - `Drop SoC version suffixes from FIT DTB compatible strings`
-
-Every commit **must** include a `Signed-off-by` trailer using the identity from
-the local git configuration:
-
-```sh
-git commit -s   # or pass --signoff; fetches user.name / user.email from git config
-```
-
-If committing programmatically, append the trailer explicitly:
+When committing programmatically, take the `Signed-off-by` identity from the
+local git configuration and append the trailer explicitly:
 
 ```text
 Signed-off-by: $(git config user.name) <$(git config user.email)>
 ```
 
-Never fabricate a name or email; always read from `git config`.
+Never fabricate a name or email; always read them from `git config`.
 
-Guidelines:
-
-- Keep subject line short and specific; capture intent, not a file-by-file dump.
-- Use imperative mood (`Add`, `Update`, `Drop`, `Enable`, `Revert`).
-- Add a body for non-trivial changes explaining **why** and key design decisions.
-- Wrap body lines for readability (~72 chars).
-- Use consistent recipe bump wording for version updates, e.g.
-  `recipe-name: upgrade vX.Y.Z -> vA.B.C`.
-- Avoid mixing unrelated changes in one commit; split logically.
-- Each patch must be logically coherent, self-contained, and independently buildable.
-- The tree must remain in a functional state after every commit.
-- Fixups within the same patch series are not allowed; changes should be corrected in the patch where they are introduced.
+Fixups within the same patch series are not allowed; changes should be
+corrected in the patch where they are introduced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,11 +140,11 @@ ci/kas-container-shell-helper.sh ci/oe-selftest.sh
 Use the style seen in recent history:
 
 - `component: imperative summary` (preferred when scoped), e.g.
-  - `ci/qcom-distro: Include meta-dpdk layer (#1902)`
+  - `ci/qcom-distro: Include meta-dpdk layer`
   - `fit-dtb-compatible: drop SoC version suffixes from compatible strings`
-  - `debug.yml: enable FTrace settings in kernel cmdline (#2155)`
+  - `debug.yml: enable FTrace settings in kernel cmdline`
 - Or concise imperative summary when cross-cutting, e.g.
-  - `Drop SoC version suffixes from FIT DTB compatible strings (#2159)`
+  - `Drop SoC version suffixes from FIT DTB compatible strings`
 
 Every commit **must** include a `Signed-off-by` trailer using the identity from
 the local git configuration:
@@ -169,7 +169,6 @@ Guidelines:
 - Wrap body lines for readability (~72 chars).
 - Use consistent recipe bump wording for version updates, e.g.
   `recipe-name: Update to vX.Y.Z`.
-- Include PR reference in subject when appropriate: `(#NNNN)`.
 - Avoid mixing unrelated changes in one commit; split logically.
 - Each patch must be logically coherent, self-contained, and independently buildable.
 - The tree must remain in a functional state after every commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Guidelines:
 - Add a body for non-trivial changes explaining **why** and key design decisions.
 - Wrap body lines for readability (~72 chars).
 - Use consistent recipe bump wording for version updates, e.g.
-  `recipe-name: Update to vX.Y.Z`.
+  `recipe-name: upgrade vX.Y.Z -> vA.B.C`.
 - Avoid mixing unrelated changes in one commit; split logically.
 - Each patch must be logically coherent, self-contained, and independently buildable.
 - The tree must remain in a functional state after every commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to meta-qcom
+
+Please submit any patches against the `meta-qcom` layer (branch **master**)
+by using the GitHub pull-request feature. Fork the repo, create a branch,
+do the work, rebase from upstream, and create the pull request.
+
+For some useful guidelines when submitting patches, please refer to:
+[Preparing Changes for Submission](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#preparing-changes-for-submission)
+
+Pull requests will be discussed within the GitHub pull-request infrastructure.
+
+## Commit messages
+
+Each commit must be atomic: it must contain exactly one logical change. Do not
+squash multiple features, fixes, or otherwise unrelated changes into a single
+commit — split them into separate commits, one per logical change. Each patch
+must be logically coherent, self-contained, and independently buildable, and
+the tree must remain in a functional state after every commit.
+
+Each commit must contain a well-formed commit subject and message.
+
+The commit subject must follow the form `recipe-name: summary of the changes`,
+where `recipe-name` identifies the recipe or component being touched and the
+summary concisely describes the change. Keep the subject short and specific,
+capturing intent rather than a file-by-file dump. For example:
+
+- `ci/qcom-distro: Include meta-dpdk layer`
+- `fit-dtb-compatible: drop SoC version suffixes from compatible strings`
+- `debug.yml: enable FTrace settings in kernel cmdline`
+
+Use consistent wording for version upgrades, e.g.
+`recipe-name: upgrade vX.Y.Z -> vA.B.C`.
+
+The commit message (the body) must:
+
+- be written in plain English;
+- first describe the issue or the problem that is being solved, so that a
+  reader can understand *why* the change is needed;
+- then use the imperative mood (e.g. "add", "drop", "enable", "update")
+  to describe the actions to be performed in order to solve the problem;
+- not merely restate *what* the diff changes line by line — the diff
+  already shows that;
+- avoid unnecessary bullet lists; prefer prose paragraphs;
+- wrap body lines for readability (~72 chars).
+
+## Sign-off and trailers
+
+Every commit must also carry a `Signed-off-by` trailer matching the
+author identity from your local `git config` (use `git commit -s`). Never
+fabricate a name or email; always read them from `git config`.
+
+If an AI coding assistant or other advanced tool was used to help create the
+change, acknowledge that use by adding an `Assisted-by` trailer in the form:
+
+```text
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+Where `AGENT_NAME` is the name of the AI tool or framework, `MODEL_VERSION` is
+the specific model version used, and `[TOOL1] [TOOL2]` are optional specialized
+analysis tools. Basic development tools (git, gcc, make, editors) should not be
+listed. For example:
+
+```text
+Assisted-by: ExampleAgent:example-model-1.0
+```

--- a/README.md
+++ b/README.md
@@ -142,14 +142,9 @@ build it with KAS using the configuration for your target machine and distro.
 
 ## Contributing
 
-Please submit any patches against the `meta-qcom` layer (branch **master**)
-by using the GitHub pull-request feature. Fork the repo, create a branch,
-do the work, rebase from upstream, and create the pull request.
-
-For some useful guidelines when submitting patches, please refer to:
-[Preparing Changes for Submission](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#preparing-changes-for-submission)
-
-Pull requests will be discussed within the GitHub pull-request infrastructure.
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
+the contribution workflow and the commit subject and message requirements
+before opening a pull request.
 
 Branch **kirkstone** is not open for direct contributions, please raise an
 issue with the suggested change instead.


### PR DESCRIPTION
Based on the lots of similar feedback we've had to give to contributors, codify contributing guidelines, saving maintainers from typing the same text again and again. Especially frown upon the bullet lists, which some engineer prefer instead of writing the text.