### PR TITLE
packagegroup-shikra-evk: add WCN3988 BT firmware package

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-shikra-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-shikra-evk.bb
@@ -11,7 +11,7 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-shikra-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3950', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn3950 linux-firmware-qca-wcn3988', '', d)} \
     linux-firmware-qcom-shikra-compute \
     linux-firmware-qcom-shikra-audio \
     linux-firmware-qcom-shikra-modem \


### PR DESCRIPTION
Shikra supports both WCN3950 and WCN3988 BT chipset variants. On boards with the WCN3988 chipset, BT initialization fails because the required firmware file qca/apbtfw11.tlv is not available:

  bluetooth hci0: Direct firmware load for qca/apbtfw11.tlv failed with error -2
  Bluetooth: hci0: QCA Failed to request file: qca/apbtfw11.tlv (-2)

WCN3950 firmware is already available. Add WCN3988 firmware package to cover the WCN3988 chipset variant.