### PR TITLE
[Wrynose] ci/base.lock: update oe-core layer

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 5d1aa5c806c061a2994f4decb59016610f093213
+            commit: 05b964cc4b56783715fa2db7c7303d978ccef7a4
         meta-lts-mixins:
             commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:


### PR DESCRIPTION
Update oe-core to 05b964cc4b56783715fa2db7c7303d978ccef7a4 on wrynose.

Changes since 5d1aa5c806:
  - 05b964cc4b bluez5: set L2CAP IMTU for OBEX profile listeners
  - e60241e0bc bluez5: fix gatt cache sync issue
  - 6db4cef64a bluez5: Fix sending extra bytes with MGMT_OP_ADD_EXT_ADV_DATA
  - 1e5bc0c6b9 bluez5: fix set volume failure