### PR TITLE
minkipc: Update tag to v1.2.9

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
@@ -23,7 +23,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93 \
                     file://optee-client/optee_client/LICENSE;md5=69663ab153298557a59c67a60a743e5b \
                     file://optee-test/optee_test/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
-SRCREV_minkipc = "2de4f84751e46da8782648518916b9c8f75894b9"
+SRCREV_minkipc = "ce145804d9e994e0a7913f8d224d52e84bce6608"
 SRCREV_opteec = "acb0885c117e73cb6c5c9b1dd9054cb3f93507ee"
 SRCREV_opteet = "1c3d6be5eaa6174e3dbabf60928d15628e39b994"
 


### PR DESCRIPTION
Release v1.2.9 of minkipc brings the following:
- Support for Shikra PKCS#11 TA.
- Fix bug whereby QTEE supplicant crashes on Hamoa/Purwa since they don't support RPMB listener due to emulated RPMB.