### PR TITLE
shikra-evk: add phone to MACHINE_FEATURES

### DIFF
--- a/conf/machine/shikra-evk.conf
+++ b/conf/machine/shikra-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-shikra.inc
 
-MACHINE_FEATURES += "efi pci"
+MACHINE_FEATURES += "efi pci phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/shikra-cqm-evk.dtb \


### PR DESCRIPTION
shikra-evk does not support cellular data calls, as modemmanager is
not enabled for this machine.

modemmanager is conditionally enabled at the distro layer based on
'phone' being present in a machine's MACHINE_FEATURES. Add 'phone'
to MACHINE_FEATURES for shikra-evk so that modemmanager gets enabled
and cellular data connectivity is supported.