### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "6540ea3824aee6ffc8cac5670d87652cb21f046f"
+SRCREV = "0ea6db50edc5d4edd3887b593bed080d71d63a08"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Ricardo Salveti (1):
      Revert "qrb2210-unoq: update partitions based on the edk2-downstream boot firmware"