### PR TITLE
Add kas config for qcom-console-image

### DIFF
--- a/ci/qcom-distro-console-image.yml
+++ b/ci/qcom-distro-console-image.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+target:
+  - qcom-console-image


### PR DESCRIPTION
qcom-console-image is a lightweight image that exercises the base system without the multimedia stack. Without a dedicated KAS fragment, there is no standardized way for developers and CI systems to build and validate this image independently from the heavier qcom-distro targets.

Add a qcom-distro-console-image KAS fragment that inherits the full qcom-distro layer setup but limits the build target to qcom-console-image only, enabling focused CI coverage for the minimal console use case.