### PR TITLE
refpolicy: seatd: allow self fifo_file read/write for signal handling

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch
@@ -1,0 +1,32 @@
+From 23fa8fee316162050e7690ba845fd7cb90fc8dc3 Mon Sep 17 00:00:00 2001
+From: fangwu <fang.wu@oss.qualcomm.com>
+Date: Fri, 24 Jul 2026 18:16:00 +0800
+Subject: [PATCH] seatd: allow self fifo_file read/write for signal handling
+
+seatd uses a self-pipe trick to deliver signals to its event loop.
+The signal handler writes '\0' to signal_fds[1] (a pipe) to wake up
+ppoll() in the main loop. Without permission to write to its own
+fifo_file, SELinux denies the write with EACCES, preventing seatd
+from processing SIGTERM during shutdown and causing a 90s reboot delay.
+
+Upstream-Status: Pending [https://github.com/SELinuxProject/refpolicy]
+Signed-off-by: fangwu <fang.wu@oss.qualcomm.com>
+---
+ policy/modules/services/seatd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/services/seatd.te b/policy/modules/services/seatd.te
+index d539dc446..5f76a1719 100644
+--- a/policy/modules/services/seatd.te
++++ b/policy/modules/services/seatd.te
+@@ -23,6 +23,7 @@ files_runtime_file(seatd_runtime_t)
+ #
+ 
+ allow seatd_t self:capability { chown dac_override sys_admin sys_tty_config };
++allow seatd_t seatd_t:fifo_file { read write getattr };
+ allow seatd_t self:unix_stream_socket { accept listen };
+ 
+ allow seatd_t seatd_runtime_t:sock_file manage_sock_file_perms;
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
+    file://0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch \
 "


### PR DESCRIPTION
seatd uses a self-pipe trick to deliver signals to its event loop. The signal handler writes '\0' to signal_fds[1] (a pipe) to wake up ppoll() in the main loop. Without permission to write to its own fifo_file, SELinux denies the write with EACCES, preventing seatd from processing SIGTERM during shutdown and causing a 90s reboot delay.

Verified on iq-x5121-evk (Purwa, X1E80100) with SELinux enforcing.

Upstream-Status: Pending [https://github.com/SELinuxProject/refpolicy]