### PR TITLE
ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,11 +3,11 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 5b718f4c044147dfa0742caacbc20133ead53f10
+            commit: f810998ac90f7a3e20e26555f39d754b16ce8b69
         bitbake:
             commit: 7e3489ab3ec39b2dcf4e50eff54d36d42e5a7307
         meta-arm:
-            commit: 3681201897f164408194e4cc823e1e3650607dab
+            commit: 847af9c082cc190b3781f101200a9403426e481b
         meta-openembedded:
             commit: a7428c96bf97a751ccd5baa63acfa1f5b49f077e
         meta-virtualization:


### PR DESCRIPTION
Relevant changes for oe-core:
- 9780e3923 oeqa/selftest: add copydebugsources tests
- 8337a9330 package: replace copydebugsources shell pipelines
- 8aace29b6 llvm/mesa/rust: simplify llvm-config handling
- f810998ac bitbake.conf: drop opencl from DISTRO_FEATURES_FILTER_NATIVE/_NATIVESDK
- 7504490ba python3: skiptest tracemalloc_track_race
- 46b79c40c classes/gtk-doc: inherit python3native only if gtk-doc is enabled
- 3f6d1fc23 shared-mime-info: remove python3native dependency
- 3deca28b2 lib/sstatesig: use the SHA256 fastpath in bitbake/utils.py
- 45302ff5c create-spdx-image-3.0: correct SSTATE_SKIP_CREATION key for do_create_image_sbom_spdx
- c7a0274d8 dlopen-deps.inc: treat soname list as ordered alternatives
- e160ff451 install-buildtools: add --local-file option
- 23ad5101d install-buildtools: refactor fetch and install logic
- d3eb9f2ae python3-certifi: upgrade 2026.5.20 -> 2026.6.17
- 1f64b7985 ncurses: fix split wide library and pkg-config installs
- 0f1c28ac8 e2fsprogs: fix parallel library build ordering
- 6e975d24f cpio_2.15.bb: delete unnecessary RDEPENDS of "ptest-runner"
- bf1681a02 jansson: Fix build with lld linker
- fba290297 sbom-cve-check-update-nvd-native: update to version 2026.06.24-000003
- f7a706321 sbom-cve-check-update-cvelist-native: update to version 2026-06-24
- cd6313d94 python3-sbom-cve-check: update to version 1.3.2
- 9b5c92cd6 python3-spdx-python-model: update from version 0.0.5 to 0.0.6
- 587b5fcc7 python3-maturin: upgrade 1.14.0 -> 1.14.1
- d0914b892 busybox: fdisk: enable GPT support
- 6ec500cd5 curl: update 8.20.0 -> 8.21.0
- abac5b73f oeqa/oelib: test patch command argv handling
- 74291582c oe/patch: return manual-resolution commands as argv lists
- 14709942f oe/patch: pass GitApplyTree commands as argv lists
- 51797c6fa oeqa/oelib: test GitApplyTree patch names
- 13baada29 oe/patch: remove obsolete PATCHFILE assignment
- e743ecf33 oe/patch: avoid shell pipeline in _applypatch
- 51431e362 oe/patch: convert simple runcmd shell callers
- b364c44de oeqa/oelib: add runcmd tests
- ef8eafe60 oe/patch: drop shell=True from runcmd
- 333595718 rust: backport explicit-tail-calls test skips for unsupported LLVM targets
- 872d86b99 tar: Fix CVE-2026-5704
- bfc0a651f libcap: add ptest support
- 4a72f62d3 vim-tiny: bugfix for lack of defaults.vim
- 716a14b7b oeqa/selftest/devtool: add regression test for kernel cfg in subdirs
- 0ac086852 clang/llvm: add missing instance of Distro class in Linux.cpp
- 959edc376 llvm-project-source.inc: fix end of line in triple variable
- ada629665 llvm-project-source.inc: fix string replacements in do_preconfigure
- d3cbc285a go-vendor.bbclass: Remove vendor symlink
- 6071a788c go-vendor.bbclass: Unpack into BP for destsuffix
- df16e4a39 uboot-sign: allow customizing the FIT configuration description
- e5a4a7d7c spdx: Add custom annotations to recipe packages
- 4297b94c3 kernel-fit-image.bbclass: Fix operation with KERNEL_DTBVENDORED = "1"
- 06ed34005 kernel-fit-image.bbclass: Do not include kernel property in DTBO config subnodes
- 85e0408a8 oe-selftest: fitimage: Do not expect kernel property in DTBO config subnodes
- f17f4263c oe-selftest: fitimage: stop hardcoding MACHINE and DISTRO in tests
- 4b08cf604 oe-selftest: fitimage: add machine settings table and skip helpers
- befc103a9 oe-selftest: fitimage: replace MACHINE==qemux86-64 guards with KERNEL_SETUP_BIN
- 5592be533 oe-selftest: fitimage: replace bbb-dtbs-as-ext with test-dtbs-as-ext
- 4817faa1d oe-selftest: fitimage: add machine-agnostic test-dtbs-as-ext recipe
- 0344e652a oe-selftest: fitimage: replace _gen_random_file with _gen_elf64_dummy
- 584b3ab92 scripts/patchtest: check for meta-selftest
- aef887447 scripts/patchtest: clean up main()
- 11c046d9d scripts/patchtest: simplify run()
- 323eeaa74 scripts/patchtest: simplify traceback logging, remove whitespace
- b054bb394 scripts/patchtest: simplify _runner()
- b8f799c26 scripts/patchtest: clean up startTestRun()
- 2264f0ed7 scripts/patchtest: refactor results methods
- ed9705610 qemuboot.bbclass: add missing task dependency on kernel deploy
- f5ae048f6 mesa: fix INSANE_SKIP package name for mesa-gl
- 5cf699043 python3-cython: make generated _cyutility.c be reproducible
- 01cec49e1 recipes.txt: correct misspelled "utilties"
- 5292369c7 local.conf.sample.extended: update fortran example
- 06a28d3a0 dmidecode: fix x86-only tools being installed on ARM targets
- 861eaeb79 cmake-native: prevent host libidn2 contamination
- 4478086b7 nospdx: also drop do_create_recipe_sbom
- cf295f86c packagegroup-core-base-utils.bb: delete duplicate "PACKAGE_ARCH" line
- cc3374ed9 oe: pass gcc and tmux commands as lists

Relevant changes for meta-arm:
- 847af9c0 arm/u-boot: fix uefi-secureboot on u-boot v2026.04