### PR TITLE
ci: fix stale workflow premature abort

### DIFF
--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -23,3 +23,4 @@ jobs:
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true
+        operations-per-run: 100


### PR DESCRIPTION
The stale workflow defaults to 30 operations per run. Meta-qcom typically has more than 30 open PRs, so the stale workflow has not been running to completion. This updates the limit to 100.

Example of the issue here:
https://github.com/qualcomm-linux/meta-qcom/actions/runs/29466083133/job/87519413546#step:2:2053
