### PR TITLE
[Backport wrynose] Add xdp-tools and rtc-testbench recipes

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/files/0001-configure-correctly-handle-CC-when-validating-requir.patch
+++ b/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/files/0001-configure-correctly-handle-CC-when-validating-requir.patch
@@ -1,0 +1,45 @@
+From 2a6d219ec2f5413e38ec502421cce8a2c6d7f054 Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+Date: Tue, 9 Jun 2026 11:22:13 +0530
+Subject: [PATCH 1/2] configure: correctly handle CC when validating required
+ tools
+
+The tool validation loop checks the availability of required
+binaries using `command -v`. However, when CC is defined with
+additional flags (e.g. "aarch64-linux-gnu-gcc -O2 -pipe"),
+the check fails because `command -v` expects only the binary
+name.
+
+Extract the actual compiler executable from CC by taking the
+first word and include it in the validation list.
+
+This ensures tool detection works correctly in cross-compilation
+environments where CC commonly includes compiler flags.
+
+Additionally, quote variable expansions to avoid issues with
+word splitting and empty values.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+---
+ configure | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index d57b2ae..a234f80 100755
+--- a/configure
++++ b/configure
+@@ -70,8 +70,10 @@ check_toolchain()
+ 
+     CLANG=$(find_tool clang "$CLANG")
+ 
+-    for TOOL in $PKG_CONFIG $CC $OBJCOPY $CLANG $M4 $READELF; do
+-        if [ ! $(command -v ${TOOL} 2>/dev/null) ]; then
++    CC_TOOL=$(echo "$CC" | awk '{print $1}')
++
++    for TOOL in $PKG_CONFIG "$CC_TOOL" $OBJCOPY $CLANG $M4 $READELF; do
++        if [ ! $(command -v "${TOOL}" 2>/dev/null) ]; then
+             echo "*** ERROR: Cannot find tool ${TOOL}" ;
+             exit 1;
+         fi;

--- a/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/files/0002-lib-libxdp-Makefile-use-cp-fRd-to-preserve-symlinks-.patch
+++ b/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/files/0002-lib-libxdp-Makefile-use-cp-fRd-to-preserve-symlinks-.patch
@@ -1,0 +1,36 @@
+From 064ccdaf0d84bea86f9cd17383581c3844a33151 Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+Date: Tue, 9 Jun 2026 11:24:51 +0530
+Subject: [PATCH 2/2] lib/libxdp/Makefile: use cp -fRd to preserve symlinks
+ without metadata
+
+cp -fpR preserves ownership and timestamps from the build host,
+which breaks cross-compilation and packaging QA checks.
+
+The `-p` flag is unnecessary for symlink handling. Replace it
+with `-d` to explicitly preserve symlinks without carrying over
+file metadata.
+
+Switch to cp -fRd to maintain symlink structure while avoiding
+host contamination.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+---
+ lib/libxdp/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 7ea7e7e..3c36b70 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -56,7 +56,7 @@ install: all
+ 	$(Q)install -d -m 0755 $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(Q)install -m 0644 $(LIB_HEADERS) $(DESTDIR)$(HDRDIR)/
+ 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
+-	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
++	$(Q)cp -fdR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
+ 	$(Q)install -m 0644 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+ 	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)

