### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "0ea6db50edc5d4edd3887b593bed080d71d63a08"
+SRCREV = "8e85e196d2478e67b32558dc833be3beceeea512"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Fang Wu (1):
    platforms/qcs615: fix duplicate xbl_b type-guid issue

Beny Compteq (1):
    platforms/qcm6490-idp: Fix emmc partitions options

Vivek Puar (2):
    platforms/sm8750-mtp: assign unique GUIDs for xbl_b and xbl_config_b partitions
    platforms/kaanapali-mtp: asign unique GUIDs to B-slot boot partitions