### PR TITLE
linux-qcom: add pahole-native dependency

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -14,6 +14,10 @@ LINUX_VERSION ?= "7.1"
 
 PV = "${LINUX_VERSION}+git"
 
+KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "1", "0", d), "0", d)}'
+do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
+EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
+
 # tag: qcom-next-7.1-20260708
 SRCREV ?= "947408df47978cb86ffcd180a6244379e03301bf"
 

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,6 +16,10 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
+KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "1", "0", d), "0", d)}'
+do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
+EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
+
 # tag:qcom-6.18.y-20260720
 SRCREV ?= "4ab384e41300a12c67d5c18c4e7bc1e3f546cc28"
 


### PR DESCRIPTION
Add pahole-native as a kernel build dependency to support BTF generation when CONFIG_DEBUG_INFO_BTF and CONFIG_DEBUG_INFO_BTF_MODULES are enabled.

This is required for builds that enable BTF support, which is used by modern eBPF workflows.
