### PR TITLE
packagegroup-machine-essential: define glymur-soc package

### DIFF
--- a/conf/machine/include/qcom-glymur.inc
+++ b/conf/machine/include/qcom-glymur.inc
@@ -9,6 +9,7 @@ require conf/machine/include/arm/arch-armv8-6a.inc
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
+    packagegroup-machine-essential-qcom-glymur-soc \
 "
 
 MACHINE_EXTRA_RRECOMMENDS += " \

--- a/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
+++ b/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 PACKAGES = " \
     ${PN}-board-generic \
     ${PN}-qcom-generic \
+    ${PN}-qcom-glymur-soc \
     ${PN}-qcom-hamoa-soc \
     ${PN}-qcom-purwa-soc \
     ${PN}-qcom-qcm2290-soc \
@@ -96,6 +97,23 @@ RRECOMMENDS:${PN}-qcom-generic += " \
 "
 
 # The packagegroups below are SoC specific
+
+RRECOMMENDS:${PN}-qcom-glymur-soc += " \
+    ${PN}-board-generic \
+    ${PN}-qcom-generic \
+    kernel-module-ath11k-pci \
+    kernel-module-ath12k \
+    kernel-module-camcc-glymur \
+    kernel-module-dispcc-glymur \
+    kernel-module-evacc-glymur \
+    kernel-module-gpucc-glymur \
+    kernel-module-pinctrl-glymur \
+    kernel-module-pmic-glink \
+    kernel-module-pmic-glink-altmode \
+    kernel-module-pwrseq-qcom-wcn \
+    kernel-module-tcsrcc-glymur \
+    kernel-module-videocc-glymur \
+"
 
 RRECOMMENDS:${PN}-qcom-hamoa-soc += " \
     ${PN}-board-generic \


### PR DESCRIPTION
Define a new package with glymur-soc specific kernel modules and add packagegroup-machine-essential-qcom-glymur-soc to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS ensuring that the required kernel modules are included in the image.

This fixes [issue#1753](https://github.com/qualcomm-linux/meta-qcom/issues/1753)