### PR TITLE
README.md: restore the 'patching' information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,5 @@
 # Contributing to meta-qcom
 
-Please submit any patches against the `meta-qcom` layer (branch **master**)
-by using the GitHub pull-request feature. Fork the repo, create a branch,
-do the work, rebase from upstream, and create the pull request.
-
 For some useful guidelines when submitting patches, please refer to:
 [Preparing Changes for Submission](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#preparing-changes-for-submission)
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,12 @@ build it with KAS using the configuration for your target machine and distro.
 
 ## Contributing
 
-Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
-the contribution workflow and the commit subject and message requirements
-before opening a pull request.
+Please submit any patches against the `meta-qcom` layer (branch **master**)
+by using the GitHub pull-request feature. Fork the repo, create a branch,
+do the work, rebase from upstream, and create the pull request.
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow
+and the commit subject and message requirements before opening a pull request.
 
 Branch **kirkstone** is not open for direct contributions, please raise an
 issue with the suggested change instead.


### PR DESCRIPTION
For the layer to be Yocto Project Comaptible it is required that its README contains information on submitting patches. Move the 'pull request' paragraph from CONTRIBUTING.md back to README.md

Fixes: f5f6a7f5afb8 ("CONTRIBUTING: document contribution and commit message requirements")