### PR TITLE
packagegroup-qcom-m2-firmware: add HastingsPrime M.2 Wi-Fi/BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -3,12 +3,14 @@ SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
 inherit packagegroup
 
 QCOM_M2_WIFI_FIRMWARE = " \
+    linux-firmware-ath11k-wcn6855 \
     linux-firmware-ath12k-qcc2072 \
     linux-firmware-ath12k-qcn9274 \
     linux-firmware-ath12k-wcn7850 \
 "
 
 QCOM_M2_BT_FIRMWARE = " \
+    linux-firmware-qca-wcn685x \
     linux-firmware-qca-qcc2072 \
     linux-firmware-qca-wcn7850 \
 "


### PR DESCRIPTION
HastingsPrime is an M.2 connectivity module. On platforms with an M.2
E-key slot, customers may populate different M.2 Wi-Fi cards.

Include WCN6855 Wi-Fi and WCN685x Bluetooth firmware in the default
packagegroup so firmware files are present in the root filesystem and a
HastingsPrime module works as expected when inserted.