### PR TITLE
qcomtee: Use release 1.0.2 instead of using git snapshot

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/qcomtee/qcomtee_1.0.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/qcomtee/qcomtee_1.0.2.bb
@@ -11,8 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93"
 
 inherit cmake
 
-SRC_URI = "git://github.com/quic/quic-teec.git;branch=main;protocol=https"
-SRCREV = "a40de2d23dc04f2fad144315848c31e70c869d3d"
-PV = "0.0+git"
+SRC_URI = "git://github.com/quic/quic-teec.git;nobranch=1;protocol=https;tag=v${PV}"
+SRCREV = "34fa8197a34a06ec0187c2958c776f3c3a6b9ec1"
 
 DEPENDS += "qcbor"


### PR DESCRIPTION
qcomtee recipe is currently not versioned, and points to an arbitrary
untagged revision of the quic-teec repo. Use release 1.0.2 instead of
using a git snapshot to consume the following updates:
- Allow fallback to CBOR when QCBOR is not available.
- Fix minor 32-bit compilation issues for qcomtee test client.