### PR TITLE
camera-service: upgrade 1.0.2 -> 1.0.4

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.4.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/qualcomm/camera-service"
 
 SRC_URI = "git://github.com/qualcomm/camera-service;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "666344262e69a6c2c5e1df9e9e52b3e74c2f4a33"
+SRCREV = "9f50e49824ed112593e6643a9197e03922cbc807"
 
 # Limit this recipe to ARMv8 (aarch64) only, because it depends
 # on camxcommon-headers which is explicitly restricted to ARMv8 (aarch64).


### PR DESCRIPTION
Upgrade camera-service recipes tag from 1.0.2 to 1.0.4

Highlights:
- Add missing copyrights
- Correctly track and assign callback buffer FDs
- Use CMAKE_INSTALL_LIBDIR for destination install paths
- Support CamX 2.0 lib names and header paths
- Use existing install path for 1.x for debian
- Preserve run directory during service restart
- Added SocId and string name for glymur
-  Added camxlib-talos camxlib-hamoa runtime dependencies
    to ${PN}-server-lib