### PR TITLE
[wrynose] ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 05b964cc4b56783715fa2db7c7303d978ccef7a4
+            commit: c2746a4a165fd99c2d1aafed17533555787f37ce
         meta-lts-mixins:
             commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
@@ -11,7 +11,7 @@ overrides:
         meta-arm:
             commit: caa36c53f796beb25d9b9f58b1b7a492e9987e15
         meta-openembedded:
-            commit: 100027977216601000cbefc42c2ff6cf667e7b5e
+            commit: d97b5602d7f64422c94b7311466cda7f6b1962d5
         meta-virtualization:
             commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
         meta-audioreach:


### PR DESCRIPTION
Relevant changes for oe-core:
- c2746a4a1 clang/llvm: Upgrade to 22.1.8 release
- b2b8d580c dropbear: Add missing WTFPL & Unlicense in LICENSE and LIC_FILES_CHKSUM
- c7f83c6eb libxml2: patch CVE-2026-11979
- 5d04fd8b2 bc: set CVE_PRODUCT
- f85bd55ae baremetal-helloworld: Fix override order
- fa85fc29b qemuboot.bbclass: add missing task dependency on kernel deploy
- cd16340b2 dmidecode: fix x86-only tools being installed on ARM targets
- 5ac52ec8b nospdx: also drop do_create_recipe_sbom
- bfcc2d06c ptest-packagelists.inc: disable glib-2.0 for RISCV64
- c72547e31 libjitterentropy: fix license statement
- 3e77d0cef tcl: disable the timer tests in run-ptest
- 14cad815f sstate: Reduce native sysroot execution race potential
- e4591b38d devtool: provide explicit error for missing "script" command
- 67ebbff68 strace: remove skip-bpf.patch
- 347c50181 i2c-tools: add LGPL-2.1-or-later license for libi2c
- bac697555 quota: use native rpcgen and a single-word RPCGEN_CPP
- c0b89be42 common-licenses/PHP-3.0: Correct the license text
- 821b394b1 python3: skiptest tracemalloc_track_race
- 257a0026c perl: patch CVE-2026-8376
- 7be2517d3 texinfo: add missing perl module runtime dependencies
- 1249e7225 sudo: fix pam-wheel sed for sudo 1.9.17p2 sudoers
- cc8017ccc dhcpcd: patch CVE-2026-56117
- d66dfbcef dhcpcd: patch CVE-2026-56116
- f539f5dcf dhcpcd: patch CVE-2026-56114
- 0d9c9ef0f dhcpcd: patch CVE-2026-56113
- 7cc52ca76 tar: Fix CVE-2026-5704
- 1d30ca40f gnupg: fix CVE-2026-57062
- d3fc48836 libsolv: Fix CVE-2026-9149
- 6aa0976fa cups: fix CVE-2026-41079
- b36ab95b5 cups: fix CVE-2026-27447
- 1244b4a94 vim: fix for CVE-2026-45130 & CVE-2026-46483
- 5d118a3a1 vim: fix for CVE-2026-41411 & CVE-2026-44656
- 20362e149 qemu: Fix CVE-2025-14876
- c7c35f71d qemu: Fix CVE-2026-0665
- 96207c099 qemu: Fix CVE-2026-2243
- 2968968fe cargo: Fix CVE-2026-5223
- e2767a182 cargo: Fix CVE-2026-5222
- 645098000 libxpm: upgrade 3.5.18 -> 3.5.19
- 854e94058 cmake-native: prevent host libidn2 contamination
- 02860b6bf binutils: Fix CVE-2026-6846
- 67b859697 libssh2: fix CVE-2026-55199
- 3db92aa68 libssh2: fix CVE-2026-55200
- 391e4eb92 linux-yocto/6.18: update to v6.18.35
- cfd9df0ee linux-yocto/6.18: update to v6.18.34
- b9dfcd159 linux-yocto/6.18: update to v6.18.33
- 2196aeaa1 linux-yocto/6.18: qat/intel configuration warning fixes
- 94d0935cd linux-yocto/6.18: update to v6.18.32
- 5a88673a5 linux-yocto/6.18: update to v6.18.28
- c1002871e linux-yocto/6.18: update to v6.18.26
- e67e4066a linux-yocto/6.18: update to v6.18.25

Relevant changes for meta-openembedded:
- d97b5602 libuio: fix FILE descriptor leak
- 532ac379 jq: Fix CVE-2026-44777
- 22b6fca8 jq: Fix CVE-2026-43896
- febf2776 jq: Fix CVE-2026-43894
- 6c734459 jq: Fix CVE-2026-41257
- 5a3f41fa jq: Fix CVE-2026-41256
- 6a3d6812 jq: Fix CVE-2026-40612
- f8e16ab3 nodejs: upgrade 22.23.0 -> 22.23.1
- 8d56e123 jsoncpp: fix GCC 16 (and Clang 22) build failure with u8 string literals
- de62fb55 nodejs: upgrade 22.22.3 -> 22.23.0