### PR TITLE
gst-plugins-imsdk-common: Add protobuf-native dependency for mlmetapa…

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk-common.inc
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk-common.inc
@@ -16,6 +16,7 @@ SRCREV = "806ad865287c418d2aac380506b7ad44b5a11319"
 DEPENDS += "\
     gstreamer1.0 \
     gstreamer1.0-plugins-base \
+    protobuf-native \
 "
 
 # This package is currently only used and tested on ARMv8 (aarch64) machines.


### PR DESCRIPTION
gst-plugins-imsdk-common: Add protobuf-native dependency for mlmetaparser)

The mlmetaparser protobuf output module uses protobuf_generate_cpp() to generate C++ sources from its .proto schema at build time. This requires the native protoc compiler, which was not declared as a build dependency, causing do_configure to fail with:

  CMake Error: protoc executable not found.

Add protobuf-native to DEPENDS so the native protoc binary is built and staged before configure runs.