### PR TITLE
iris-video-dlkm: Purwa : hamoa : load qcom-iris instead of iris_vpu 

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.22.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.22.bb
@@ -46,6 +46,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:shikra = "150"
 # On purwa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:purwa = "150"
 
+# On hamoa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:hamoa = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"

--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.22.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.22.bb
@@ -43,6 +43,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:qcs615 = "150"
 # On shikra, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:shikra = "150"
 
+# On purwa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:purwa = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"


### PR DESCRIPTION
On Purva and Hamou targets, 
When iris-video-dlkm is installed (for example, in qcom-multimedia-proprietary-image),
the default update-alternatives priority activates `blacklist-video.conf.venus`,
which results in qcom_iris being blacklisted and prevents the in-kernel driver
from loading and functioning correctly.

Raise the update-alternatives priority of the `bl-vidc sub-package` to 150 ,
ensuring it takes precedence over bl-venus and becomes the active alternative.
This activates `blacklist-video.conf.vidc` , effectively blacklisting iris_vpu while
allowing qcom_iris to load and operate as expected.