### PR TITLE
[wrynose] ci: build world only once per machine and distro family

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -193,6 +193,12 @@ jobs:
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
+      # One world build per machine and distro family is enough for compile
+      # coverage: nodistro (including the nogl variant) covers the plain OE
+      # configuration and qcom-distro-catchall enables a superset of the
+      # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
+      # combinations only repeat already-covered world builds.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}
@@ -430,6 +436,12 @@ jobs:
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
       enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
+      # One world build per machine and distro family is enough for compile
+      # coverage: nodistro (including the nogl variant) covers the plain OE
+      # configuration and qcom-distro-catchall enables a superset of the
+      # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
+      # combinations only repeat already-covered world builds.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2704.