### PR TITLE
iq-x5121-evk: add SoC staging dtbo file

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -22,7 +22,9 @@ FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx hamoa-staging"
 
 # ---------- purwa -----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-staging] = "purwa-iot-evk purwa-staging"
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-staging] = "purwa-iot-evk purwa-evk-camx purwa-staging"
 
 # ---------- lemans ----------
 

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -23,8 +23,11 @@ FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx 
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-el2kvm] = "hamoa-iot-evk hamoa-evk-camx x1-el2 hamoa-camx-el2"
 
 # ---------- purwa -----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-staging] = "purwa-iot-evk purwa-staging"
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-staging] = "purwa-iot-evk purwa-evk-camx purwa-staging"
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm-staging] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2 purwa-staging"
 
 # ---------- lemans ----------
 

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/purwa-evk-camx.dtbo \
+    qcom/purwa-staging.dtbo \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE ?= " \
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
     qcom/purwa-evk-camx.dtbo \
     qcom/purwa-camx-el2.dtbo \
+    qcom/purwa-staging.dtbo \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
The initial SoC staging DTBO includes the TGU device nodes used to enable IPCB logging. IPCB (inter-Processor Communication Bus) is a bus monitoring mechanism within the AOSS (Always On Subsystem) on Qualcomm SoCs.