### PR TITLE
smart-venc-ctrl-algo: update from 1.0 -> 1.0.1

### DIFF
--- a/recipes-multimedia/imsdk/smart-venc-ctrl-algo_1.0.1.bb
+++ b/recipes-multimedia/imsdk/smart-venc-ctrl-algo_1.0.1.bb
@@ -1,13 +1,13 @@
 SUMMARY = "Smart Video Encoder Control Algorithm Prebuilt Libraries"
 DESCRIPTION = "Provides prebuilt binaries for the Smart Video Encoder Control Algorithm, used to dynamically optimize video encoding parameters and performance."
 LICENSE = "LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/qcom-video-ctrl/NO.LOGIN.BINARY.LICENSE.QTI;md5=eabe5444aa94c3e0e8b37b132a94e08b"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/qcom-video-ctrl/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260112.1"
+PBT_BUILD_DATE = "260709"
 
-SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/iot-core-algs.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-video-ctrl_${PV}_armv8-2a.tar.gz"
+SRC_URI = "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/component/iot-core-algs.lnx.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/qcom-video-ctrl_${PV}_armv8a.tar.gz"
 
-SRC_URI[sha256sum] = "9e6b8b6e0b013b6126fe6ab0776591347f0f66fd7153f4afa8e100b9d64af308"
+SRC_URI[sha256sum] = "72fd2cbe5ab1e12c718d67f9a0a9687063b7b22a1c2c5c4bad1eca6d2eedfe14"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
This tag v1.0.1 brings below changes:

- Add CHANGES file
- Replace NO.LOGIN.BINARY.LICENSE.QTI with LICENSE.qcom-2 file

Update LIC_FILES_CHKSUM in recipe accordingly to reference the new license file and its checksum.