### PR TITLE
firmware-qcom-boot-kaanapali: align SRC_URI with other recipes

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
@@ -3,12 +3,10 @@ LICENSE = "LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.0.0/qualcomm_linux.spf.0.0-test-device-public"
-FW_BUILD_ID = "r0.0_${PV}/KAANAPALI.LE.0.0"
-FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "kaanapali_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/common/build/ufs/bin/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
     https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"


### PR DESCRIPTION
The kaanapali bootbins recipe uses the SPF-based download path, relying on FW_BUILD_ID and FW_BIN_PATH variables to construct the SRC_URI. All other bootbins recipes are using the tech-pack based release path style that inlines version and subpath directly into the URL. Keeping the kaanapali recipe in the old style creates inconsistency that makes the recipe harder to maintain and review alongside its peers.

Drop FW_BUILD_ID and FW_BIN_PATH and inline the path directly into SRC_URI, bringing the kaanapali recipe inline with the rest of the bootbins recipes.

No functional changes.