### PR TITLE
[Backport wrynose] firmware-qcom-boot-kaanapali: fix LICENSE.txt fetch after FW_BUILD_ID removal

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
@@ -7,7 +7,7 @@ BOOTBINARIES = "kaanapali_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/common/build/ufs/bin/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 


### PR DESCRIPTION
# Description
Backport of #2791 to `wrynose`.

Cherry-picked from #2796 (commit bfe5f41b4cee1a18aa550e56575a4b27ace4209e).