### PR TITLE
[Backport wrynose] mesa: Backport reg_size_vec4 fix for a608 and a612 to 32

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,7 +1,9 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI:append:qcom = " file://0001-freedreno-Add-support-for-A704.patch \
-                        file://0001-freedreno-layout-tu-Fix-UBWC-block-sizes-for-PIPE_FO.patch \
+SRC_URI:append:qcom = " \ 
+    file://0001-freedreno-Add-support-for-A704.patch \
+    file://0001-freedreno-layout-tu-Fix-UBWC-block-sizes-for-PIPE_FO.patch \
+    file://0001-freedreno-Modify-reg_size_vec4-for-a608-and-a612-to-32.patch \
 "
 
 # Enable freedreno driver

--- a/recipes-graphics/mesa/mesa/0001-freedreno-Modify-reg_size_vec4-for-a608-and-a612-to-32.patch
+++ b/recipes-graphics/mesa/mesa/0001-freedreno-Modify-reg_size_vec4-for-a608-and-a612-to-32.patch
@@ -1,0 +1,107 @@
+From 16fb6dcfd1ab2d565363d04b20a77ef24ab56bec Mon Sep 17 00:00:00 2001
+From: Sahitya Kandru <kandru@qti.qualcomm.com>
+Date: Wed, 15 Jul 2026 14:32:30 +0530
+Subject: [PATCH] freedreno: Modify reg_size_vec4 for a608 and a612 to 32
+
+a6xx_gen1_low advertises reg_size_vec4 as 48. But this value is not
+accurate for a608/a612. In some scenarios, when the allocated registers
+exceed the actual number of vec4 registers available, it results into a
+GPU hang. Fix this by using the correct register size.
+
+Cc: mesa-stable
+Fixes: 3d299bc7ef8 ("freedreno: Add A605, A608, A610, A612 GPUs definition")
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/68f79fed521d807e3b53e2f317316d2b1cf09275]
+
+Signed-off-by: Sahitya Kandru <kandru@qti.qualcomm.com>
+---
+ src/freedreno/common/freedreno_devices.py | 63 ++++++++++++++++-------
+ 1 file changed, 43 insertions(+), 20 deletions(-)
+
+diff --git a/src/freedreno/common/freedreno_devices.py b/src/freedreno/common/freedreno_devices.py
+index 742fd1f1df9..4ac41a02b01 100644
+--- a/src/freedreno/common/freedreno_devices.py
++++ b/src/freedreno/common/freedreno_devices.py
+@@ -446,11 +446,28 @@ a6xx_gen4 = GPUProps(
+         # supports_linear_mipmap_threshold_in_blocks = True,
+     )
+ 
++a6xx_gen1_low_magic_regs = dict(
++        RB_DBG_ECO_CNTL = 0x04100000,
++        RB_DBG_ECO_CNTL_blit = 0x04100000,
++        RB_RBP_CNTL = 0x00000001,
++    )
++
++a6xx_gen1_low_raw_magic_regs = [
++        [A6XXRegs.REG_A6XX_PC_MODE_CNTL, 0xf],
++        [A6XXRegs.REG_A6XX_PC_POWER_CNTL, 0],
++        [A6XXRegs.REG_A6XX_VFD_POWER_CNTL, 0],
++        [A6XXRegs.REG_A6XX_TPL1_DBG_ECO_CNTL, 0],
++        [A6XXRegs.REG_A6XX_GRAS_DBG_ECO_CNTL, 0],
++        [A6XXRegs.REG_A6XX_SP_CHICKEN_BITS, 0],
++        [A6XXRegs.REG_A6XX_SP_DBG_ECO_CNTL, 0],
++        [A6XXRegs.REG_A6XX_HLSQ_DBG_ECO_CNTL, 0],
++        [A6XXRegs.REG_A6XX_VPC_DBG_ECO_CNTL, 0],
++        [A6XXRegs.REG_A6XX_UCHE_UNKNOWN_0E12, 0x10000000],
++    ]
++
+ add_gpus([
+         GPUId(605), # TODO: Test it, based only on libwrapfake dumps
+-        GPUId(608), # TODO: Test it, based only on libwrapfake dumps
+         GPUId(610),
+-        GPUId(612), # TODO: Test it, based only on libwrapfake dumps
+     ], A6xxGPUInfo(
+         CHIP.A6XX,
+         [a6xx_base, a6xx_gen1_low],
+@@ -466,24 +483,30 @@ add_gpus([
+         highest_bank_bit = 13,
+         ubwc_swizzle = 0x7,
+         macrotile_mode = 0,
+-        magic_regs = dict(
+-            RB_DBG_ECO_CNTL = 0x04100000,
+-            RB_DBG_ECO_CNTL_blit = 0x04100000,
+-            RB_RBP_CNTL = 0x00000001,
+-        ),
+-        raw_magic_regs = [
+-            [A6XXRegs.REG_A6XX_PC_MODE_CNTL, 0xf],
+-            [A6XXRegs.REG_A6XX_PC_POWER_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_VFD_POWER_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_TPL1_DBG_ECO_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_GRAS_DBG_ECO_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_SP_CHICKEN_BITS, 0],
+-            [A6XXRegs.REG_A6XX_SP_DBG_ECO_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_UCHE_CLIENT_PF, 0x00000004],
+-            [A6XXRegs.REG_A6XX_HLSQ_DBG_ECO_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_VPC_DBG_ECO_CNTL, 0],
+-            [A6XXRegs.REG_A6XX_UCHE_UNKNOWN_0E12, 0x10000000],
+-        ],
++        magic_regs = a6xx_gen1_low_magic_regs,
++        raw_magic_regs = a6xx_gen1_low_raw_magic_regs,
++    ))
++
++add_gpus([
++        GPUId(608),
++        GPUId(612),
++    ], A6xxGPUInfo(
++        CHIP.A6XX,
++        [a6xx_base, a6xx_gen1_low, GPUProps(reg_size_vec4 = 32)],
++        num_ccu = 1,
++        tile_align_w = 32,
++        tile_align_h = 16,
++        tile_max_w = 1024,
++        tile_max_h = 1024,
++        num_vsc_pipes = 16,
++        cs_shared_mem_size = 16 * 1024,
++        wave_granularity = 1,
++        fibers_per_sp = 128 * 16,
++        highest_bank_bit = 13,
++        ubwc_swizzle = 0x7,
++        macrotile_mode = 0,
++        magic_regs = a6xx_gen1_low_magic_regs,
++        raw_magic_regs = a6xx_gen1_low_raw_magic_regs,
+     ))
+ 
+ add_gpus([
+-- 
+2.43.0
+


### PR DESCRIPTION
The freedreno driver in the Mesa version currently shipped via oe-core does not include this fix, which can cause GPU hangs in some graphics compute shaders.

Pull this upstream Mesa commit as a backport to resolve the GPU hangs with the current meta-qcom build until oe-core advances to a Mesa version that already contains this fix. Same changes have been merged into master branch(https://github.com/qualcomm-linux/meta-qcom/commit/0e2d9a0b5bc2b8e2bb961d79c8b2d5b6a801e13e).

QLI-2.0 P0 critical fix.