### PR TITLE
ci: build world only once per machine and distro family

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -193,6 +193,12 @@ jobs:
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
+      # One world build per machine and distro family is enough for compile
+      # coverage: nodistro (including the nogl variant) covers the plain OE
+      # configuration and qcom-distro-catchall enables a superset of the
+      # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
+      # combinations only repeat already-covered world builds.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}
@@ -438,6 +444,12 @@ jobs:
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
       enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
+      # One world build per machine and distro family is enough for compile
+      # coverage: nodistro (including the nogl variant) covers the plain OE
+      # configuration and qcom-distro-catchall enables a superset of the
+      # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
+      # combinations only repeat already-covered world builds.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}


### PR DESCRIPTION
Every job in the compile matrix builds world, so each machine rebuilds it for every distro and kernel combination, around 258 world builds per run. The extra combinations repeat coverage the first build already provides: the kernel variants only change the kernel provider, whose dependent recipes (the out-of-tree kernel modules) are already part of the images built by those jobs, and the debug, performance and qcom-distro configurations are subsets or flag variants of the qcom-distro-catchall configuration. The repeated builds add significant time to every job and deploy another copy of the world-only artifacts, such as the initramfs firmware images, for each combination.

Pass the world input to the compile workflow so world is built once per machine and distro family: on the default kernel row of nodistro (including nodistro-nogl, whose purpose is a world build without opengl) and of qcom-distro-catchall, which enables a superset of the qcom-distro DISTRO_FEATURES. This keeps world compile coverage for every machine under both the plain OE and the qcom-distro configurations while reducing the world builds to 35 per run. The open-fw machine variants never build world, but their base machines do, and their additional recipes (trusted-firmware-a-qcom and OP-TEE) are pulled in by their image builds.

Assisted-by: Claude Code:claude-fable-5