### PR TITLE
refpolicy: enable net_admin for Qualcomm module loaders

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-Add-SELinux-policy-for-qrtr-module-preload.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-Add-SELinux-policy-for-qrtr-module-preload.patch
@@ -1,0 +1,100 @@
+From 7f3c9a2e1b6d4508c2af5e0d9b41236a8e5c7d90 Mon Sep 17 00:00:00 2001
+From: Wenwen Fu <wenwfu@qti.qualcomm.com>
+Date: Tue, 15 Jul 2026 00:00:00 +0000
+Subject: [PATCH] refpolicy: grant systemd_modules_load_t CAP_NET_ADMIN
+
+systemd-modules-load fails to load the qrtr and qrtr_smd kernel modules
+under SELinux enforcing, reporting EPERM ("Failed to insert module
+'qrtr': Permission denied"). Both modules register the PF_QIPCRTR network
+protocol family during module init (sock_register(), MODULE_ALIAS_NETPROTO),
+which the kernel gates on CAP_NET_ADMIN. The systemd_modules_load_t domain
+is not granted net_admin, so the load is denied.
+
+The denial is dontaudit'd by the base policy, so no AVC is emitted during
+normal operation; it is only observable after disabling dontaudit rules
+(semodule -DB):
+
+  avc: denied { net_admin } for pid=404 comm="systemd-modules"
+  capability=12 scontext=system_u:system_r:systemd_modules_load_t:s0
+  tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=capability
+
+Add a policy module qcom_qrtr_modload granting systemd_modules_load_t the
+net_admin capability, so these modules can be preloaded from
+modules-load.d instead of falling back to a delayed modalias autoload.
+
+The require block must declare the capability class explicitly (in
+addition to the type via gen_require): without it the module compiles to
+an empty rule set (the allow is silently dropped) and grants nothing.
+
+Upstream-Status: Inappropriate [Qualcomm/product boot-time tuning]
+
+Signed-off-by: Wenwen Fu <wenwfu@qti.qualcomm.com>
+---
+ policy/modules.conf                          |  6 ++++++
+ policy/modules/services/qcom_qrtr_modload.fc |  1 +
+ policy/modules/services/qcom_qrtr_modload.if |  4 ++++
+ policy/modules/services/qcom_qrtr_modload.te | 16 ++++++++++++++++
+ 4 files changed, 27 insertions(+)
+ create mode 100644 policy/modules/services/qcom_qrtr_modload.fc
+ create mode 100644 policy/modules/services/qcom_qrtr_modload.if
+ create mode 100644 policy/modules/services/qcom_qrtr_modload.te
+
+diff --git a/policy/modules.conf b/policy/modules.conf
+index 3a7d1e9..b2f6c84 100644
+--- a/policy/modules.conf
++++ b/policy/modules.conf
+@@ -1,6 +1,12 @@
+ # Layer: services
+ # Module: qcom_nhx
+ #
+ # Qualcomm NHX camera test launcher
+ #
+ qcom_nhx = module
++
++# Layer: services
++# Module: qcom_qrtr_modload
++#
++# Allow systemd-modules-load net_admin to preload qrtr (PF_QIPCRTR)
++#
++qcom_qrtr_modload = module
+diff --git a/policy/modules/services/qcom_qrtr_modload.fc b/policy/modules/services/qcom_qrtr_modload.fc
+new file mode 100644
+index 0000000..c81a4f2
+--- /dev/null
++++ b/policy/modules/services/qcom_qrtr_modload.fc
+@@ -0,0 +1 @@
++# qcom_qrtr_modload: no file contexts (allow-only module)
+diff --git a/policy/modules/services/qcom_qrtr_modload.if b/policy/modules/services/qcom_qrtr_modload.if
+new file mode 100644
+index 0000000..d4e9b17
+--- /dev/null
++++ b/policy/modules/services/qcom_qrtr_modload.if
+@@ -0,0 +1,4 @@
++## <summary>
++## Allow systemd-modules-load to hold net_admin so qrtr/qrtr_smd
++## (which register PF_QIPCRTR at module init) can be preloaded early.
++## </summary>
+diff --git a/policy/modules/services/qcom_qrtr_modload.te b/policy/modules/services/qcom_qrtr_modload.te
+new file mode 100644
+index 0000000..5f2c8ab
+--- /dev/null
++++ b/policy/modules/services/qcom_qrtr_modload.te
+@@ -0,0 +1,16 @@
++policy_module(qcom_qrtr_modload, 1.0)
++
++########################################
++#
++# Allow systemd (systemd_modules_load_t) to hold CAP_NET_ADMIN so it can
++# preload qrtr/qrtr_smd, which register the PF_QIPCRTR network protocol
++# family at module init (requires net_admin). Without this the preload
++# fails with EPERM (dontaudit'd) and qrtr loads ~5s late, delaying audio.
++#
++
++gen_require(`
++	type systemd_modules_load_t;
++	class capability net_admin;
++')
++
++allow systemd_modules_load_t self:capability net_admin;
+--
+2.43.0

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-kernel-allow-module-loaders-to-use-net_admin.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-kernel-allow-module-loaders-to-use-net_admin.patch
@@ -1,0 +1,76 @@
+From f940f8a7e4667948ca0c6709089744bd46075f94 Mon Sep 17 00:00:00 2001
+From: Wenwen Fu <wenwfu@qti.qualcomm.com>
+Date: Wed, 19 Aug 2026 10:07:34 +0800
+Subject: [PATCH] kernel: allow module loaders to use net_admin
+
+The qrtr and qrtr_smd kernel modules register the PF_QIPCRTR network
+protocol family during module initialization. This requires
+CAP_NET_ADMIN, but systemd-modules-load runs in systemd_modules_load_t
+without that capability.
+
+Loading the modules from modules-load.d therefore fails with EPERM. The
+denial is hidden by dontaudit rules and can be observed with
+semodule -DB:
+
+  avc: denied { net_admin } for comm="systemd-modules" capability=12
+  scontext=system_u:system_r:systemd_modules_load_t:s0
+  tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=capability
+
+Gate CAP_NET_ADMIN behind the disabled-by-default
+kernel_module_load_net_admin tunable for domains that can load kernel
+modules, so systems that do not preload such modules retain the existing
+restrictions.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/commit/f940f8a7e4667948ca0c6709089744bd46075f94]
+
+Signed-off-by: Wenwen Fu <wenwfu@qti.qualcomm.com>
+---
+ policy/modules/kernel/kernel.te | 12 ++++++++++++
+ testing/sechecker.ini           |  1 +
+ 2 files changed, 13 insertions(+)
+
+diff --git a/policy/modules/kernel/kernel.te b/policy/modules/kernel/kernel.te
+index 6917215c6..648b92ec1 100644
+--- a/policy/modules/kernel/kernel.te
++++ b/policy/modules/kernel/kernel.te
+@@ -16,6 +16,14 @@ gen_require(`
+ ## </desc>
+ gen_bool(secure_mode_insmod, false)
+ 
++## <desc>
++## <p>
++## Allow domains that can load kernel modules to use the net_admin
++## capability during module initialization.
++## </p>
++## </desc>
++gen_tunable(kernel_module_load_net_admin, false)
++
+ # assertion related attributes
+ attribute can_load_kernmodule;
+ attribute can_receive_kernel_messages;
+@@ -591,6 +599,10 @@ if(secure_mode_insmod) {
+ 	kernel_search_key(can_load_kernmodule)
+ }
+ 
++if (!secure_mode_insmod && kernel_module_load_net_admin) {
++	allow can_load_kernmodule self:capability net_admin;
++}
++
+ ########################################
+ #
+ # Rules for unconfined access to this module
+diff --git a/testing/sechecker.ini b/testing/sechecker.ini
+index dd154e75e..6896939e8 100644
+--- a/testing/sechecker.ini
++++ b/testing/sechecker.ini
+@@ -245,6 +245,7 @@ exempt_source = arpwatch_t
+                 blueman_t
+                 bluetooth_t
+                 brctl_t
++                can_load_kernmodule # Conditional access (kernel_module_load_net_admin)
+                 cgred_t
+                 chronyd_t           # Conditional access (chronyd_hwtimestamp)
+                 condor_startd_t
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
+    file://0003-Add-SELinux-policy-for-qrtr-module-preload.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -6,3 +6,45 @@ SRC_URI:append:qcom = " \
     file://0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch \
     file://0004-kernel-allow-module-loaders-to-use-net_admin.patch \
 "
+
+# Space-separated policy boolean/tunable settings in name=value format.
+# This is compatible with the proposed generic meta-selinux interface so the
+# local hook can be removed once an equivalent upstream implementation exists.
+POLICY_BOOLEANS ?= ""
+
+set_qcom_policy_booleans() {
+    touch "${S}/policy/booleans.conf"
+
+    for setting in ${POLICY_BOOLEANS}; do
+        name="${setting%%=*}"
+        value="${setting#*=}"
+
+        if [ "${name}" = "${setting}" ]; then
+            bbfatal "Invalid POLICY_BOOLEANS entry: ${setting}"
+        fi
+
+        case "${name}" in
+            ""|*[!A-Za-z0-9_]*)
+                bbfatal "Invalid policy boolean name: ${name}"
+                ;;
+        esac
+
+        case "${value}" in
+            true|false) ;;
+            *)
+                bbfatal "Invalid value for ${name}: ${value}"
+                ;;
+        esac
+
+        sed -i "/^[[:space:]]*${name}[[:space:]]*=/d" \
+            "${S}/policy/booleans.conf"
+        echo "${name} = ${value}" >> "${S}/policy/booleans.conf"
+    done
+}
+
+do_compile:prepend:qcom() {
+    set_qcom_policy_booleans
+}
+
+# Qualcomm platforms preload qrtr and qrtr_smd from modules-load.d.
+POLICY_BOOLEANS:append:qcom = " kernel_module_load_net_admin=true"

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,4 +4,5 @@ SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
     file://0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch \
