### PR TITLE
ci: add bitbake-lint workflow for pull requests

### DIFF
--- a/.github/workflows/bitbake-lint.yml
+++ b/.github/workflows/bitbake-lint.yml
@@ -1,0 +1,42 @@
+name: Bitbake Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.bb'
+      - '**/*.bbappend'
+      - '**/*.bbclass'
+      - '**/*.inc'
+      - '**/*.conf'
+      - '!.github/**'
+      - '!ci/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine Yocto release
+        id: release
+        run: |
+          rel=$(awk -F'"' '/^LAYERSERIES_COMPAT_qcom/ {n=split($2,a," "); print a[n]}' conf/layer.conf)
+          echo "Inferred Yocto release: ${rel}"
+          echo "release=${rel}" >> "$GITHUB_OUTPUT"
+
+      - name: Run bitbake-lint
+        uses: qualcomm-linux/bitbake-lint-action@1b3b5e7d6753138d75e7d179dd956c437824cb7a # v1.0.0
+        with:
+          diff_only: 'true'
+          hide: info
+          mode: fast
+          release: ${{ steps.release.outputs.release }}
+          exit_zero: 'true'


### PR DESCRIPTION
Add a Bitbake Lint GitHub Actions workflow using
qualcomm-linux/bitbake-lint-action to catch recipe/metadata issues on pull requests.

Fine-tuning:
- paths filter: only run on bitbake metadata changes (*.bb, *.bbappend, *.bbclass, *.inc, *.conf) to skip doc/CI-only PRs
- diff_only: lint only files touched in the PR diff
- release: wrynose, matching LAYERSERIES_COMPAT_qcom
- hide info: drop info-severity noise
- mode fast: quick per-PR feedback
- exit_zero: advisory rollout, findings annotate but do not block merge
- permissions: pull-requests/checks write for inline diff annotations