### PR TITLE
kgsl-dlkm: Update to v1.0.6

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.6.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.6.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "4300b655d3c0018b5341ecf876698cbb1c31f255"
+SRCREV = "d086580545b1019dcc4d702ebe859312acca91c4"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.6 brings below fixes:

- Resolve type confusion for lpac.
- Acquire lock while working on fence lists.
- Remove cmd_list_objs from cmd_list for faults.
- Add support for A704 GPU with standard DT bindings.
- Fix KVA Leak.