### PR TITLE
packagegroup-iq-615-evk: add WCN3988 BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
@@ -11,7 +11,7 @@ PACKAGES = " \
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a612 linux-firmware-qcom-qcs615-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698 linux-firmware-qca-wcn3988', '', d)} \
     camxfirmware-talos \
     linux-firmware-qcom-qcs615-audio \
     linux-firmware-qcom-qcs615-compute \


### PR DESCRIPTION
Talos Lyra EVK has WCN3988 BT chip in addition to QCA6698. Add linux-firmware-qca-wcn3988 so apbtfw10.tlv / apbtfw11.tlv / apnv10.bin / apnv11.bin get packaged into the image.