### PR TITLE
ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: f810998ac90f7a3e20e26555f39d754b16ce8b69
+            commit: 171af3b2915dd076c8d1b205ff75eac1ebd5a586
         bitbake:
-            commit: 7e3489ab3ec39b2dcf4e50eff54d36d42e5a7307
+            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
         meta-arm:
-            commit: 847af9c082cc190b3781f101200a9403426e481b
+            commit: 28606c721503b70e8343968731a24260cfe985bc
         meta-openembedded:
-            commit: a7428c96bf97a751ccd5baa63acfa1f5b49f077e
+            commit: dc0ccaa27311b3379749ecf44f98c0b5e249902e
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
+            commit: bb3f812fa666fa1a03279b77e2c75f529ee9d797
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: f0e1ccafaa877d2781ed953236981dac57439dc8
+            commit: fff4a58a057c26ec0a2067ea5f32acd75ef7add4
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
-            commit: 6e46e36155ff181fb45d9cb5d290d9a3480bf6f7
+            commit: c6bd686178d1dcf3b9b4c859058428ede406f7d1

--- a/patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
+++ b/patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
@@ -16,7 +16,7 @@ Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
 Upstream-Status: Submitted [https://lore.kernel.org/r/20260626201256.112352-1-dmitry.baryshkov@oss.qualcomm.com/]
 ---
  ...t-pause-mnemonic-only-on-x86-x86_64-.patch | 36 +++++++++++++++++++
- .../igt-gpu-tools/igt-gpu-tools_2.4.bb        |  1 +
+ .../igt-gpu-tools/igt-gpu-tools_2.5.bb        |  1 +
  2 files changed, 37 insertions(+)
  create mode 100644 meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-lib-amdgpu-insert-pause-mnemonic-only-on-x86-x86_64-.patch
 
@@ -62,11 +62,11 @@ index 000000000000..1fdaad7b0c66
 + 	}
 + }
 + 
-diff --git a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
+diff --git a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.5.bb b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.5.bb
 index 32a3a3cc48c9..f5f5b3b87316 100644
---- a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
-+++ b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.4.bb
-@@ -13,6 +13,7 @@ SRCREV = "e6b603e4984e4ce30fe1cc2705734d0f130e0550"
+--- a/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.5.bb
++++ b/meta/recipes-graphics/igt-gpu-tools/igt-gpu-tools_2.5.bb
+@@ -13,6 +13,7 @@ SRCREV = "a8e2cbd2854d7980a9eccecc6e0c801d0824b88f"
  
  SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https;branch=master;tag=v${PV} \
             file://0001-lib-meson.build-do-not-hardcode-the-build-directory-.patch \


### PR DESCRIPTION
Also update patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
to make it compatible with igt-gpu-tools 2.5, which is now in oe-core.

meta-openembedded is intentionally held at dc0ccaa27, the last commit
before the abseil-cpp 20260107.1 -> 20260526.0 upgrade (90603f7d4),
because the prebuilt libsensinghubapiprop.so.1.2.1 in qcom-sensors-
binaries links against the abseil 2601.0.0 sonames and fails the file-
rdeps QA check with the newer abseil.

meta-updater is likewise held at fff4a58, right before it moved the
ostree bbappend to 2026.2, since the held-back meta-openembedded still
ships ostree 2026.1.

