### PR TITLE
ci: Add qcom-quickboot.yml kas overlay for QuickBoot feature

### DIFF
--- a/ci/qcom-quickboot.yml
+++ b/ci/qcom-quickboot.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+# By default, this YAML enables QuickBoot feature.
+# But, subsystems (Audio, Camera, Display) can be enabled individually.
+#
+# For example, set the variable as below
+# To enable display only      : QUICKBOOT_SUBSYSTEMS = "display"
+# To enable audio and display : QUICKBOOT_SUBSYSTEMS = "audio display"
+# To enable all               : QUICKBOOT_SUBSYSTEMS = "audio camera display"
+#
+local_conf_header:
+  quickboot_features: |
+    DISTRO_FEATURES:append = " quickboot"
+    QUICKBOOT_SUBSYSTEMS = " "


### PR DESCRIPTION
Add a kas overlay file to enable the QuickBoot DISTRO_FEATURES for fast time-to-first-frame and time-to-first-sound boot optimization.

Following DISTO_FEATURES are appendend:
 1. quickboot             (master switch)
 2. quickboot-display     (early DRM/display subsystem)
 3. quickboot-audio       (early PipeWire/audio subsystem)
 4. quickboot-camera      (early V4L2/camera subsystem)

Usage:
  kas build <machine.yml>:<distro.yml>:meta-qcom/ci/qcom-quickboot.yml

Individual subsystems can be disabled by removing the corresponding sub-feature from the DISTRO_FEATURES:append line.