### PR TITLE
workflows/compile: drop buildstats github artifacts

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -87,12 +87,6 @@ runs:
 
     - uses: actions/upload-artifact@v6
       with:
-        name: buildstats-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
-        path: |
-          buildstats*
-
-    - uses: actions/upload-artifact@v6
-      with:
         name: kas-build-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
         path: kas-build.yml
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -153,12 +153,6 @@ jobs:
 
       - uses: actions/upload-artifact@v6
         with:
-          name: buildstats-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
-          path: |
-            buildstats*
-
-      - uses: actions/upload-artifact@v6
-        with:
           name: kas-build-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
           path: kas-build.yml
 


### PR DESCRIPTION
They're already stored in S3, so we don't need to have them available here. This will considerably reduce the number of artifacts used because we have many builds.