### PR TITLE
Disable systemd TPM device wait on Glymur

### DIFF
--- a/conf/machine/include/qcom-glymur.inc
+++ b/conf/machine/include/qcom-glymur.inc
@@ -7,6 +7,10 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-6a-crypto"
 require conf/machine/include/arm/arch-armv8-6a.inc
 
+# The secure TPM device is not yet available on Glymur, so avoid
+# systemd's boot-time wait for /dev/tpm0.
+KERNEL_CMDLINE_EXTRA:append = " systemd.tpm2_wait=false"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-glymur-soc \


### PR DESCRIPTION
After the QSEECOM driver is enabled, LoaderTpm2ActivePcrBanks is visible
to userspace on Glymur platforms. This makes systemd wait for /dev/tpm0
during boot, but the secure TPM device is not yet enabled on Glymur.
The missing TPM device adds a 90 second boot delay.
    
Set `systemd.tpm2_wait=false` on the command line so systemd does not
wait for a TPM device that is not currently available.
    
This is a temporary change and can be reverted once the secure TPM is
fully enabled on Glymur.