### PR TITLE
ci: skip uploading redundant build artifacts to S3

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -169,8 +169,25 @@ jobs:
           uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
           mkdir -p $uploads_dir
           if [ -d $images_dir ]; then
+            # Skip symlink names whose content is also published under another
+            # name: the versioned '*--<version>*' links duplicate the
+            # machine-suffixed ones, and the '<type>-<machine>.bin' kernel
+            # links duplicate Image, Image.gz, zImage and vmlinux.
+            exclude=( ! -name '*--*' ! -name 'vmlinux-*.bin' ! -name 'Image-*.bin' ! -name 'Image.gz-*.bin' ! -name 'zImage-*.bin' )
+            # The qcomflash tarball already ships the rootfs (rootfs.img), the
+            # ESP (efi.bin) and vmlinux, so skip their standalone copies when
+            # the tarball is published (uncompress or extract them if needed)
+            if compgen -G "$images_dir/*.qcomflash.tar.gz" > /dev/null; then
+              exclude+=( ! -name '*.rootfs.ext4' ! -name 'esp-qcom-image-*.vfat' ! -name 'vmlinux' )
+            fi
+            # The world build deploys the same initramfs images for every
+            # machine, so publish them only from the generic machines
+            case "${INPUTS_MACHINE}" in
+              qcom-armv8a|qcom-armv7a) ;;
+              *) exclude+=( ! -name 'initramfs-firmware-*' ! -name 'initramfs-test*' ! -name 'initramfs-kerneltest*' ! -name 'initramfs-tiny*' ) ;;
+            esac
             # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
-            find $images_dir/ -maxdepth 1 -type l -exec cp -v --dereference {} $uploads_dir/ \;
+            find $images_dir/ -maxdepth 1 -type l "${exclude[@]}" -exec cp -v --dereference {} $uploads_dir/ \;
             # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
             # Copy *.efi, *.efi and *.vfat as they are useful for debugging
             find $images_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp -v {} $uploads_dir/ \;


### PR DESCRIPTION
The artifact staging step publishes every symlinked file from the
deploy directory, which uploads several copies of the same content: the
versioned '*--<version>*' symlinks duplicate the machine-suffixed
names, and the '<type>-<machine>.bin' kernel symlinks duplicate Image,
Image.gz, zImage and vmlinux (vmlinux alone accounts for two 450 MB
copies per job). For machines flashed via the qcomflash tarball, the
raw rootfs '.ext4' (multiple GBs per image, uncompressed), the 512 MB
ESP '.vfat' and vmlinux are already shipped inside the tarball as
rootfs.img, efi.bin and vmlinux, so their standalone copies only
inflate the upload. On top of that, the world build deploys the same
initramfs images (firmware and test variants, around 120 files and
1.3 GiB) for every machine, duplicating near-identical content across
every job of a run. A single qcom-distro job currently uploads around
32 GiB, most of it redundant.

Skip the duplicated symlink names, skip the raw rootfs ext4, the ESP
vfat and vmlinux whenever a qcomflash tarball is part of the upload
(anyone needing those files can extract them from the tarball), and
publish the world-built initramfs images only from the generic
qcom-armv8a and qcom-armv7a machines. The initramfs-rootfs-image
artifacts are still published for every machine, as that image is part
of the machine's UKI boot chain. The qcom-armv8a artifacts consumed by
the LAVA fastboot jobs (boot images and the compressed rootfs) are
unaffected, as that machine does not produce a qcomflash tarball.
