### PR TITLE
Add support for Qualcomm display overlays that enable platform-specific color-processing functionality

### DIFF
--- a/recipes-graphics/sde-dlkm/sde-dlkm_1.0.0.bb
+++ b/recipes-graphics/sde-dlkm/sde-dlkm_1.0.0.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Qualcomm SDE (Snapdragon Display Engine) display driver"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=223037c4be0bfc6cf757035432adf983"
+
+inherit module
+
+SRCREV = "70ef6d41350020df80c406fcc30db4d63e9d776b"
+SRC_URI = " \
+    git://github.com/qualcomm-linux/display-driver.git;tag=v${PV};branch=main;protocol=https \
+"
+
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
Some Qualcomm display hardware features, including post-processing capabilities such as IGC, GC, dither, gamut correction, PCC, and QSEED scaling, require platform-specific controls and user-mode integration that are not currently exposed through the standard DRM/KMS interfaces provided by the SDE driver. The overlay implementation provides access to these capabilities on supported platforms while preserving compatibility with the upstream display stack.

The SDE driver implementation remains compatible with existing DRM/KMS workflows and standard display operation. Existing compositors and user space components continue to operate using standard DRM/KMS interfaces for basic display functionality. Overlay-specific interfaces are only required for Qualcomm-specific color-processing features that rely on vendor-defined properties and associated user-space support.

On supported platforms, these properties are consumed by Snapdragon Display Manager (SDM) user-space libraries through the SDM backend to exercise advanced display post-processing capabilities. Standard compositors and backends continue to function for basic display operation without requiring awareness of these Qualcomm-specific features.

This enables supported Qualcomm platforms to expose advanced display hardware capabilities without impacting core display functionality, existing user space components, or standard compositor operation.