### PR TITLE
trusted-firmware-a-qcom: upgrade to qcom-next-2.15-20260804

### DIFF
--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -1,7 +1,12 @@
 DEPENDS += "qtestsign-native optee-os-qcom u-boot-qcom"
 
-SRC_URI:append:qcm6490 = " git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc_blobs;subdir=qc_blobs;branch=main"
-SRCREV_qc_blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
+SRCREV_FORMAT_qcom ?= ""
+
+SRC_URI:append:qcm6490 = " git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc-blobs;subdir=qc_blobs;branch=main"
+SRCREV_qc-blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
+SRCREV_FORMAT_qcom:qcm6490 = "_qc-blobs"
+
+SRCREV_FORMAT .= "${SRCREV_FORMAT_qcom}"
 
 LICENSE += "& LICENSE.qcom"
 LIC_FILES_CHKSUM:qcm6490 += "file://${UNPACKDIR}/qc_blobs/sc7280/qtiseclib/LICENSE;md5=fa83f30385e617b56ef0934f13645621"

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -1,6 +1,6 @@
 DEPENDS += "qtestsign-native optee-os-qcom u-boot-qcom"
 
-SRC_URI += "git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc_blobs;subdir=qc_blobs;branch=main"
+SRC_URI:append:qcm6490 = " git://github.com/coreboot/qc_blobs.git;protocol=https;name=qc_blobs;subdir=qc_blobs;branch=main"
 SRCREV_qc_blobs = "16207f367ddbf280a0c2c8a3d3ee454a59710a25"
 
 LICENSE += "& LICENSE.qcom"

--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom_git.bb
@@ -1,10 +1,10 @@
 require recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
 
-PV = "2.14.0-qcom+git"
+PV = "2.15.0-qcom+git"
 
-SRC_TAG = "tag=qcom-next-2.14-20260507"
+SRC_TAG = "tag=qcom-next-2.15-20260804"
 SRC_URI = "git://github.com/qualcomm-linux/trusted-firmware-a.git;protocol=https;name=tfa;nobranch=1;${SRC_TAG}"
-SRCREV_tfa = "7336923157d8e55ec6e1111b111d6c1befdb1054"
+SRCREV_tfa = "10ecf7dcc641e8453e2e2ea2f21c13c7a867ffe0"
 
 LIC_FILES_CHKSUM += "file://docs/license.rst;md5=6ed7bace7b0bc63021c6eba7b524039e"
 


### PR DESCRIPTION
Upgrade TF-A to qcom-next-2.15-20260804 for all machines. The tag carries the lemans native platform drivers, so qcs9100 builds with no qtiseclib; qcm6490 keeps its qc_blobs qtiseclib.