### PR TITLE
trusted-firmware-a-qcom: add bl31 to TFA build targets

### DIFF
--- a/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-bsp/trusted-firmware-a/trusted-firmware-a-qcom.inc
@@ -10,7 +10,7 @@ COMPATIBLE_MACHINE = "qcm6490|qcs9100"
 TFA_PLATFORM:qcm6490 = "rb3gen2"
 TFA_PLATFORM:qcs9100 = "lemans_evk"
 
-TFA_BUILD_TARGET = "bl2 fip"
+TFA_BUILD_TARGET = "bl2 bl31 fip"
 TFA_SPD = "opteed"
 
 EXTRA_OEMAKE:append = " \


### PR DESCRIPTION
Adding bl31 to TFA_BUILD_TARGET ensures bl31.bin is produced and available for packaging into the SPL FIT image.