### PR TITLE
adreno: upgrade 1.877.2 -> 1.877.3

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.877.3.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.877.3.bb
@@ -10,8 +10,8 @@ LIC_FILES_CHKSUM = "file://NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=4ceffe94cb40cdce6
 
 # no top-level dir in the archive, unpack to subdir to prevent UNPACKDIR pollution
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/gfx-adreno.le.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8a.tar.gz;subdir=${BP}"
-PBT_BUILD_DATE = "260702"
-SRC_URI[sha256sum] = "0bdc3a737f7529b9673bd8c895ddf823b40f0f3708ed1c345f0bb21a088a37b7"
+PBT_BUILD_DATE = "260728"
+SRC_URI[sha256sum] = "11c141b6bed7cad32a7b171bb71b886b299e0c6bc6407a1e542b7c57d4bd798d"
 
 # These are listed here in order to identify RDEPENDS
 DEPENDS += " glib-2.0 libdrm \


### PR DESCRIPTION
Update qcom-adreno version from 1.877.2 to 1.877.3

CHANGES for 1.877.3:

 - Fix GPU instruction validation errors during OpenCL program builds like OpenCL SDK samples.
 - Enable OpenCL perf_hint and priority_hint extensions for Hamoa and Glymur.