### PR TITLE
workflows: upgrade lava-test-plans to ed4ac266

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "62f75dda7cc3c62305abaa5b6ace6c06a080bb7f"
+  LAVA_TEST_PLANS_REF: "ed4ac266438d0d9be521a6bd5498c6816ba718c5"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.06.21"
 


### PR DESCRIPTION
This upgrade includes:
 - moving LAVA jobs to use QDL native deployment in LAVA jobs
 - adding shikra-evk device templates