### PR TITLE
Improvide packaging of Hexagon DSP binaries

### DIFF
--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -51,10 +51,6 @@ FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "${DSP_QCOM_PATH}/dsp/cdsp"
 FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-config = "${DSP_QCOM_CONF_D_PATH}"
 FILES:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "${DSP_QCOM_PATH}/dsp/sdsp"
 
-ALLOW_EMPTY:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "1"
-ALLOW_EMPTY:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "1"
-ALLOW_EMPTY:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "1"
-
 INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-adsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-cdsp = "arch libdir file-rdeps textrel"
 INSANE_SKIP:hexagon-dsp-binaries-${DSP_PKG_NAME}-sdsp = "arch libdir file-rdeps textrel"

--- a/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
+++ b/recipes-bsp/hexagon-dspso/hexagon-dspso.inc
@@ -114,3 +114,7 @@ do_install:prepend() {
     ls ${B}/dspso-cdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/cdsp && install -m 0644 ${B}/dspso-cdsp/* ${D}${DSP_QCOM_PATH}/dsp/cdsp
     ls ${B}/dspso-sdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/sdsp && install -m 0644 ${B}/dspso-sdsp/* ${D}${DSP_QCOM_PATH}/dsp/sdsp
 }
+
+# Make sure that there is nothing in the meta-package, all firmware must go to
+# a particular package.
+FILES:${PN} = ""

--- a/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qar2130p.bb
@@ -14,7 +14,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sar2130p-compute \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-qar2130p-adsp \
     hexagon-dsp-binaries-qcom-qar2130p-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8150-hdk.bb
@@ -19,7 +19,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8150-sensors \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-sm8150-hdk-adsp \
     hexagon-dsp-binaries-qcom-sm8150-hdk-cdsp \
     hexagon-dsp-binaries-qcom-sm8150-hdk-sdsp \

--- a/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8350-hdk.bb
@@ -21,7 +21,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-vpu \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-sm8350-hdk-adsp \
     hexagon-dsp-binaries-qcom-sm8350-hdk-cdsp \
     hexagon-dsp-binaries-qcom-sm8350-hdk-sdsp \

--- a/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8450-hdk.bb
@@ -19,7 +19,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8450-sensors \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-sm8450-hdk-adsp \
     hexagon-dsp-binaries-qcom-sm8450-hdk-cdsp \
     hexagon-dsp-binaries-qcom-sm8450-hdk-sdsp \

--- a/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8550-hdk.bb
@@ -17,7 +17,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8550-modem \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-sm8550-hdk-adsp \
     hexagon-dsp-binaries-qcom-sm8550-hdk-cdsp \
 "

--- a/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-sm8650-hdk.bb
@@ -19,7 +19,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-sm8650-ipa \
 "
 
-RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+RRECOMMENDS:${PN}-hexagon-dsp-binaries = " \
     hexagon-dsp-binaries-qcom-sm8650-hdk-adsp \
     hexagon-dsp-binaries-qcom-sm8650-hdk-cdsp \
 "


### PR DESCRIPTION
Providing empty Hexagon DSP packages for commercial devices doesn't play
 well with the packages for commercial devices. Users can end up with
empty packages still claiming to be covered by the EULA. Drop
ALLOW_EMPTY from those packages to prevent them from being created.
