### PR TITLE
ci: test-pr: recreate the results comment so runs notify again

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -110,14 +110,17 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
-          file-path: pr-comment.txt
-          pr-number: ${{ steps.pr_comment_prep.outputs.pr_number }}
-          # Update a single tagged comment per PR instead of posting a new one on
-          # every run, so the PR shows one current result instead of accumulating
-          # stale comments (one per run / per superseded commit).
-          comment-tag: test-results
+          path: pr-comment.txt
+          number_force: ${{ steps.pr_comment_prep.outputs.pr_number }}
+          # Post a fresh comment on every run (GitHub only notifies on
+          # comment creation) and minimize the previous tagged comment as
+          # outdated instead of deleting it, so the retry history stays
+          # visible (collapsed) in the PR timeline.
+          header: test-results
+          hide_and_recreate: true
+          hide_classify: OUTDATED
 
   publish-test-results:
     uses: ./.github/workflows/publish-results.yml


### PR DESCRIPTION
Tagging the PR results comment with comment-tag made the action update a single comment in place (the default upsert mode). GitHub only sends notifications when a comment is created, never when one is edited, so test re-runs stopped generating any email and updated results went unnoticed until someone manually revisited the PR.

Switch the comment action to mode: recreate, which deletes the tagged comment and posts a fresh one. Every (re-)run's results now trigger a notification again, while the PR still carries exactly one results comment per head instead of accumulating stale ones.