### PR TITLE
recipes-connectivity: Update sigma-dut revision

### DIFF
--- a/recipes-connectivity/sigma-dut/sigma-dut_git.bb
+++ b/recipes-connectivity/sigma-dut/sigma-dut_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://README;md5=e877b35748195c6ab87bf2d1ebed9a89"
 SRC_URI = "git://github.com/qualcomm/sigma-dut.git;branch=master;protocol=https"
 
 PV = "1.11+git"
-SRCREV = "89d3c0271c1000932475467c70f529b67157a386"
+SRCREV = "bd455d362f824f8d15dee305fec32aefafdca0a1"
 
 DEPENDS = "libnl"
 


### PR DESCRIPTION
  recipes-connectivity: Update sigma-dut revision

  Certification runs need recent sigma-dut fixes for AP EHT/MLO and
  ath12k STA test flows. Without these updates, some certification cases
  can fail due to missing or incomplete support in sigma-dut.

  This brings in AP EHT/MLO fixes, NAN support through wifi-hal on LE
  targets, deferred fwtest handling for ath12k, mac80211 CodingType
  configuration, and ADDBA buffer size configuration support.

  CRs-Fixed: 4619496,4419928,4419997