### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260720 v6.18.37

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -10,14 +10,14 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "6.18.30"
+LINUX_VERSION ?= "6.18.37"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260626
-SRCREV ?= "8c49474603c0b1c278b8fe00ac4e735b92d78ce9"
+# tag:qcom-6.18.y-20260720
+SRCREV ?= "4ab384e41300a12c67d5c18c4e7bc1e3f546cc28"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260720

Changelog:
Merge tag 'v6.18.37' into qcom-6.18.y
Revert "FROMLIST: drm/msm/dp: return 0 from audio_prepare when cable is disconnected"
QCLINUX: arm64: dts: qcom: Add shared X1 staging overlay
BACKPORT: drm/bridge: lontium-lt9611uxc: switch to HDMI audio helpers
BACKPORT: drm/bridge: add connector argument to .hpd_notify callback
FROMLIST: arm64: dts: qcom: purwa-iot-evk: Add Embedded controller node
FROMLIST: dt-bindings: embedded-controller: qcom,hamoa-crd-ec: Add Purwa IOT EVK
FROMLIST: wifi: ath12k: fix ML-STA authentication timeout
FROMLIST: arm64: dts: qcom: shikra: Add missing CPU OPPs
FROMLIST: wifi: ath12k: fix rx_mpdu_start layout for QCC2072
Revert "BACKPORT: drm/bridge: add next_bridge pointer to struct drm_bridge"
Revert "BACKPORT: drm/bridge: refactor HDMI InfoFrame callbacks"
Revert "FROMLIST: dt-bindings: bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver"
Revert "FROMLIST: drm/bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver"
Revert "FROMLIST: dt-bindings: brige: lt9611c: add port-select property for LT9611C"
Revert "FROMLIST: drm/bridge: lontium-lt9611c: Increase MCU poll timeout to 200ms"
Revert "FROMLIST: drm-bridge: lontium lt9611c: fixes and improvements"
Revert "FROMLIST: drm/bridge: lontium-lt9611c: Add DSI port selection via DT property"
Revert "FROMLIST: drm/bridge: lt9611c: fallback to cached HPD status on read failure"
Revert "FROMLIST: drm/bridge: lt9611c: implement hpd_enable callback"
Revert "FROMLIST: drm/bridge: lt9611c: fix DT parsing and bridge refcount"
Revert "FROMLIST: drm/bridge: lt9611c: fix chip type initialization"
Revert "FROMLIST: drm/bridge: lt9611c: clean up probe error and remove paths"
Revert "FROMLIST: arm64: defconfig: Enable LT9611C bridge driver"
QCLINUX: arm64: dts: qcom: Add Hamoa camera sensor support
FROMLIST: arm64: dts: qcom: talos: Add memory-region for audio PD
FROMLIST: arm64: defconfig: Enable LT9611C bridge driver
QCLINUX: arm64: dts: qcom: hamoa: Add pm8010 camera PMIC regulators
FROMLIST: drm/bridge: lt9611c: clean up probe error and remove paths
FROMLIST: drm/bridge: lt9611c: fix chip type initialization
FROMLIST: drm/bridge: lt9611c: fix DT parsing and bridge refcount
FROMLIST: drm/bridge: lt9611c: implement hpd_enable callback
FROMLIST: drm/bridge: lt9611c: fallback to cached HPD status on read failure
FROMLIST: drm/bridge: lontium-lt9611c: Add DSI port selection via DT property
FROMLIST: drm-bridge: lontium lt9611c: fixes and improvements
FROMLIST: drm/bridge: lontium-lt9611c: Increase MCU poll timeout to 200ms
FROMLIST: dt-bindings: brige: lt9611c: add port-select property for LT9611C
FROMLIST: drm/bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver
FROMLIST: dt-bindings: bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver
BACKPORT: drm/bridge: refactor HDMI InfoFrame callbacks
FROMLIST: arm64: dts: qcom: kodiak: Add EL2 overlay
FROMLIST: drm/msm/dp: return 0 from audio_prepare when cable is disconnected
BACKPORT: drm/bridge: add next_bridge pointer to struct drm_bridge
FROMLIST: wifi: ath11k: fix NULL pointer dereference in ath11k_hal_srng_access_begin