### PR TITLE
camx-dlkm: Update camx driver to v1.0.4

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.4.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.4.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
 "
 
-SRCREV = "56b463cba50c1db1f2cc53ddd8790730f14bd8a8"
+SRCREV = "f073e13d7a310df5c1551f2136199f85c85db6d8"
 
 inherit module
 


### PR DESCRIPTION
This tag v1.0.4 brings a below updates:

- Release SCM PAS metadata context after firmware load.
- Atomic-safe memory reference handling and VFE reset race condition fixes.
- Fix OOB write in bus_rd/bus_wr reg_set.
- Add KMD buffer space validation.
- Fix use-after-free by validating against in_q.
- Fix OOB access in bandwidth path handling.
- Fix OOB write via TOCTOU and shallow-copy issues.
- Add recovery skip support for ICP.
- Add support for multi-trigger link.
- Fix use-after-free and confused deputy vulnerabilities.
- Fix OOB write in LRME driver.
- Fix GPIO acquire and release logic.
- Enable per-port start/stop feature.
- Fix OOB write in OPE bus write update path.
- Fix out-of-bounds array access in ISP driver.
- Validate request ID before array indexing during packet parsing.
- Enable power domain support for MCLK.
- Fix OOB write and memory leak issues in OPE.
- Wait for in-flight buffer completion before per-port flush operations.