### PR TITLE
recipes-graphics: restrict QCOM graphics recipes to QCOM machines

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.877.2.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.877.2.bb
@@ -27,7 +27,7 @@ ANY_OF_DISTRO_FEATURES = "glvnd vulkan opencl"
 COMPATIBLE_MACHINE = "^$"
 # It should be armv8-2a, but then it wouldn't be possible to use it for
 # qcom-armv8a machine.
-COMPATIBLE_MACHINE:aarch64 = "(.*)"
+COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PACKAGE_BEFORE_PN += " \
     ${PN}-common \

--- a/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
+++ b/recipes-graphics/msm-gbm-backend/msm-gbm-backend.bb
@@ -14,6 +14,8 @@ SRC_URI = "git://github.com/qualcomm-linux/gbm-msm-backend.git;protocol=https;br
 
 inherit meson pkgconfig features_check
 
+COMPATIBLE_MACHINE = "(qcom)"
+
 DEPENDS = "mesa libdrm libxml2"
 REQUIRED_DISTRO_FEATURES = "opengl"
 


### PR DESCRIPTION
qcom-adreno and msm-gbm-backend are Qualcomm-specific graphics recipes, but
qcom-adreno was visible for every aarch64 machine.

That can break mixed-layer builds for non-QCOM aarch64 machines during provider
resolution. qcom-adreno advertises runtime providers for the OpenCL and Vulkan
ICD virtuals, so it can be considered as a provider candidate even when the
final image should use another GPU stack. Its dependency chain then reaches
msm-gbm-backend, which depends on mesa and can fail when mesa is intentionally
skipped in favour of another provider.

Restrict qcom-adreno to aarch64 QCOM machines and restrict msm-gbm-backend to
QCOM machines.

Tested with:

- `bitbake-layers show-recipes qcom-adreno msm-gbm-backend`
- `bitbake -g tdx-reference-multimedia-image` (our Toradex reference image which we recently started building with meta-qcom included in BBLAYERS, provided by meta-toradex-demos)