### PR TITLE
firmware-qcom-boot-glymur: update boot to 00079

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00073.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00073.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-glymur.inc
-
-SRC_URI[bootbinaries.sha256sum] = "ab9e2349c18ac761522c31822a6874818ac027f9560e36cb83c48103ff96a2c4"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00079.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00079.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-glymur.inc
+
+SRC_URI[bootbinaries.sha256sum] = "b8063fd1dff26bdc289d96ceb21edb6fcc0dbd604277a948df43699299b32649"


### PR DESCRIPTION
Known fixes:

EFI Variables Changes & Multi-DTB Support

Extended EFI variable handling to support runtime read/write operations aligned with UEFI BDS boot flow.

AOSS Sleep Issue Fixes

Addressed AOSS (Always-On SubSystem) sleep entry/exit failures that were preventing the platform from achieving deep low-power states on Glymur LNX.
