### PR TITLE
packagegroup-rb1: add vpu firmware packagegroup

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-rb1.bb
@@ -15,6 +15,7 @@ RRECOMMENDS:${PN}-firmware = " \
     linux-firmware-qcom-qcm2290-audio \
     linux-firmware-qcom-qcm2290-modem \
     linux-firmware-qcom-venus-6.0 \
+    linux-firmware-qcom-vpu \
 "
 
 RDEPENDS:${PN}-hexagon-dsp-binaries = " \


### PR DESCRIPTION
The RB1 iris platform data (qcm2290_data) registers both Gen1 and Gen2 firmware descriptors. The IRIS driver prefers the Gen2 descriptor and only falls back to Gen1 if the Gen2 firmware is unavailable.

Encoder use cases are currently broken with the Gen1 (AR50_LITE) firmware on this platform: H.264, H.265 encode sessions hang on every frame with a VPP watchdog timeout. This points to a Gen1 firmware defect and is tracked separately, decoder use cases are unaffected. Encoder use cases work correctly with Gen2 firmware.

The Gen2 merged AR50LT VPU firmware is packaged as linux-firmware-qcom-vpu, but packagegroup-rb1 does not currently include it, so the driver falls back to the broken Gen1 path. Add linux-firmware-qcom-vpu to packagegroup-rb1 so the Gen2 firmware binary is included in RB1 images and video use cases work by default.