--- a/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/xdp-tools_1.6.3.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/xdp-tools/xdp-tools_1.6.3.bb
@@ -1,0 +1,47 @@
+SUMMARY = "Utilities and library for managing XDP/eBPF programs"
+
+DESCRIPTION = "xdp-tools provides libxdp and command-line utilities for working \
+with XDP eBPF programs in Linux, including tools for loading programs, packet \
+processing, monitoring, traffic generation, and benchmarking."
+
+HOMEPAGE = "https://github.com/xdp-project/xdp-tools"
+LICENSE = "GPL-2.0-only & GPL-2.0-or-later & LGPL-2.1-only & BSD-2-Clause"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=9ee53f8d06bbdb4c11b1557ecc4f8cd5 \
+    file://LICENSES/GPL-2.0;md5=994331978b428511800bfbd17eea3001 \
+    file://LICENSES/LGPL-2.1;md5=b370887980db5dd40659b50909238dbd \
+    file://LICENSES/BSD-2-Clause;md5=5d6306d1b08f8df623178dfd81880927 \
+"
+SRC_URI = " \
+    git://github.com/xdp-project/xdp-tools.git;tag=v${PV};nobranch=1;protocol=https \
+    file://0001-configure-correctly-handle-CC-when-validating-requir.patch \
+    file://0002-lib-libxdp-Makefile-use-cp-fRd-to-preserve-symlinks-.patch \
+"
+SRCREV = "8fbad9f0af621a22aa87ff2520b3735915b1f0fd"
+
+DEPENDS += " \
+    libbpf \
+    clang-native \
+    zlib \
+    elfutils \
+    libpcap \
+"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE += " \
+    PREFIX=${prefix} \
+    LIBDIR=${libdir} \
+    PRODUCTION=1 \
+    BPF_CFLAGS='-D__${TARGET_ARCH}__ -I${S}/headers -I${STAGING_INCDIR} -ffile-prefix-map=${S}=${TARGET_DBGSRC_DIR} -ffile-prefix-map=${STAGING_DIR_HOST}=' \
+"
+
+do_install () {
+    oe_runmake DESTDIR=${D} install
+}
+
+# libxdp.so loads BPF objects at runtime from ${libdir}/bpf, not embedded in the .so.
+FILES:${PN} += "${libdir}/bpf ${libdir}/bpf/*"
+
+# Test scripts under ${datadir}/xdp-tools require bash.
+RDEPENDS:${PN} += "bash"

