### PR TITLE
firmware-qcom-boot-shikra: Update boot to 00053

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00036.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00036.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-shikra.inc
-
-SRC_URI[bootbinaries.sha256sum] = "df2437405516034fb2d33585c8436891f7fb765e92022256364b4cf609089d0e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00053.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00053.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-shikra.inc
+
+SRC_URI[bootbinaries.sha256sum] = "f3f9508288c7d9b10119dae3e423fee3edfc74f720394b0204e3cbafa0fc9542"


### PR DESCRIPTION
This PR updates boot tag for shikra.

Known fixes:
feat: add support for boot without KVM virtualization workflows
security: promote production-signed XBL_SEC image and update secure boot components
security: integrate OpenSSL, Zlib, and DxeCore CVE fixes in boot firmware
chore: update DevProg, storage provisioning, and platform boot configuration changes