### PR TITLE
ci: bump lava-test-plans and testkit refs, add sm8750-mtp to qcom-distro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,8 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk"
-      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk,sm8750-mtp"
+      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,sm8750-mtp"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
       lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.07.12"
+  TESTKIT_REF: "testkit-2026.07.19"
 
 jobs:
   prepare-env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "1d5707eec220248e0b4e7a039c545aba4d3e3deb"
+  LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.07.12"
 


### PR DESCRIPTION
qcom-distro premerge was pinned to lava-test-plans commit 1d5707e and testkit-2026.07.12, neither of which carries support for the sm8750-mtp device: lava-test-plans had no device profile for it, and testkit lacked DIAG userspace functional validation along with MSM/KGSL graphics stack coverage for kmscube.

Bump LAVA_TEST_PLANS_REF to a20c74e to pick up the sm8750-mtp device profile (excludes the camera testplan and ethernet test), bump TESTKIT_REF to testkit-2026.07.19 to pick up the new DIAG testcase and its helpers plus the kmscube MSM/KGSL graphics stack support, and add sm8750-mtp to the qcom-distro boot and premerge device lists so it is exercised by these checks.

Anil Yadav <anilyada@qti.qualcomm.com>