### PR TITLE
fastrpc: create fastrpc system group account

### DIFF
--- a/recipes-support/fastrpc/fastrpc_1.0.6.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.6.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-inherit autotools systemd ptest pkgconfig
+inherit autotools systemd ptest pkgconfig useradd
 
 EXTRA_OECONF += "\
     --with-systemdsystemunitdir=${systemd_system_unitdir} \
@@ -61,6 +61,9 @@ FILES:${PN}-tests += " \
     ${libdir}/fastrpc_test/*.so \
     ${datadir}/fastrpc_test \
 "
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM:${PN} = "--system fastrpc"
 
 # Tests specific packages are including prebuilt test libraries
 INSANE_SKIP:${PN}-tests += "arch libdir ldflags"


### PR DESCRIPTION
The fastrpc group is missing from the system and this creates a warning during the image:

| stdio: WARNING: core-image-base-1.0-r0 do_rootfs: Group fastrpc has never been defined
| stdio: WARNING: core-image-weston-1.0-r0 do_rootfs: Group fastrpc has never been defined

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/2436