### PR TITLE
kgsl-dlkm: Update v1.0.9 ->  v1.0.10

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.10.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.10.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "854e5e32a528c52c6cd3548f1d760ecad7ab6e70"
+SRCREV = "35c8f193149983c38709a7713c72af7c6b7876af"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.10 brings below fixes:

- Add snapshot for gen8_1_0.
- Use synced_poweroff to collapse GX GDSC during recovery.

Signed-off-by: Sumant Gupta <sumagupt@qti.qualcomm.com>
