### PR TITLE
camx-dlkm: Update camx driver to v1.0.5

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.5.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.5.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
 "
 
-SRCREV = "f073e13d7a310df5c1551f2136199f85c85db6d8"
+SRCREV = "0f16924ff6a7f9bb56a7e958016da2ed8a174f2f"
 
 inherit module
 


### PR DESCRIPTION
This tag v1.0.5 brings a below updates:

- Update the camera driver to use the new upstream PAS APIs when CONFIG_QCOM_PAS is enabled.
- Fix build errors in various modules.
- Fix genirq buffer offset and NRT final CDM BL offset.