### PR TITLE
iq-x5121-evk.conf: enable fastcv dsp package for purwa

### DIFF
--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -19,6 +19,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-purwa-iot-evk-firmware \
     packagegroup-purwa-iot-evk-hexagon-dsp-binaries \
+    qcom-fastcv-binaries-purwa-iot-evk-dsp \
 "
 
 # IQ-X5121 and IQ-x7181 share the same partition configuration.


### PR DESCRIPTION
Add FastCV DSP support for purwa-iot-evk

CRs-Fixed: 4599178