### PR TITLE
optee-os-qcom: Update to qcom-next-4.10-20260721

### DIFF
--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom_git.bb
@@ -1,9 +1,9 @@
 require recipes-security/optee/optee-os.inc
 
-PV = "4.10.0-qcom+git"
+PV = "4.10.0-qcom-20260721+git"
 
-SRC_TAG = "tag=qcom-next-4.10-20260507"
+SRC_TAG = "tag=qcom-next-4.10-20260721"
 SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;nobranch=1;${SRC_TAG}"
-SRCREV_optee = "3ea006809a3ef569db4da775600cd2a46206120b"
+SRCREV_optee = "690842e042dc470bf0625eb77a8cab926c372a8f"
 
 require optee-qcom.inc


### PR DESCRIPTION
Update SRC_TAG and SRCREV to qcom-next-4.10-20260721.

Changes since qcom-next-4.10-20260507:
Add BOBCAT architecture with IPQ96xx, IPQ52xx platform support
Add QFPROM OTP fuse provisioning support for Kodiak and Lemans
Add PAS subsystem bring-up for Lemans (CDSP0/1, GP-DSP0/1,
LPASS, IRIS)
Add diagnostic ring buffer support wired into OP-TEE trace path
Add RPMH client and CMD_DB drivers
Refactor PAS driver into descriptor/ops abstraction
Refactor platform configuration into architecture-based hierarchy