### PR TITLE
dTPM: declare tpm2 machine feature on glymur-crd and shikra-evk

### DIFF
--- a/conf/machine/glymur-crd.conf
+++ b/conf/machine/glymur-crd.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-glymur.inc
 
-MACHINE_FEATURES = "efi pci"
+MACHINE_FEATURES = "efi pci tpm2"
 
 QCOM_DTB_DEFAULT ?= "glymur-crd"
 

--- a/conf/machine/shikra-evk.conf
+++ b/conf/machine/shikra-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-shikra.inc
 
-MACHINE_FEATURES += "efi pci phone"
+MACHINE_FEATURES += "efi pci phone tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/shikra-cqm-evk.dtb \


### PR DESCRIPTION
Glymur-CRD and Shikra-EVK boards have a discrete TPM (ST33HTPH2X32AHE4) chip connected over SPI. Without tpm2 in MACHINE_FEATURES the TPM2 stack and related recipes are not pulled in for these targets.

Add tpm2 to MACHINE_FEATURES for both machines to properly enable dTPM hardware support