### PR TITLE
[Backport wrynose] packagegroup-qcom-m2-firmware: add HastingsPrime M…

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
+++ b/recipes-bsp/packagegroups/packagegroup-qcom-m2-firmware.bb
@@ -3,6 +3,7 @@ SUMMARY = "Firmware for Qualcomm M.2 wireless attachments"
 inherit packagegroup
 
 QCOM_M2_WIFI_FIRMWARE = " \
+    linux-firmware-ath11k-wcn6855 \
     linux-firmware-ath12k-qcn9274 \
     linux-firmware-ath12k-wcn7850 \
 "
@@ -14,6 +15,7 @@ QCOM_M2_WIFI_FIRMWARE:append:qcom = " \
 "
 
 QCOM_M2_BT_FIRMWARE = " \
+    linux-firmware-qca-wcn685x \
     linux-firmware-qca-qcc2072 \
     linux-firmware-qca-wcn7850 \
 "


### PR DESCRIPTION
….2 Wi-Fi/BT firmware

Backport of #2753 to `wrynose`.