### PR TITLE
u-boot-qcom: bump SRCREV to 2026.07

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -5,9 +5,9 @@ DEPENDS += "bc-native dtc-native gnutls-native python3-pyelftools-native qtestsi
 
 COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
-PV = "2026.04+2026.07-rc2+git"
+PV = "2026.07+git"
 
-SRCREV = "5a77d4670d8084ada24a2735dda75788ed5ce925"
+SRCREV = "e35d929347b19b66db87995724f0fd94be057ff4"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
u-boot-qcom: Update U-Boot revision from 2026.07-rc2 to 2026.07

Bump SRCREV and PV to pull in the latest upstream fixes and
updates from the Qualcomm U-Boot repository.

Changelog:
    - Sync to 2026.07 release
    - Add QCOM SPL support
    - Add SPL UFS boot support
    - Add SPL support for drivers: serial, pinctrl, GENI, clk-stub
    - Add Snagboot support and documentation
    - Add Shikra SoC support (clk, pinctrl, dtsi, defconfig)
    - Fix SMEM RAM partition sizing, increase host count, add SPL support
    - Fix GENI serial clock, SPMI V5 offset, I2C NACK recovery
    - Misc config updates (watchdog autostart, SKIP_EARLY_DM)