### PR TITLE
qcom-dtb-metadata: update to build version V1.0

### DIFF
--- a/recipes-kernel/linux/qcom-dtb-metadata_1.0.bb
+++ b/recipes-kernel/linux/qcom-dtb-metadata_1.0.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-dtb-metadata.git;branch=main;protocol=https;tag=v${PV}"
 
-SRCREV = "3bad7a71dd87df675353ec6c07d97f8bf6c68761"
+SRCREV = "7fc788a9758b572cbbbea312332b6621823d55c0"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Update SRCREV to pick up V1.0 tag

Changes since V0.8:

v0.9:
- Update Stale PR Workflow: Auto-close after 30+5 days
- Update check-fitimage-metadata.sh
- Add compatible support for qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo and board-subtype
- Update qcom-next-fitimage.its: Update Hamoa & Purwa with camx overlay

v1.0:
- Update qcom-metadata.dts: Update the Glymur SOC
- Add FIT support for Kaanapali and SM8750
- Update qcom-next-fitimage.its to add staging dtbo for Hamoa
- Update qcom-preflight-checks.yml
- fitimage: renumber and correctly prune conf entries
- fitimage: use prebuilt EL2 DTBs in FIT configurations
- qcom-next-fitimage.its: Add support for glymur-crd-camx.dtbo