### PR TITLE
systemd: skip blkid probing for Qualcomm raw partitions

### DIFF
--- a/recipes-bsp/partition/qcom-raw-partitions-udev-rules_git.bb
+++ b/recipes-bsp/partition/qcom-raw-partitions-udev-rules_git.bb
@@ -1,0 +1,51 @@
+SUMMARY = "udev rules for Qualcomm raw partitions"
+DESCRIPTION = "Machine-specific udev rules that skip filesystem probing for reviewed Qualcomm raw GPT partitions"
+
+require qcom-ptool.inc
+
+DEPENDS = "qcom-ptool-native"
+
+QCOM_PARTITION_FILES_SUBDIR ??= ""
+QCOM_PARTITION_FILES_SUBDIR_SPINOR ??= ""
+
+QCOM_RAW_PARTITIONS_RULES = "${B}/55-qcom-raw-partitions-noblkid.rules"
+QCOM_RAW_PARTITION_LAYOUTS = " \
+    ${QCOM_PARTITION_FILES_SUBDIR} \
+    ${QCOM_PARTITION_FILES_SUBDIR_SPINOR} \
+"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_compile() {
+    rm -f ${QCOM_RAW_PARTITIONS_RULES}
+
+    set --
+    for layout in ${QCOM_RAW_PARTITION_LAYOUTS}; do
+        layout=${layout#partitions/}
+        set -- "$@" --input "${S}/platforms/$layout/partitions.conf"
+    done
+
+    if [ "$#" -gt 0 ]; then
+        if ${STAGING_BINDIR_NATIVE}/qcom-ptool \
+                gen_udev_rules --help >/dev/null 2>&1; then
+            ${STAGING_BINDIR_NATIVE}/qcom-ptool gen_udev_rules \
+                --output ${QCOM_RAW_PARTITIONS_RULES} \
+                "$@"
+        else
+            bbwarn "qcom-ptool ${SRCREV} has no gen_udev_rules support; skipping raw partition rules"
+        fi
+    fi
+}
+
+do_install() {
+    if [ -f ${QCOM_RAW_PARTITIONS_RULES} ]; then
+        install -Dm 0644 ${QCOM_RAW_PARTITIONS_RULES} \
+            ${D}${nonarch_libdir}/udev/rules.d/55-qcom-raw-partitions-noblkid.rules
+    fi
+}
+
+FILES:${PN} = " \
+    ${nonarch_libdir}/udev/rules.d/55-qcom-raw-partitions-noblkid.rules \
+"
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -16,3 +16,6 @@ do_install:append:qcom() {
 }
 
 FILES:${PN}-udev-rules:append:qcom = " ${nonarch_libdir}/udev/rules.d/99-dma-heap.rules"
+
+# Install the machine-specific raw partition rules whenever udev is installed.
+RRECOMMENDS:udev:append:qcom = " qcom-raw-partitions-udev-rules"


### PR DESCRIPTION
Add a Qualcomm-specific udev rule to skip `blkid` probing for known raw GPT partitions.

Qualcomm platforms can expose many bootloader, firmware, metadata, modem NV, and dump partitions during coldplug. These partitions are accessed as raw block partitions rather than mounted filesystems, but systemd's default `60-persistent-storage.rules` still runs the `blkid` builtin for each one.

This rule matches known raw partition names by GPT `PARTNAME`, preserves `/dev/disk/by-partlabel` and `/dev/disk/by-partuuid` links from kernel-provided partition metadata, and sets `UDEV_DISABLE_PERSISTENT_STORAGE_BLKID_FLAG=1` before `60-persistent-storage.rules` runs.

The rule intentionally avoids matching by kernel block device names such as `sda`, `sdb`, etc. Disk enumeration is board- and boot-order-dependent, and some platforms may place mountable partitions on the same storage device as raw boot or firmware partitions.

The rule also does not set `SYSTEMD_READY=0`, so block devices remain visible to systemd. Normal filesystem partitions such as `rootfs`, `efi`, `persist`, `userdata`, `logfs`, and `vm-data` continue to use the stock persistent-storage handling.

Sysinit milestone improved by about 0.38s on `rb3gen2-core-kit`
(`QLI-2.0` tag `wrynose-260627.1`):

```text
Default:           sysinit.target reached at 5.74s
With optimization: sysinit.target reached at 5.37s
```