### PR TITLE
pkcs11:  Fix static initialization issue caused by compound literal address.

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/files/0001-test-pkcs11-Fix-static-initialization-issue-caused-by-compound-literal-address.patch
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/files/0001-test-pkcs11-Fix-static-initialization-issue-caused-by-compound-literal-address.patch
@@ -1,0 +1,48 @@
+From 9dd9d864042871518a257af3a46f53dc299ae778 Mon Sep 17 00:00:00 2001
+From: Saheli Saha <sahesaha@qti.qualcomm.com>
+Date: Tue, 23 Jun 2026 15:47:50 +0530
+Subject: [PATCH] test: pkcs11: Fix static initialization issue caused by
+ compound literal address
+
+Modified the compound literals used for session object templates to avoid problems arising from taking the address of a compound literal during
+static initialization.
+
+Reviewed-by: Jens Wiklander <jens.wiklander@oss.qualcomm.com>
+Signed-off-by: Saheli Saha <sahesaha@qti.qualcomm.com>
+---
+ host/xtest/pkcs11_1000.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/host/xtest/pkcs11_1000.c b/host/xtest/pkcs11_1000.c
+index 13f3f43..ba3fa62 100644
+--- a/host/xtest/pkcs11_1000.c
++++ b/host/xtest/pkcs11_1000.c
+@@ -1201,14 +1201,18 @@ static CK_ATTRIBUTE cktest_token_object[] = {
+ 	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
+ };
+ 
++static const CK_BBOOL ck_true = CK_TRUE;
++static const CK_BBOOL ck_false = CK_FALSE;
++static const CK_OBJECT_CLASS secret_key_class = CKO_SECRET_KEY;
++static const CK_KEY_TYPE aes_key_type = CKK_AES;
++
+ static CK_ATTRIBUTE cktest_session_object[] = {
+-	{ CKA_DECRYPT,	&(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
+-	{ CKA_TOKEN,	&(CK_BBOOL){CK_FALSE}, sizeof(CK_BBOOL) },
+-	{ CKA_MODIFIABLE, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
+-	{ CKA_KEY_TYPE,	&(CK_KEY_TYPE){CKK_AES}, sizeof(CK_KEY_TYPE) },
+-	{ CKA_CLASS,	&(CK_OBJECT_CLASS){CKO_SECRET_KEY},
+-						sizeof(CK_OBJECT_CLASS) },
+-	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
++	{ CKA_DECRYPT,	  (void *)&ck_true,         sizeof(CK_BBOOL) },
++	{ CKA_TOKEN,	  (void *)&ck_false,        sizeof(CK_BBOOL) },
++	{ CKA_MODIFIABLE, (void *)&ck_true,         sizeof(CK_BBOOL) },
++	{ CKA_KEY_TYPE,	  (void *)&aes_key_type,    sizeof(CK_KEY_TYPE) },
++	{ CKA_CLASS,	  (void *)&secret_key_class, sizeof(CK_OBJECT_CLASS) },
++	{ CKA_VALUE,	  (void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
+ };
+ 
+ /* Create session object and token object from a session */
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/qualcomm/minkipc.git;branch=main;protocol=https;tag=
            git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https;tag=4.0.0;name=opteet;destsuffix=${BPN}-${PV}/optee-test/optee_test \
            file://0001-xtest-Remove-regression-suite-from-default-test-suit.patch;patchdir=optee-test/optee_test \
            file://0002-xtest-pkcs11-Stub-the-test-cases-inapplicable-for-QT.patch;patchdir=optee-test/optee_test \
+		   file://0001-test-pkcs11-Fix-static-initialization-issue-caused-by-compound-literal-address.patch;patchdir=optee-test/optee_test \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93 \


### PR DESCRIPTION
Fixes a static initialization issue in the PKCS#11 tests caused by using the address of a compound literal. The compound literal had limited lifetime semantics, which could lead to compiler warnings and potential undefined behavior. This change replaces the compound literal usage with a statically allocated object to ensure correct initialization and improve code reliability.