Relevant changes for oe-core:
- 171af3b29 oeqa/selftest/devtool: cover update-recipe --initial-rev
- 62abb60b8 devtool: standard: fix update-recipe/finish --initial-rev override
- aa85baff9 package.bbclass: hardcode emit_pkgdata to run last
- b05a90340 oeqa/selftest/devtool: exercise devtool finish on an AUTOREV recipe
- ae7be93cf devtool: standard: fix finish/update-recipe for recipes using AUTOREV
- 497133784 python3-pyasn1: set CVE_PRODUCT
- bb80fef9a python3-ply: set CVE_PRODUCT
- b721019e0 python3-cryptography: set CVE_PRODUCT
- cf5859260 os-release: set BUILD_ID vardepsexclude with weak assignment
- 698e72cfe screen: upgrade 5.0.1 -> 5.0.2
- 7ea792798 bindgen-cli: set CLANG_PATH in native and nativesdk wrappers to matching clang
- de2e11e63 oe-selftest: fitimage: Add tests for KERNEL_DTBVENDORED
- 3bceb2dab kernel-fit-image: Add KERNEL_DTBVENDORED support for FIT_CONF_DEFAULT_DTB
- f77d8886f glibc: disable nscd by default
- 42b917f96 glibc: only inherit init script classes if nscd is enabled
- 6da10b262 glibc: only install nscd if it's been enabled
- 55bf6734b glibc: inherit update-rc.d
- aa0d9d1c1 gtk-doc: upgrade 1.35.1 -> 1.36.1
- c2bd43b37 openssh: set status for https://github.com/advisories/GHSA-wcpp-3x59-h8vp
- deaaaacab gzip: fix https://github.com/advisories/GHSA-qxh4-rprf-2mmj
- e88ee794a kernel-yocto: Set CLANG_FLAGS for kernel config checks when using clang
- 928d81916 kernel-arch: Add clang toolchain support
- ac992c21f lib/oe/utils: move INHIBIT_DEFAULT_DEPS from make_arch_independent() to allarch.bbclass
- fef027f23 u-boot: re-enable RISC-V compressed (c) ISA extension
- 5107ca6f4 base-files: Replace /srv, /var by $servicedir, $localstatedir
- 57d9ac9fe systemd: Ship /srv with the package
- 46964503b cml1: use KCONFIG_CONFIG_ROOTDIR in savedefconfig
- 7f4bb090a systemd: Simplify code to handle resolv.conf with resolved
- 77b7f90b1 files/fs-perms.txt: Replace /srv by $servicedir
- facd4a756 flac: make documentation build deterministic
- 9905d3d66 flac: fix buildpaths with doxygen enabled
- a23291aff lzlib: respect CFLAGS from the recipe
- 57e0e7573 python3-build: upgrade 1.5.0 -> 1.5.1
- ae58caa75 fontconfig: upgrade 2.18.1 -> 2.18.2
- b5e88c26a libffi: upgrade 3.6.0 -> 3.7.1
- 354157c8a python3-websockets: upgrade 16.0 -> 16.1
- 4e58b57cd p11-kit: upgrade 0.26.2 -> 0.26.4
- 97105e74f diffoscope: upgrade 323 -> 324
- b03b78921 xset: upgrade 1.2.5 -> 1.2.6
- 744c0fcf8 cmake: upgrade 4.3.4 -> 4.4.0
- aff034daa webkitgtk: upgrade 2.52.4 -> 2.52.5
- 4b0ccc34e mesa-demos: upgrade to latest revision
- fe54f5ce8 libmicrohttpd: upgrade 1.0.5 -> 1.0.6
- f3016c2e6 gawk: upgrade 5.4.0 -> 5.4.1
- 33a7e1170 tzdata/tzcode-native: upgrade 2026b -> 2026c
- b498f6d6d go: upgrade 1.26.4 -> 1.26.5
- 8b1fb9fbe libx11-compose-data: set CVE_PRODUCT to empty value
- bf39a3c04 bzip2: Fix https://github.com/advisories/GHSA-9r29-3vrx-4537
- cddc75dcf glib-2.0: add back Signed-off-by in https://github.com/advisories/GHSA-8rpw-4xx7-27w7 patch
- b470a7480 python3: add back Co-authored-by in https://github.com/advisories/GHSA-wqxf-pjxh-hh4h patch
- 5a5f2ec43 parted: skip flaky test on riscv64
- 40ca5fc90 report-error.bbclass: add site.conf/toolcfg.conf into error report
- d6b434455 ovmf: fix tpm PACKAGECONFIG to use TPM2_ENABLE
- 72d5d469e pybootchartgui/README: fix broken bootchart.org URL
- 6ca1f213e oeqa/selftest/kernelmodulesplit: test cross-recipe kernel module dependencies
- 3dcbaf596 buildtools-extended-tarball: drop wic helper tools
- 2f3e6452e bluez5: tool changes following 5.87 upgrade
- bbd9c8229 python3: fix https://github.com/advisories/GHSA-wqxf-pjxh-hh4h
- 85f043e20 python3: fix https://github.com/advisories/GHSA-9mc4-rqmq-h467
- d52f4d582 glib-2.0: fix https://github.com/advisories/GHSA-8rpw-4xx7-27w7
- f7fdf4221 mesa-demos: move to latest commit
- 15c2560db mesa-demos: switch to fetching from git instead of tarballs
- 3336a9409 fmt: upgrade 12.1.0 -> 12.2.0
- 3950144c1 files/common-licenses/MIT-with-fmt-exception: add a custom license
- ef0178f12 json-c: upgrade 0.18 -> 0.19
- 285202510 busybox: enable xxd
- df0207af6 piglit: upgrade to latest revision
- 2f571c6f7 gn: upgrade to latest revision
- 0102f4e6b gnu-config: upgrade to latest revision
- 9522a615c libical: upgrade 3.0.20 -> 4.0.3
- 8ab9c8472 log4cplus: upgrade 2.1.2 -> 2.2.0.1
- bd11efe7d vulkan: upgrade 1.4.350.0 -> 1.4.350.1
- ad8a191a4 strace: upgrade 7.0 -> 7.1
- c3ef37162 shared-mime-info: upgrade 2.4 -> 2.5.1
- e588ed1d5 python3-setuptools-rust: upgrade 1.12.1 -> 1.13.0
- 8caf288d3 python3-click: upgrade 8.4.1 -> 8.4.2
- 60dfb1470 git: upgrade 2.54.0 -> 2.55.0
- cd6348644 attr: upgrade 2.5.2 -> 2.6.0
- ac0953bd0 appstream: upgrade 1.1.2 -> 1.1.3
- 2830d1319 acl: upgrade 2.3.2 -> 2.4.0
- 1c53b7059 tiff: upgrade 4.7.1 -> 4.7.2
- bd6c770d2 python3-cffi: upgrade 2.0.0 -> 2.1.0
- 49a103bc5 opkg: upgrade 0.9.0 -> 0.10.0
- a8c7924c0 lttng-modules: upgrade 2.15.1 -> 2.15.2
- 9b1822519 qemu: upgrade 11.0.1 -> 11.0.2
- 0046c780b xmlto: update SRC_URI
- 8d0220301 kernel.bbclass: fix typo in comment, "INTIRAMFS_TASK"
- 90caae509 vulkan-samples: upgrade to latest revision
- 613ac0be6 scdoc: Upgrade 1.11.4 -> 1.11.5
- c503e1195 vim: upgrade 9.2.0569 -> 9.2.0782
- 94749b6f9 rust: Upgrade 1.96.0 -> 1.96.1
- 9967cfbb4 repo: upgrade 2.64 -> 2.65
- 387910ed2 patchelf: upgrade 0.19.0 -> 0.19.1
- 69036e112 dropbear: upgrade 2026.91 -> 2026.92
- f93929ba6 xwayland: upgrade 24.1.12 -> 24.1.13
- a0bcc350b xserver-xorg: upgrade 21.1.23 -> 21.1.24
- 697051def python3-uv-build: upgrade 0.11.26 -> 0.11.28
- 02e430a29 python3-hatchling: upgrade 1.30.1 -> 1.31.0
- db951392b libxfont2: upgrade 2.0.7 -> 2.0.8
- 3c05281a7 enchant2: upgrade 2.8.18 -> 2.8.19
- f927df355 openssh: upgrade 10.3p1 -> 10.4p1
- 4f207d0c5 xkeyboard-config: upgrade 2.47 -> 2.48
- b24c4f46b wic: upgrade 0.3.0 -> 0.3.1
- 05c0ff915 waffle: upgrade 1.8.2 -> 1.8.3
- 918ff85b0 ttyrun: upgrade 2.42.1 -> 2.43.0
- 0fc5e6f12 tcl: upgrade 9.0.3 -> 9.0.4
- 94f08fd3d sqlite3: upgrade 3.53.2 -> 3.53.3
- 5b92ec0f7 socat: upgrade 1.8.1.1 -> 1.8.1.3
- e4dc9b800 python3-wcwidth: upgrade 0.8.1 -> 0.8.2
- 76da88389 python3-vcs-versioning: upgrade 1.1.1 -> 2.2.2
- 878d33350 python3-setuptools-scm: upgrade 10.0.5 -> 10.2.0
- 9afd7190c python3-pytest: upgrade 9.1.0 -> 9.1.1
- 1e5e62f79 python3-pdm: upgrade 2.27.0 -> 2.28.0
- a0e73cd1f python3-hypothesis: upgrade 6.155.2 -> 6.155.7
- 695145958 lighttpd: upgrade 1.4.83 -> 1.4.84
- 4ad6c430b libpsl: upgrade 0.21.5 -> 0.22.0
- 3ebde0299 libffi: upgrade 3.5.2 -> 3.6.0
- 7c6d6f954 libarchive: upgrade 3.8.7 -> 3.8.8
- 5ad74c58b iproute2: upgrade 7.0.0 -> 7.1.0
- c22a7bd7e glib-2.0: upgrade 2.88.1 -> 2.88.2
- e7052ee7a expat: upgrade 2.8.1 -> 2.8.2
- 291254cd8 cmake: upgrade 4.3.3 -> 4.3.4
- 49ebdcb49 barebox-tools: upgrade 2026.06.0 -> 2026.06.1
- bb3260bfb at-spi2-core: upgrade 2.60.4 -> 2.60.5
- 0f3ce620a package_pkgdata: Drop unneeded vardepsexlude
- f5f110b29 staging: Fix vardepsexclude
- 4c6d47c60 selftest/locales: opt out of ptests in DISTRO_FEATURES
- c205e77fc classes/insane: increase shebang size limit
- 07d87ad66 classes/insane: clean up do_qa_sysroot
- d164dd294 classes/insane: create one CachedPath instance in qa_check_staged
- 24ea36ad9 tune-cortexa32: enable Thumb-2 and fix AArch32 crypto FPU selection
- 1808270d6 rust-target-config: armv8a AArch32 Thumb build fixes
- 69ce7593e classes/archiver: remove SRPM mode
- f5d6ed757 classes/archiver: change numbered list to bullets
- 0f9dc05e3 python3-sphinx-argparse: update 0.5.2 -> 0.6.0
- 77023812c webkitgtk: allow usign clang to compile for arm target
- 9bf56df6d opensbi: don't override ELFFLAGS, silence ldflags QA for bare-metal ELFs
- 1377132a7 webkitgtk: add PACKAGECONFIG for bubblewrap
- a68a517eb webkitgtk: add PACKAGECONFIG for webrtc
- 8aa8dd83b webkitgtk: add PACKAGECONFIG for librice
- 79d8dd775 meson: remove obsolete SSL_CERT_DIR assignment in the wrapper script
- 4b5c8fca2 meson: remove obsolete environment unsets
- 722732d95 meson: add explanatory comment to the meson-native wrapper script
- 78ac4beaa patchtest: correctly abort --directory test
- 705fbd6cd patchtest: tests: test_python_pylint.py: use more Pythonic comparison, fix indent
- 0897b93e0 patchtest: tests: test_patch.py: simplify source patch and upstream status checking
- b4f4293ce patchtest: tests: test_metadata.py: simplify SRC_URI collection, remove unneeded import
- 13bea4921 patchtest: tests: test_mbox.py: improve variable and message clarity, fix whitespace
- 3be193de4 patchtest: tests: base.py: remove duplicate Commit object
- 8db26e7ef libarchive: skip fuzz tests in ptest run
- 11aa3b360 kea: remove obsolete staticdev packaging
- 5dbc84f72 kea: fix python module packaging
- 1f136ce0a conf/templates/local.conf.sample: add comment about headless qemu
- c8580f654 at-spi2-core: inherit python3-dir not python3targetconfig
- 7aa548771 python3-pycairo: inherit python3-dir not python3targetconfig
- 2bf79efae blueprint-compiler: inherit python3-dir not python3targetconfig
- 77c5ed98d classes/meson: set python install locations in the cross file
- a4b106d9b wic-tools: Change to MACHINE_ARCH
- 9f3a44169 multilib: Add systemd-boot to NON_MULTILIB_RECIPES
- 884e09017 systemd-boot: Change to MACHINE_ARCH
- 2064c652d grub-efi: Change to MACHINE_ARCH
- 0052647f5 bluez5: upgrade 5.86 -> 5.87
- ad931d773 enchant2: upgrade 2.8.16 -> 2.8.18
- 237cb6d95 python3-setuptools: upgrade 82.0.1 -> 83.0.0
- d267e1086 gpgme: upgrade 2.1.0 -> 2.1.2
- d15c6ee73 libjpeg-turbo: Add PIC flags
- 721fd498c libjpeg-turbo: upgrade 3.1.4.1 -> 3.2.0
- e0a604731 erofs-utils: upgrade 1.9.1 -> 1.9.2
- a82e2ac1d python3-uv-build: upgrade 0.11.21 -> 0.11.26
- c7ba3f61f python3-rpds-py: upgrade 2026.5.1 -> 2026.6.3
- 012e8472a python3-cython: upgrade 3.2.5 -> 3.2.8
- da5b14222 libxmlb: upgrade 0.3.27 -> 0.3.28
- ddcbd22dd igt-gpu-tools: upgrade 2.4 -> 2.5
- 9a47c5a9d diffoscope: upgrade 319 -> 323
- 4f0e7ec24 mesa/mesa-tools-native: Upgrade 26.1.2 -> 26.1.4
- f7ca4ab2a jansson: upgrade 2.15.0 -> 2.15.1
- a22d344c7 python3-typing-extensions: upgrade 4.15.0 -> 4.16.0
- 012992cc2 libadwaita: upgrade 1.9.1 -> 1.9.2
- 440b93878 hwdata: upgrade 0.408 -> 0.409
- 9ae7030db libevent: upgrade 2.1.12 -> 2.1.13
- 928baf0ce patchelf: upgrade 0.18.0+git -> 0.19.0
- e38777a85 dhcpcd: patch https://github.com/advisories/GHSA-p284-r695-7gxf
- 809f0984e dhcpcd: patch https://github.com/advisories/GHSA-g36w-q35r-qvg3
- d0b6b8bb2 dhcpcd: patch https://github.com/advisories/GHSA-8q8g-fjv5-5h56
- 53b396792 dhcpcd: patch https://github.com/advisories/GHSA-vh4p-87xg-jc4x
- 94da70197 gnupg: fix https://github.com/advisories/GHSA-m6x2-4hhh-669j
- b4da2dbdb gnupg: Upgrade 2.5.17 -> 2.5.20
- 12e80a614 package_pkgdata: fix typo to stop calling undefined function
- f29e2b8a7 scripts/oe-publish-sdk: Convert string subprocess parameters to list
- 77a329d18 qemu: add ppc64le support to COMPATIBLE_HOST
- 16e543a22 sstate/staging: Add SSTATETASKS vardepsexclude entries
- 832bfebbc kea: remove install-umask workaround
- 0776ddc45 dhcpcd: Add PACKAGECONFIG for seccomp
- 77516d3c4 sanity.bbclass: warn on cargo config files outside the build tree
- 06d3dbfcb dropbear: Add missing WTFPL & Unlicense in LICENSE and LIC_FILES_CHKSUM
- 3dd117b14 libxml2: patch https://github.com/advisories/GHSA-h67q-h62w-5mjr
- 078dbbff5 systemd-systemctl-native: remove systemd-sysv-install logic
- 33750e825 systemd-systemctl-native: update MESON_TARGET for direct ninja use
- 9e1513b29 classes/meson: use ninja explicitly when compiling
- 6243578a7 glib-2.0: refresh gio-querymodules install path patch
- ecf869558 bc: set CVE_PRODUCT
- a541d76b8 clang_git.bb: remove dangling comment
- 3ec50048c common-clang.inc: fix undefined name in get_clang_arch
- 64e54554a avahi: upgrade 0.9-rc4 -> 0.9-rc5
- 14397f222 gdk-pixbuf: upgrade 2.44.6 -> 2.44.7
- d0860a2b2 pango: upgrade 1.57.1 -> 1.58.0
- 21994d6de qemu: set the compilation progress bar flag
- ee29a9132 oeqa: allow exceptions in buildpath HOME checks
- 4981f3087 boost: upgrade 1.90.0 -> 1.91.0
- e38654c92 kea: upgrade 3.0.3 -> 3.2.0
- cff4bf427 systemtap: upgrade 5.4 -> 5.5
- 6de6b9a14 webkitgtk: upgrade 2.50.6 -> 2.52.4
- 1d67542bb pkgconf: exclude pre-releases from version checks
- a02059069 baremetal-helloworld: Fix override order
- b93727864 oeqa/selftest/pkgdata: add a test for variable consistency in multilib
- 432ab37a4 multilib: extend variables after packages split
- 9780e3923 oeqa/selftest: add copydebugsources tests
- 8337a9330 package: replace copydebugsources shell pipelines
- 8aace29b6 llvm/mesa/rust: simplify llvm-config handling

