### PR TITLE
firmware-qcom-boot-kaanapali: fix LICENSE.txt fetch after FW_BUILD_ID removal

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
@@ -7,7 +7,7 @@ BOOTBINARIES = "kaanapali_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/common/build/ufs/bin/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 


### PR DESCRIPTION
Commit 3c9ace01 ("firmware-qcom-boot-kaanapali: align SRC_URI with other recipes") dropped the FW_BUILD_ID variable definition but left the LICENSE.txt SRC_URI entry referencing it. With the variable undefined, the URL contains a literal ${FW_BUILD_ID} and do_fetch fails:

  ERROR: firmware-qcom-boot-kaanapali-00009.1-r0 do_fetch: Bitbake
  Fetcher Error: FetchError('Unable to fetch URL from any source.', ...)

Inline the path FW_BUILD_ID used to expand to, restoring the previous download URL and matching the inlined style of the bootbinaries entry.

Fixes: https://github.com/qualcomm-linux/meta-qcom/issues/2770