### PR TITLE
minkipc: add patch for pkcs11 static initialization issue

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/files/0003-test-pkcs11-Fix-static-initialization-issue-caused-b.patch
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/files/0003-test-pkcs11-Fix-static-initialization-issue-caused-b.patch
@@ -1,0 +1,52 @@
+From 9250d66bd04c758d03ce219c23a7b1dab9adbad9 Mon Sep 17 00:00:00 2001
+From: Saheli Saha <sahesaha@qti.qualcomm.com>
+Date: Tue, 23 Jun 2026 15:47:50 +0530
+Subject: [PATCH] test: pkcs11: Fix static initialization issue caused by
+ compound literal address
+
+Modified the compound literals used for session object templates to
+avoid problems arising from taking the address of a compound literal
+during static initialization.
+
+Upstream-Status: Backport [https://github.com/OP-TEE/optee_test/pull/821/changes/9dd9d864042871518a257af3a46f53dc299ae778]
+
+Reviewed-by: Jens Wiklander <jens.wiklander@oss.qualcomm.com>
+Signed-off-by: Saheli Saha <sahesaha@qti.qualcomm.com>
+Signed-off-by: Jiaxing Li <jiaxing.li@oss.qualcomm.com>
+---
+ host/xtest/pkcs11_1000.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/host/xtest/pkcs11_1000.c b/host/xtest/pkcs11_1000.c
+index a55691d..a848478 100644
+--- a/host/xtest/pkcs11_1000.c
++++ b/host/xtest/pkcs11_1000.c
+@@ -1152,14 +1152,18 @@ static CK_ATTRIBUTE cktest_token_object[] = {
+ 	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
+ };
+
++static const CK_BBOOL ck_true = CK_TRUE;
++static const CK_BBOOL ck_false = CK_FALSE;
++static const CK_OBJECT_CLASS secret_key_class = CKO_SECRET_KEY;
++static const CK_KEY_TYPE aes_key_type = CKK_AES;
++
+ static CK_ATTRIBUTE cktest_session_object[] = {
+-	{ CKA_DECRYPT,	&(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
+-	{ CKA_TOKEN,	&(CK_BBOOL){CK_FALSE}, sizeof(CK_BBOOL) },
+-	{ CKA_MODIFIABLE, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
+-	{ CKA_KEY_TYPE,	&(CK_KEY_TYPE){CKK_AES}, sizeof(CK_KEY_TYPE) },
+-	{ CKA_CLASS,	&(CK_OBJECT_CLASS){CKO_SECRET_KEY},
+-						sizeof(CK_OBJECT_CLASS) },
+-	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
++	{ CKA_DECRYPT,	  (void *)&ck_true,         sizeof(CK_BBOOL) },
++	{ CKA_TOKEN,	  (void *)&ck_false,        sizeof(CK_BBOOL) },
++	{ CKA_MODIFIABLE, (void *)&ck_true,         sizeof(CK_BBOOL) },
++	{ CKA_KEY_TYPE,	  (void *)&aes_key_type,    sizeof(CK_KEY_TYPE) },
++	{ CKA_CLASS,	  (void *)&secret_key_class, sizeof(CK_OBJECT_CLASS) },
++	{ CKA_VALUE,	  (void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
+ };
+
+ /* Create session object and token object from a session */
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
+++ b/dynamic-layers/openembedded-layer/recipes-security/minkipc/minkipc_1.2.9.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/qualcomm/minkipc.git;branch=main;protocol=https;tag=
            git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https;tag=4.0.0;name=opteet;destsuffix=${BPN}-${PV}/optee-test/optee_test \
            file://0001-xtest-Remove-regression-suite-from-default-test-suit.patch;patchdir=optee-test/optee_test \
            file://0002-xtest-pkcs11-Stub-the-test-cases-inapplicable-for-QT.patch;patchdir=optee-test/optee_test \
+           file://0003-test-pkcs11-Fix-static-initialization-issue-caused-b.patch;patchdir=optee-test/optee_test \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2b1366ebba1ebd9ae25ad19626bbca93 \


### PR DESCRIPTION
meta-qcom uses OP-TEE optee_test v4.0.0, where pkcs11 test code takes the address of a compound literal in a static initializer (e.g. &(CK_BBOOL){CK_TRUE}). Under compiler optimization, the storage for such compound literals may be reused or overlap with other objects, which can result in invalid values being read back during the test.

Add a new patch (0003) to the minkipc recipe's optee_test source to fix this issue, and reference it in SRC_URI. The patch replaces the compound literal usage with statically allocated objects to ensure correct initialization and improve reliability.

CR: 4500374
Inherited from: https://github.com/qualcomm-linux/meta-qcom/pull/2726