--- a/dynamic-layers/openembedded-layer/recipes-test/rtc-testbench/files/0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch
+++ b/dynamic-layers/openembedded-layer/recipes-test/rtc-testbench/files/0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch
@@ -1,0 +1,54 @@
+From 53c57b337a51a47b0edca64d88ef9aaacce90044 Mon Sep 17 00:00:00 2001
+From: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+Date: Wed, 10 Jun 2026 11:39:40 +0530
+Subject: [PATCH] CMakeLists.txt: make BPF clang and include paths configurable
+ for cross-builds
+
+The upstream CMakeLists.txt hardcodes the clang binary name and
+derives the BPF include path from CMAKE_C_LIBRARY_ARCHITECTURE,
+which is empty in a cross-compilation environment. This causes
+the BPF kernel programs to be compiled with the host clang and
+-I /usr/include/ (the build host include path), which fails with:
+
+  fatal error: 'asm/types.h' file not found
+
+Fix by converting the hardcoded values to CMake CACHE variables
+so they can be overridden from the recipe via -DCLANG=,
+-DBPF_INCLUDE_DIRS=, and -DBPF_EXTRA_FLAGS=.
+
+Upstream-Status: Inappropriate [OE cross-compilation specific]
+
+Signed-off-by: Rajkumar Patel <patel.rajkumar@oss.qualcomm.com>
+---
+ CMakeLists.txt | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f782304..7f284f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -174,15 +174,21 @@ include_directories("${PROJECT_BINARY_DIR}")
+ #
+ # Add code for compiling XDP eBPF programes.
+ #
+-set(ASM_INCLUDE "/usr/include/${CMAKE_C_LIBRARY_ARCHITECTURE}")
++set(CLANG "clang" CACHE STRING "Clang binary used for BPF compilation")
++set(BPF_INCLUDE_DIRS "" CACHE STRING "Sysroot include path for BPF compilation")
++set(BPF_EXTRA_FLAGS "" CACHE STRING "Extra flags for BPF clang compilation (space-separated)")
++
++separate_arguments(BPF_EXTRA_FLAGS_LIST UNIX_COMMAND "${BPF_EXTRA_FLAGS}")
++
+ set(CLANG_FLAGS -Wall -O2 -fno-stack-protector
+-    -I ${ASM_INCLUDE}
++    ${BPF_EXTRA_FLAGS_LIST}
++    -I ${BPF_INCLUDE_DIRS}
+     -I ${PROJECT_BINARY_DIR}  # required for app_config.h
+ )
+ 
+ function(add_xdp_prog name)
+   add_custom_target(${name} ALL
+-    COMMAND clang ${CLANG_FLAGS} -target bpf -c -g -o ${CMAKE_BINARY_DIR}/${name}.o ${name}.c
++    COMMAND ${CLANG} ${CLANG_FLAGS} -target bpf -c -g -o ${CMAKE_BINARY_DIR}/${name}.o ${name}.c
+     DEPENDS reference
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+     SOURCES src/${name}.c

--- a/dynamic-layers/openembedded-layer/recipes-test/rtc-testbench/rtc-testbench_5.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-test/rtc-testbench/rtc-testbench_5.4.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Real-time and non-real-time traffic validation tool for converged TSN networks"
+
+DESCRIPTION = "The Linux RealTime Communication Testbench validates real-time \
+performance and robustness of hardware, drivers, and the Linux network stack on \
+TSN-enabled Ethernet networks. It generates and mirrors cyclic traffic using \
+AF_PACKET or AF_XDP with eBPF, supporting protocols like PROFINET and OPC UA PubSub."
+
+HOMEPAGE = "https://github.com/Linutronix/RTC-Testbench"
+LICENSE = "BSD-2-Clause & (GPL-2.0-only | BSD-2-Clause)"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=f39e57686080f8752e19c4cd3e04e351 \
+    file://LICENSES/BSD-2-Clause.txt;md5=9e16594a228301089d759b4f178db91f \
+    file://LICENSES/GPL-2.0-only.txt;md5=3d26203303a722dedc6bf909d95ba815 \
+"
+SRC_URI = " \
+    git://github.com/Linutronix/RTC-Testbench.git;tag=v${PV};nobranch=1;protocol=https \
+    file://0001-CMakeLists.txt-make-BPF-clang-and-include-paths-conf.patch \
+"
+SRCREV = "bf016fdf422094f1ef65c0d88f148f46663ebbd8"
+
+DEPENDS += " \
+    libyaml \
+    libbpf \
+    xdp-tools \
+    openssl \
+    clang-native \
+"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE += " \
+    -DRX_TIMESTAMP=ON \
+    -DTX_TIMESTAMP=ON \
+    -DCLANG=${STAGING_BINDIR_NATIVE}/clang \
+    -DBPF_INCLUDE_DIRS=${STAGING_INCDIR} \
+    -DBPF_EXTRA_FLAGS='-D__${TARGET_ARCH}__ -ffile-prefix-map=${S}=${TARGET_DBGSRC_DIR} -ffile-prefix-map=${STAGING_DIR_HOST}=' \
+"
+
+# Require bash since installed scripts use /bin/bash shebang
+RDEPENDS:${PN} += "bash"


### PR DESCRIPTION
Add xdp-tools and rtc-testbench recipes under the
openembedded-layer dynamic layer for wrynose.

These recipes are imported from meta-openembedded/meta-oe because they are
needed for Qualcomm Linux wrynose, but cannot be backported through
meta-openembedded for this stable branch.

rtc-testbench depends on libxdp from xdp-tools, so both recipes are carried
together in meta-qcom. The recipes are placed under
dynamic-layers/openembedded-layer so they are only exposed when meta-oe is
present in BBLAYERS.

Imported from meta-openembedded/meta-oe:
- xdp-tools current recipe state, including:
  - cdd53d4d0d xdp-tools: add recipe
  - b1f98d1a7a xdp-tools: upgrade 1.2.10 -> 1.6.3
- 1eebf6bd51 rtc-testbench: add recipe