### PR TITLE
qcom-purwa: remove QCOM_VFAT_SECTOR_SIZE overwrite for IQ-X5121

### DIFF
--- a/conf/machine/include/qcom-purwa.inc
+++ b/conf/machine/include/qcom-purwa.inc
@@ -4,8 +4,6 @@ SOC_FAMILY = "purwa"
 require conf/machine/include/qcom-base.inc
 require conf/machine/include/qcom-common.inc
 
-QCOM_VFAT_SECTOR_SIZE = "512"
-
 DEFAULTTUNE = "armv8-6a-crypto"
 require conf/machine/include/arm/arch-armv8-6a.inc
 


### PR DESCRIPTION
Remove the overwrite to use sector size 4096 as UFS build is enabled by default.

Fix the efi mount failure on UFS build:
[ 2122.484676] FAT-fs (sda1): logical sector size too small for device (logical sector size = 512)