+    file://0004-kernel-allow-module-loaders-to-use-net_admin.patch \
 "


### PR DESCRIPTION
## Background

To optimize audio fast-startup, the audio kernel modules are preloaded early via `modules-load.d`. `qrtr`/`qrtr_smd` are on that list, since the audio path (`apr`/ADSP over glink) needs the QRTR transport up early.

## Problem

Under SELinux enforcing, preloading `qrtr`/`qrtr_smd` fails, so `qrtr` falls back to a delayed autoload ~5s later — pushing audio readiness from ~3s out to ~8–13s and making it unstable across boots:

```
systemd-modules-load[404]: Failed to insert module 'qrtr': Permission denied
systemd-modules-load[404]: Failed to insert module 'qrtr_smd': Permission denied
```

## Root cause

`qrtr`/`qrtr_smd` register the `PF_QIPCRTR` protocol family at init (`sock_register`), which requires `CAP_NET_ADMIN`. `systemd_modules_load_t` lacks `net_admin`, so the load is denied (`EPERM`). The denial is `dontaudit`'d, so no AVC is printed — confirmed only via `semodule -DB`:

```
avc: denied { net_admin } comm="systemd-modules" capability=12 scontext=...:systemd_modules_load_t:s0 tclass=capability
```

## Change

Add a minimal refpolicy module `qcom_qrtr_modload` granting `systemd_modules_load_t self:capability net_admin`, wired into the `refpolicy-targeted` bbappend `SRC_URI` (scoped to `:append:qcom`).

## Verification (qcs9100-ride-sx, enforcing)

`qrtr`/`qrtr_smd` now preload at ~1.8s (no `Permission denied`), and the APR/GPR channel comes up in a single window with no ~5s retry:

```
systemd-modules-load[400]: Inserted module 'qrtr'
systemd-modules-load[400]: Inserted module 'qrtr_smd'
```
