### PR TITLE
firmware-qcom-boot: update boot to 00135

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "bdbc6aa0390f5c78059e0d9f2c70f8bc0695b350d1a8a47d65c9c758847050f2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00135.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "8dcdbbedaf3ec0fc26cf438222e06d141c8c9a17ba87bbf7f888341145d9c8ef"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "25b19ccc56d6e4133df15b7b5ac9353357efc66cbf17e9f84d0a459724e0e3e0"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00135.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "43549a7dce32134f81706fd2d0e3550a655563ccdd708d11b89480281485003e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a94a26782bdcef18599fcc098fee77db50154ac31126dae86847c32205b224e6"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00135.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "67b023c4b18188ac5f4c0f50b656902501cf8c735982b7b099493bea85da4a21"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00126.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6bcc47460e2127c6bf1ebda1726e87659820dadeceb68f15c52aed80086b64a2"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00135.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "2db1108f41ea9feddff0303be7e0b0af4fa66ce7405ee6e874749a9f4f266e82"


### PR DESCRIPTION
This PR updates boot for QCM6490, QCS8300, QCS9100 and QCS615.

QCS9100 Known fixes:
feat: add support for booting without a hypervisor, enabling a non-virtualized boot path
feat: enable host OS clients and remote processor driver support in virtualized environments
feat: add ADB fastboot interface support for real-time subsystem debug and flash operations
fix: reduce secure firmware image size through compression to optimize flash storage usage


QCS8300 Known fixes:
feat: add support for booting without a hypervisor, enabling a non-virtualized boot path
feat: enable host OS clients and remote processor driver support in virtualized environments
fix: reduce secure firmware image size through compression to optimize flash storage usage


QCS6490 Known fixes:
feat: add support for booting without a hypervisor, enabling a non-virtualized boot path
feat: enable host OS clients and remote processor driver support in virtualized environments
feat: add secure firmware authentication and reset handling for peripheral image loading under hypervisor
fix: reduce secure firmware image size through compression to optimize flash storage usage
chore: compress bootloader firmware images to improve packaging and deployment efficiency


QCS615 Known fixes:
feat: add support for booting without a hypervisor, enabling a non-virtualized boot path
feat: enable host OS clients and remote processor driver support in virtualized environments
fix: reduce secure firmware image size through compression to optimize flash storage usage