### PR TITLE
firmware-qcom-boot-glymur: update boot to 00073

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00065.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00065.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-glymur.inc
-
-SRC_URI[bootbinaries.sha256sum] = "bcc25ba8ac20b759d6068bf127af2aa0f8fccb08ea130a251dcdc6101123edc1"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00073.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00073.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-glymur.inc
+
+SRC_URI[bootbinaries.sha256sum] = "ab9e2349c18ac761522c31822a6874818ac027f9560e36cb83c48103ff96a2c4"


### PR DESCRIPTION
Known fixes:
Glymur

S2RAM is auto resuming
Improved UEFI compliance, USB/Type‑C interoperability Improved PCIe stability
Enabled FastCV capabilities and resolved stability and compilation