### PR TITLE
iq-8275-evk: shikra-evk: iq-x7181-evk: iq-x5121-evk: Enable m2connector MACHINE_FEATURE

### DIFF
--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs8300.inc
 
-MACHINE_FEATURES += "efi kvm pci tpm2 phone"
+MACHINE_FEATURES += "efi m2connector kvm pci tpm2 phone"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/monaco-evk.dtb \

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-purwa.inc
 
-MACHINE_FEATURES += "efi pci tpm2"
+MACHINE_FEATURES += "efi pci m2connector tpm2"
 
 KERNEL_DEVICETREE ?= " \
     qcom/purwa-iot-evk.dtb \

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-hamoa.inc
 
-MACHINE_FEATURES += "efi pci tpm2"
+MACHINE_FEATURES += "efi pci m2connector tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/hamoa-iot-evk.dtb \

--- a/conf/machine/shikra-evk.conf
+++ b/conf/machine/shikra-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-shikra.inc
 
-MACHINE_FEATURES += "efi pci phone tpm2"
+MACHINE_FEATURES += "efi pci m2connector phone tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/shikra-cqm-evk.dtb \


### PR DESCRIPTION
Declare M.2 connector presence on iq-8275-evk shikra-evk iq-x7181-evk: iq-x5121-evk.
    
The m2connector feature gates installation of optional M.2 attachment
firmware from image recipes, so firmware selection follows hardware
capability instead of unconditional machine packagegroup content.