### PR TITLE
qcom-common: force PCIe root port D3 during suspend for validation

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -95,3 +95,5 @@ RT_KERNEL_CMDLINE = "${RT_ARGS_ISOL} ${RT_ARGS_IRQ} ${RT_ARGS_NOCBS} \
 KERNEL_CMDLINE_EXTRA:append = "${@bb.utils.contains_any('PREFERRED_PROVIDER_virtual/kernel',\
                               'linux-qcom-rt linux-qcom-next-rt', \
                               ' ${RT_KERNEL_CMDLINE}', '', d)}"
+
+KERNEL_CMDLINE_EXTRA:append = " pcie_port_pm=force"


### PR DESCRIPTION
Any PCIe Root Port that is a native OS-handled hotplug-capable bridge stays in D0 across system suspend instead of transitioning to D3hot.

drivers/pci/pci.c:pci_bridge_d3_possible() explicitly rejects D3 for this class of port:

    if (bridge->is_hotplug_bridge && !bridge->is_pciehp)
            return false;
    if (bridge->is_pciehp && !pciehp_is_native(bridge))
            return false;
    ...
    if (bridge->is_pciehp)
            return false;

so pci_dev->bridge_d3 is left cleared. pci_power_manageable() (drivers/pci/pci.h) in turn reports the bridge as not power manageable whenever it has a subordinate bus and bridge_d3 isn't set, and the suspend path in drivers/pci/pci-driver.c gates pci_prepare_to_sleep() behind that same check:

    if (!pci_dev->skip_bus_pm && pci_power_manageable(pci_dev))
            pci_prepare_to_sleep(pci_dev);

so pci_prepare_to_sleep() is skipped entirely and the Root Port never leaves D0, observed as:

    bridge_d3 = 0
    pci_power_manageable = 0

The kernel already has a command line hook for this: pcie_port_pm=force maps to pci_bridge_d3_force in pci_bridge_d3_possible(), which short- circuits the hotplug checks above and always allows D3:

    if (pci_bridge_d3_force)
            return true;

Add it for all qcom targets so bridge_d3 and pci_power_manageable get set to 1, allowing hotplug-capable Root Ports to transition to D3hot during suspend. This is meant to validate that the D0 behavior is caused by the generic hotplug bridge D3 policy rather than a platform-specific issue.