Relevant changes for bitbake:
- 3a99c26 utils: Add NFS EEXISTS/isdir failure workaround
- 6609657 data: Optimise renameVar when a variable doesn't exist
- 0c5161b bitbake-setup: Add exception for E402 for bb.__version__
- 0d6aa2b fetch2: export AWS_SHARED_CREDENTIALS_FILE for S3 fetches
- a6c08bb contrib/prserv/Dockerfile: remove non-existent codegen.py
- 1dca8d8 fetch/wget/_check_latest_version_by_dir: correct iterative check of versioned directories
- 02a7ba5 bin/*: Add/improve __version__ processing

Relevant changes for meta-arm:
- 28606c72 CI: fix sstate-mirror
- b4fbbaf1 arm/optee-ftpm: update recipe name
- c2a169b1 arm/opencsd: update to 1.8.3
- ea93de35 arm-bsp/external-system: update to the latest commit
- 82711f1a arm-bsp/corstone1000-external-sys-tests: update to the latest commit
- 451dfc37 arm-toolchain: Update to new toolchain version
- 9607ed4e arm-bsp: Lengthen Boot timeout for rdv2/rdn2
- 94e19cb2 ci: enable testimage coverage for Corstone-1000 A320 FVP
- 589e16ae fvp:corstone1000-a320: update Corstone-1000 A320 FVP to 11.31
- 793354db arm-bsp/documentation: corstone1000-a320: update 2026.05 wrynose release documentation
- c6febbdd arm-bsp/documentation: corstone1000: update 2026.05 wrynose release documentation

Relevant changes for meta-openembedded:
- dc0ccaa27 giflib: upgrade 6.1.2 -> 6.1.3
- 85245ad38 cloc: upgrade 1.98 -> 2.08
- 97c61343d cpuid: upgrade 20230614 -> 20260503
- fb6c6d8be weechat: upgrade 4.8.2 -> 4.9.2
- 9d25355c4 networkmanager-openconnect: upgrade 1.2.8 -> 1.2.10
- 70d097818 libmaxminddb: upgrade 1.4.3 -> 1.13.3
- 7840b777e samba: upgrade 4.23.5 -> 4.23.8
- 8a08726c4 restinio: upgrade 0.6.13 -> 0.6.19
- e499a8feb ncftp: upgrade 3.2.7 -> 3.3.0
- ed02dad69 squid: upgrade 7.5 -> 7.6
- b1a3e2012 drbd: upgrade 9.2.1 -> 9.3.2
- e4f43d7ee libldb: upgrade 2.8.2 -> 2.9.2
- 30f546b13 fetchmail: upgrade 6.6.2 -> 6.6.4
- e76528898 strongswan: upgrade 6.0.6 -> 6.0.7
- ebc9888c8 geoipupdate: upgrade 2.5.0 -> 3.1.1
- 5c4ebf142 pgpool2: upgrade 4.6.6 -> 4.7.2
- 68ddc6cff libowfat: upgrade 0.32 -> 0.34
- c6a5835cd nbd: upgrade 3.26.1 -> 3.27.0
- d9cf386de rp-pppoe: upgrade 3.15 -> 4.0
- e7fd0da06 dlm: upgrade 4.2.0 -> 4.3.0
- 9082b0af3 aravis: upgrade 0.8.31 -> 0.8.36
- 581c2869a gupnp-av: upgrade 0.14.4 -> 0.14.5
- 690ec4e46 libopenmpt: upgrade 0.8.4 -> 0.8.7
- 53f74b740 dconf-editor: upgrade 45.0.1 -> 49.0
- a0b1ffc56 gnome-control-center: upgrade 49.2.2 -> 49.7
- 7e61738d4 libpeas-1: upgrade 1.36.0 -> 1.38.1
- 32706fe09 openvpn: upgrade 2.7.0 -> 2.7.4
- a8bba4162 xfce4-dev-tools: upgrade 4.21.0 -> 4.21.1
- 23cdc4ca4 apache2: upgrade 2.4.67 -> 2.4.68
- 779cef925 xdebug: upgrade 3.5.1 -> 3.5.3
- c738d1473 libtest-nowarnings-perl: upgrade 1.04 -> 1.06
- 73c6c3009 libxml-libxml-perl: upgrade 2.0134 -> 2.0213
- 11a2f137b libfile-slurp-perl: upgrade 9999.19 -> 9999.32
- 3259516d4 ccid: upgrade 1.5.5 -> 1.8.0
- 1f16d1142 pcsc-lite: upgrade 2.0.3 -> 2.5.0
- a2ab01984 ifuse: upgrade 1.2.0 -> 1.2.1
- e73caaf78 crash-cross-canadian: fix build, including on clang based SDKs
- 496ce8193 crash: pull in gmp/mpfr for the cross variant
- 15f9b7f91 crash: fix buildpaths QA properly via gdb --with-sysroot=/
- d5423311b crash: drop unnecessary git scaffolding from do_compile
- 56b437228 crash 8.0.6 -> 9.0.2 + crash-memory-driver

Relevant changes for meta-audioreach:
- 19a3d27 audioreach-kernel: srcrev bump 664f553..a532b21
- bf2a6d8 Revert "audioreach-kernel: Fix WSA Mute during playback"
- 54c0ace ci/qcom-distro: update the URL for meta-virtualization
- 2077344 CI: pin Yocto dependencies from lockfile
- 923b6d4 Revert applying MariaDB ARMv8.3+ build fix patch in qcom-distro
- 674cc9b Switch Buildx GHA cache export to min and ignore errors

Relevant changes for meta-updater:
- fff4a58 ostree: disable ptest for sota builds

Relevant changes for meta-ai:
- 21b0c31 tflite: upgrade to 2.21.0 and update dependencies