### PR TITLE
workflows: include PR details in LAVA metadata

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -116,6 +116,9 @@ runs:
           if [ -n "${INPUTS_PR_URL}" ]; then
             echo "PR_URL=${INPUTS_PR_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
           fi
+          echo "GITHUB_WORKFLOW_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/ations/runs/${GITHUB_RUN_ID}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "GITHUB_WORKFLOW_RUN_ID=${GITHUB_RUN_ID}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "GITHUB_WORKFLOW_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}" >> "${VARS_OUT_PATH}/gh-variables.ini"
           IMAGE_TYPE="core-image-base"
           case "${INPUTS_DISTRO_NAME}" in
             "qcom-distro"*)

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: "Ref in qcom-linux-testkit repository. Can be a CalVer tag (testkit-YYYY.MM.DD) or commit SHA"
     required: false
     default: ""
+  pr_number:
+    description: "Pull request number. When set, it is added to the LAVA job metadata as PR_NUMBER"
+    required: false
+    default: ""
+  pr_url:
+    description: "Pull request URL. When set, it is added to the LAVA job metadata as PR_URL"
+    required: false
+    default: ""
 
 outputs:
   jobmatrix:
@@ -68,6 +76,8 @@ runs:
           INPUTS_TESTPLAN: ${{ inputs.testplan }}
           INPUTS_PREFIX: ${{ inputs.prefix }}
           INPUTS_TESTKIT_REF: ${{ inputs.testkit_ref }}
+          INPUTS_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUTS_PR_URL: ${{ inputs.pr_url }}
         run: |
           set -euo pipefail
           cd lava-test-plans && pip install .
@@ -96,6 +106,15 @@ runs:
           echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/" >> "${VARS_OUT_PATH}/gh-variables.ini"
           if [ -n "${INPUTS_TESTKIT_REF}" ]; then
             echo "TEST_DEFINITIONS_REVISION=${INPUTS_TESTKIT_REF}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          fi
+          # For pull request builds, record the PR number and URL so they end up
+          # in the LAVA job metadata section (rendered by the lava-test-plans
+          # metadata templates). Left unset for push/nightly builds.
+          if [ -n "${INPUTS_PR_NUMBER}" ]; then
+            echo "PR_NUMBER=${INPUTS_PR_NUMBER}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          fi
+          if [ -n "${INPUTS_PR_URL}" ]; then
+            echo "PR_URL=${INPUTS_PR_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
           fi
           IMAGE_TYPE="core-image-base"
           case "${INPUTS_DISTRO_NAME}" in

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -36,6 +36,14 @@ on:
         required: true
         type: string
         description: "Name of the project in lava-test-plans"
+      pr_number:
+        required: false
+        type: string
+        description: "Pull request number. Added to the LAVA job metadata for PR builds"
+      pr_url:
+        required: false
+        type: string
+        description: "Pull request URL. Added to the LAVA job metadata for PR builds"
     outputs:
       summary_id:
         description: "ID of the test summary artifact"
@@ -67,6 +75,8 @@ jobs:
           testplan: "${{ inputs.distro_name }}/boot"
           ref: ${{ inputs.lava_test_plans_ref }}
           testkit_ref: ${{ inputs.testkit_ref }}
+          pr_number: ${{ inputs.pr_number }}
+          pr_url: ${{ inputs.pr_url }}
 
       - name: Print output ID
         env:
@@ -192,6 +202,8 @@ jobs:
           testplan: "${{ inputs.distro_name }}/pre-merge"
           ref: ${{ inputs.lava_test_plans_ref }}
           testkit_ref: ${{ inputs.testkit_ref }}
+          pr_number: ${{ inputs.pr_number }}
+          pr_url: ${{ inputs.pr_url }}
 
       - name: Print output ID
         env:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.branch.outputs.value }}
+      pr_number: ${{ steps.branch.outputs.pr_number }}
+      pr_url: ${{ steps.branch.outputs.pr_url }}
     steps:
       # github.event.workflow_run.pull_requests is empty for PRs opened from
       # forked repositories, so the target branch can't be read from the event
@@ -37,6 +39,14 @@ jobs:
           BRANCH=$(jq -r '.pull_request.base.ref // "master"' event.json)
           echo "::notice title=Target branch::Resolved target branch: $BRANCH"
           echo "value=$BRANCH" >> "$GITHUB_OUTPUT"
+          # PR number and URL are taken from the pull_request event payload and
+          # forwarded to the test workflow so they can be embedded in the LAVA
+          # test job metadata section.
+          PR_NUMBER=$(jq -r '.number // .pull_request.number // ""' event.json)
+          PR_URL=$(jq -r '.pull_request.html_url // ""' event.json)
+          echo "::notice title=Pull request::PR #${PR_NUMBER} (${PR_URL})"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
   test:
     needs: determine-target-branch
@@ -45,6 +55,8 @@ jobs:
     secrets: inherit
     with:
       build_id: ${{ github.event.workflow_run.id }}
+      pr_number: ${{ needs.determine-target-branch.outputs.pr_number }}
+      pr_url: ${{ needs.determine-target-branch.outputs.pr_url }}
 
   comment-on-pr:
     name: "Comment on PR"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,14 @@ on:
       build_id:
         required: true
         type: string
+      pr_number:
+        required: false
+        type: string
+        description: "Pull request number. Added to the LAVA job metadata for PR builds"
+      pr_url:
+        required: false
+        type: string
+        description: "Pull request URL. Added to the LAVA job metadata for PR builds"
     outputs:
       summary_ids:
         description: "IDs of the test summary artifact"
@@ -40,6 +48,8 @@ jobs:
       distro_name: "nodistro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
+      pr_number: "${{ inputs.pr_number }}"
+      pr_url: "${{ inputs.pr_url }}"
   test-qcom-distro:
     needs: [prepare-env]
     name: "Test qcom-distro"
@@ -53,6 +63,8 @@ jobs:
       distro_name: "qcom-distro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
+      pr_number: "${{ inputs.pr_number }}"
+      pr_url: "${{ inputs.pr_url }}"
   test-qcom-distro_linux-qcom-6-18:
     needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-6.18"
@@ -67,6 +79,8 @@ jobs:
       distro_suffix: "_linux-qcom-6.18"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
       testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
+      pr_number: "${{ inputs.pr_number }}"
+      pr_url: "${{ inputs.pr_url }}"
 
   collect-ids:
     name: "Collect Summary artifact IDs"


### PR DESCRIPTION
Add PR URL and number to .ini file that is used in lava-test-plans to generate test jobs. This will allow to query LAVA database for jobs related to a specific pull request.