### PR TITLE
refpolicy: seatd: allow self fifo_file read/write for signal handling

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch
@@ -1,0 +1,31 @@
+From a7e7df1b5bb6b98297c3306bc5b1832a5d86a47a Mon Sep 17 00:00:00 2001
+From: fangwu <fangwu@qti.qualcomm.com>
+Date: Tue, 28 Jul 2026 21:17:19 +0800
+Subject: [PATCH] seatd: allow self fifo_file read/write for signal handling
+
+seatd uses a self-pipe trick to deliver signals to its event loop.
+The signal handler writes '\0' to signal_fds[1] (a pipe) to wake up
+ppoll() in the main loop. Without permission to write to its own
+fifo_file, SELinux denies the write with EACCES, preventing seatd
+from processing SIGTERM during shutdown and causing a 90s reboot delay.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/commit/a7e7df1b5bb6b98297c3306bc5b1832a5d86a47a]
+Signed-off-by: fangwu <fang.wu@oss.qualcomm.com>
+---
+ policy/modules/services/seatd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/services/seatd.te b/policy/modules/services/seatd.te
+index d539dc446..5f76a1719 100644
+--- a/policy/modules/services/seatd.te
++++ b/policy/modules/services/seatd.te
+@@ -23,6 +23,7 @@ files_runtime_file(seatd_runtime_t)
+ #
+
+ allow seatd_t self:capability { chown dac_override sys_admin sys_tty_config };
++allow seatd_t self:fifo_file rw_fifo_file_perms;
+ allow seatd_t self:unix_stream_socket { accept listen };
+
+ allow seatd_t seatd_runtime_t:sock_file manage_sock_file_perms;
+--
+2.43.0

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:qcom = " \
     file://0001-Add-SELinux-policy-for-nhx.sh.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
+    file://0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch \
 "


### PR DESCRIPTION
  seatd uses a self-pipe trick to deliver signals to its event loop: the signal handler writes \0 to signal_fds[1] to wake up ppoll() in the main loop. Without SELinux
  permission to access its own fifo_file, seatd cannot process SIGTERM during shutdown, causing a 90-second reboot delay.

  Fix: Add allow seatd_t self:fifo_file rw_fifo_file_perms; to policy/modules/services/seatd.te.

  Verified on: iq-x5121-evk (X1E80100) with SELinux in enforcing mode.

  Upstream status:
  - Fix merged upstream: [SELinuxProject/refpolicy@a7e7df1](https://github.com/SELinuxProject/refpolicy/commit/a7e7df1b5bb6b98297c3306bc5b1832a5d86a47a)
  - meta-selinux update submitted: [yocto-patches/message/4562](https://lists.yoctoproject.org/g/yocto-patches/message/4562)

  This patch is a temporary backport via .bbappend, following the same pattern as the existing patches in refpolicy-targeted_git.bbappend. It will be dropped once meta-selinux bumps SRCREV_refpolicy to include the upstream fix.