### PR TITLE
sde: add FIT overlay support and device tree for qcs6490-rb3gen2

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -242,6 +242,56 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-sde] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-sde] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-sde] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-sde-el2kvm] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde kodiak-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-camx-sde-staging] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-camx-sde-staging] = \
+    "qcs6490-rb3gen2 qcs5430-fps-camx qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde kodiak-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-sde-staging] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx qcs6490-rb3gen2-sde kodiak-staging"
+
 # ---------- glymur ----------
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -21,6 +21,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/kodiak-el2.dtbo \
                       qcom/kodiak-staging.dtbo \
                       qcom/qcs5430-fps-camx.dtbo \
+                      qcom/qcs6490-rb3gen2-sde.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Add FIT_DTB_COMPATIBLE entries in fit-dtb-compatible-linux-qcom.inc for the SDE overlay variants and include the corresponding device tree blob in the RB3 Gen2 core kit machine configuration.

As of now, EDP display is being enabled via SDE overlay support for the following targets:
Base SDE variants:
- qcom_qcs5430-iot-sde / qcom_qcs6490-iot-sde
- qcom_qcs5430-iot-subtype2-sde / qcom_qcs6490-iot-subtype2-sde

SDE + el2kvm variants:
- qcom_qcs{5430,6490}-iot{,-subtype2}-sde-el2kvm

SDE + staging variants:
- qcom_qcs{5430,6490}-iot{,-subtype2}-sde-staging

Combined camx + SDE variants:
- qcom_qcs{5430,6490}-iot{,-subtype2}-camx-sde
- qcom_qcs{5430,6490}-iot{,-subtype2}-camx-sde-el2kvm
- qcom_qcs{5430,6490}-iot{,-subtype2}-camx-sde-staging