### PR TITLE
initramfs-firmware-iq-x5121-evk-image: firmware image for Purwa IoT EVK

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-iq-x5121-evk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-iq-x5121-evk-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with IQ-x5121 EVK firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-purwa-iot-evk-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Add recipe to generiate small initramfs image with firmware for the Purwa IoT EVK.