### PR TITLE
u-boot-qcom: enable libubootenv environment access tool

### DIFF
--- a/ci/u-boot-qcom.yml
+++ b/ci/u-boot-qcom.yml
@@ -4,3 +4,5 @@ header:
 local_conf_header:
   bootloaderprovider: |
     PREFERRED_PROVIDER_virtual/bootloader = "u-boot-qcom"
+  libubootenv: |
+    IMAGE_INSTALL:append = " u-boot-fw-utils u-boot-qcom-env"

--- a/conf/machine/include/qcom-u-boot-common.inc
+++ b/conf/machine/include/qcom-u-boot-common.inc
@@ -6,7 +6,7 @@
 UBOOT_CONFIG ?= ""
 UBOOT_CONFIG_DEFAULT ?= "${UBOOT_CONFIG}"
 
-UBOOT_INITIAL_ENV = ""
+UBOOT_INITIAL_ENV = "u-boot-initial-env"
 
 # Don't forget to add config to qcom-armv8a.conf when adding it here
 UBOOT_CONFIG[iq-615-evk] = "qcom_qcs615_defconfig"

--- a/recipes-bsp/u-boot/files/fw_env.config
+++ b/recipes-bsp/u-boot/files/fw_env.config
@@ -1,0 +1,3 @@
+# Configuration file for fw_(printenv/setenv) utility (libubootenv).
+# Device path             Offset   Size
+/dev/disk/by-partlabel/logfs   -0x4000   0x4000

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=http
 SRC_URI += " \
     file://disable-eficapsule-tool.cfg \
     file://efi-rt-volatile-store.cfg \
+    file://fw_env.config \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'file://tfa-optee.cfg', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'kvm', 'file://gunyah-exit.cfg', '', d)} \
 "


### PR DESCRIPTION
Enable userspace access to the U-Boot environment variable on U-Boot based builds using libubootenv (fw_printenv/fw_setenv) tools.

Changes
1. Enable fw_env.config support in u-boot-qcom
- Install u-boot-fw-utils and u-boot-qcom-env.
- Add fw_env.config for the U-Boot environment partition.
- Include fw_env.config in SRC_URI for automatic packaging.

2. Standardize initial environment naming
- Re-enable UBOOT_INITIAL_ENV generation for Qualcomm machines.
- Use the standard name u-boot-initial-env for compatibility with libubootenv.