### PR TITLE
firmware-qcom-boot-glymur: update Glymur boot binaries to 00080

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00079.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00079.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-glymur.inc
-
-SRC_URI[bootbinaries.sha256sum] = "b8063fd1dff26bdc289d96ceb21edb6fcc0dbd604277a948df43699299b32649"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00080.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-glymur_00080.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-glymur.inc
+
+SRC_URI[bootbinaries.sha256sum] = "82abec551e305643ec0acfd9bff77b6fc27c410220ef0ce4b0bce30d268387de"


### PR DESCRIPTION
Known fixes:

fix: resolve PCAT erase and flash failures