### PR TITLE
workflows/compile: mount kvm device on kas container

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
+  KAS_IMAGE_VERSION: "latest"
 
 jobs:
   kas-setup:
@@ -38,8 +39,7 @@ jobs:
         run: |
           KAS_CONTAINER=$RUNNER_TEMP/kas-container
           echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
-          LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
-          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
+          wget -qO ${KAS_CONTAINER} https://github.com/siemens/kas/raw/refs/heads/master/kas-container
           chmod +x ${KAS_CONTAINER}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -61,8 +61,11 @@ jobs:
         shell: bash
         run: |
           KAS_CONTAINER=$GITHUB_WORKSPACE/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           chmod +x $KAS_CONTAINER
+          if [ -c /dev/kvm ]; then
+            KAS_CONTAINER="$KAS_CONTAINER --kvm"
+          fi
+          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
 
       - name: Setup build variables
         shell: bash

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -41,6 +41,7 @@ on:
 
 env:
   KAS_CLONE_DEPTH: 1
+  KAS_IMAGE_VERSION: "latest"
 
 jobs:
   reusable_compile_job:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -68,8 +68,11 @@ jobs:
         shell: bash
         run: |
           KAS_CONTAINER=$RUNNER_TEMP/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           chmod +x $KAS_CONTAINER
+          if [ -c /dev/kvm ]; then
+            KAS_CONTAINER="$KAS_CONTAINER --kvm"
+          fi
+          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
 
       - name: Setup build variables
         shell: bash


### PR DESCRIPTION
The KVM is necessary when we need to emulate a full systems, considerably improvising the use of qemu. This is necessary to efficiently execute the OE-core runqemu inside the kas container helper.