### PR TITLE
initramfs-firmware-shikra-evk-image: add Shikra EVK initramfs firmware image

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-shikra-evk-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-shikra-evk-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with Shikra EVK firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-shikra-evk-firmware \
+"
+
+require initramfs-firmware-image.inc


### PR DESCRIPTION
Add initramfs firmware image recipe for Shikra EVK board to include required firmware files via packagegroup-shikra-evk-firmware for kernel validation workflows.