### PR TITLE
Remove the FIT disable workaround to enable lava test

### DIFF
--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -6,8 +6,6 @@ require conf/machine/include/qcom-hamoa.inc
 
 MACHINE_FEATURES += "efi pci tpm2"
 
-QCOM_DTB_DEFAULT ?= "hamoa-iot-evk"
-
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \
                       qcom/hamoa-iot-evk-camera-imx577.dtbo \

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -18,7 +18,6 @@ KERNEL_DEVICETREE = ""
 KERNEL_DEVICETREE:glymur-crd = "${QCOM_DTB_DEFAULT}.dtb"
 KERNEL_DEVICETREE:kaanapali-mtp = "${QCOM_DTB_DEFAULT}.dtb"
 KERNEL_DEVICETREE:sm8750-mtp = "${QCOM_DTB_DEFAULT}.dtb"
-KERNEL_DEVICETREE:iq-x7181-evk = "${QCOM_DTB_DEFAULT}.dtb"
 
 setup_efi_folder() {
     # Move EFI content from packages expecting /boot to be the ESP location


### PR DESCRIPTION
As SPINOR flash is deployed in production from lava, the FIT disable workaround is not needed any more.
Revert the FIT disable commits in PR: https://github.com/qualcomm-linux/meta-qcom/pull/2419
LAVA job with SPINOR flash: https://lava.infra.foundries.io/scheduler/job/306661