### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260723 v6.18.37

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -20,8 +20,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag:qcom-6.18.y-20260720
-SRCREV ?= "4ab384e41300a12c67d5c18c4e7bc1e3f546cc28"
+# tag:qcom-6.18.y-20260723
+SRCREV ?= "3167b12384380f1463ccf3b42f83adcac5a3f754"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260723

Changelog:
QCLINUX: arm64: dts: qcom: Monaco-EVK Swap RESET and POWER down pins
QCLINUX: memory-dump: add memory dump table for Shikra
QCLINUX: qcom-dcc: add shikra register list and move config to header
FROMLIST: Bluetooth: hci_qca: Set 'bt_en_available' based on W_DISABLE2# presence in M.2 connector
FROMLIST: Bluetooth: hci_qca: Rename 'power_ctrl_enabled' to 'bt_en_available'
FROMLIST: Bluetooth: hci_qca: Add M.2 Bluetooth device support using pwrseq
UPSTREAM: power: sequencing: Add an API to return the pwrseq device's 'dev' pointer
BACKPORT: power: sequencing: pcie-m2: Create BT node based on the pci_device_id[] table
UPSTREAM: power: sequencing: pcie-m2: Create serdev for PCI devices present before probe
UPSTREAM: power: sequencing: pcie-m2: Improve PCI device ID check
BACKPORT: power: sequencing: pcie-m2: Allow creating serdev for multiple PCI devices
UPSTREAM: power: sequencing: pcie-m2: Fix inconsistent function prefixes
UPSTREAM: arm64: defconfig: Enable PCI M.2 power sequencing driver
UPSTREAM: power: sequencing: pcie-m2: Fix device node reference leak in probe
UPSTREAM: power: sequencing: pcie-m2: add SERIAL_DEV_BUS dependency
UPSTREAM: power: sequencing: pcie-m2: enforce PCI and OF dependencies
BACKPORT: power: sequencing: pcie-m2: Create serdev device for WCN7850 bluetooth
UPSTREAM: power: sequencing: pcie-m2: Add support for PCIe M.2 Key E connectors
UPSTREAM: dt-bindings: connector: Add PCIe M.2 Mechanical Key E connector
UPSTREAM: dt-bindings: serial: Document the graph port
UPSTREAM: serdev: Do not return -ENODEV from of_serdev_register_devices() if external connector is used
UPSTREAM: serdev: Add an API to find the serdev controller associated with the devicetree node
UPSTREAM: serdev: Convert to_serdev_*() helpers to macros and use container_of_const()
BACKPORT: PCI/pwrctrl: Add PCIe M.2 connector support
BACKPORT: PCI/pwrctrl: Create pwrctrl device if graph port is found
BACKPORT: power: sequencing: Add the Power Sequencing driver for the PCIe M.2 connectors
UPSTREAM: dt-bindings: connector: Add PCIe M.2 Mechanical Key M connector
QCLINUX: arm64: dts: qcom: Add Purwa sensors support
FROMLIST: arm64: dts: qcom: hamoa: add audio PD remote heap region
FROMLIST: wifi: ath12k: fix EAPOL TX failure caused by stale tcl_metadata bits