### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260812 v6.18.37

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -20,8 +20,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag:qcom-6.18.y-20260723
-SRCREV ?= "3167b12384380f1463ccf3b42f83adcac5a3f754"
+# tag:qcom-6.18.y-20260812
+SRCREV ?= "bfeb0e5567c0987f05faeec78664719b718133e5"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -20,8 +20,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag:qcom-6.18.y-20260723
-SRCREV ?= "3167b12384380f1463ccf3b42f83adcac5a3f754"
+# tag:qcom-6.18.y-20260804
+SRCREV ?= "d9ebca924ccc940f0b3b64c702fee8608abba8b7"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260812

Changelog:
QCLINUX: Revert "WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO" (5a472e184be9)
QCLINUX: Revert "WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO" (06f2b9c60834)
FROMLIST: arm64: dts: qcom: purwa-iot-evk: Describe the PCIe M.2 Key E connector
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: Describe the PCIe M.2 Key E connector
QCLINUX: Revert "WORKAROUND: arm64: dts: qcom: purwa-iot-evk: support Bluetooth over both USB and UART"
QCLINUX: Revert "WORKAROUND: arm64: dts: qcom: hamoa-iot-evk: support Bluetooth over both USB and UART"
FROMLIST: arm64: dts: qcom: hamoa: Add compatible to the PCIe Root Port
FROMLIST: arm64: dts: qcom: hamoa: Add graph port/endpoint anchors to pcie4_port0 and uart14
FROMLIST: power: sequencing: pcie-m2: Deassert W_DISABLE2# when no UART serdev is created
FROMGIT: power: sequencing: pcie-m2: Match WCN6855 and WCN7851 UART BT variants by subdevice ID
UPSTREAM: pinctrl: qcom: Replace open coded eoi call with irq_chip_eoi_parent()
UPSTREAM: pinctrl: qcom: Register functions before enabling pinctrl
UPSTREAM: pinctrl: qcom: Drop redundant intr_target_reg on modern SoCs
FROMLIST: wifi: ath11k: unregister PM notifier on QMI init failure path
FROMLIST: wifi: ath11k: fix NULL dereference in ahb remove when QMI init incomplete
FROMLIST: wifi: ath11k: fix sporadic WLAN initialization failures
UPSTREAM: interconnect: qcom: qcs8300: fix the num_links for nsp icc node
FROMLIST: arm64: dts: qcom: shikra: Enable CDSP cooling
FROMLIST: coresight: tnoc: Bind Aggregator TNOC on the platform bus
FROMLIST: dt-bindings: arm: coresight-tnoc: Bind on platform bus instead of AMBA
BACKPORT: coresight-tnoc: Add runtime PM support for Interconnect TNOC
BACKPORT: coresight-tnoc: add platform driver to support Interconnect TNOC
BACKPORT: dt-bindings: arm: qcom: Add Coresight Interconnect TNOC
BACKPORT: arm64: dts: qcom: hamoa: Add label properties to CoreSight devices
BACKPORT: arm64: dts: qcom: talos: Add label properties to CoreSight devices
BACKPORT: arm64: dts: qcom: kodiak: Add label properties to CoreSight devices
BACKPORT: arm64: dts: qcom: monaco: Add label properties to CoreSight devices
BACKPORT: arm64: dts: qcom: lemans: Add label properties to CoreSight devices
BACKPORT: arm64: dts: qcom: lemans: enable static TPDM
FROMLIST: arm64: dts: qcom: purwa-evk: add DP0/DP1 audio playback support
FROMGIT: arm64: dts: qcom: lemans-evk: Describe the PCIe M.2 Key E connector
FROMGIT: arm64: dts: qcom: lemans: Add compatible to the PCIe Root Port
FROMGIT: power: sequencing: pwrseq-pcie-m2: Add QCC2072 BT PCI device ID
UPSTREAM: power: sequencing: pcie-m2: Sort PCI device IDs in ascending order
UPSTREAM: power: sequencing: pcie-m2: Add PCI ID 0x1103 for WCN6855 Bluetooth
UPSTREAM: wifi: ath12k: fix EHT TX MCS limitation due to wrong 20 MHz-only parsing
WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO
UPSTREAM: Bluetooth: qca: enable pwrseq support for WCN39xx devices
UPSTREAM: power: sequencing: qcom-wcn: add support for WCN39xx
UPSTREAM: regulator: dt-bindings: qcom,wcn3990-pmu: describe PMUs on WCN39xx
FROMLIST: arm64: dts: qcom: shikra: Add WCN3988 PMU and fix WiFi/BT supply routing
BACKPORT: arm64: dts: qcom: sa8775p: Add reg and clocks for QoS configuration
BACKPORT: interconnect: qcom: sa8775p: enable QoS configuration
UPSTREAM: dt-bindings: interconnect: add reg and clocks properties to enable QoS on sa8775p
UPSTREAM: arm64: dts: qcom: qcs8300: Add clocks for QoS configuration
UPSTREAM: interconnect: qcom: qcs8300: enable QoS configuration
UPSTREAM: dt-bindings: interconnect: qcom,qcs8300-rpmh: add clocks property to enable QoS
UPSTREAM: interconnect: qcom: kaanapali: Drop redundant link_nodes casts
UPSTREAM: arm64: dts: qcom: talos: Add clocks for QoS configuration
UPSTREAM: interconnect: qcom: qcs615: enable QoS configuration
UPSTREAM: dt-bindings: interconnect: qcom,qcs615-rpmh: add clocks property to enable QoS
UPSTREAM: interconnect: qcom: icc-rpmh: drop support for non-dynamic IDS
UPSTREAM: interconnect: qcom: sm8750: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8650: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8550: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8450: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8350: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8150: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm7150: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm6350: convert to dynamic IDs
BACKPORT: interconnect: qcom: sdx75: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sdx65: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sdx55: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sdm670: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sc7180: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sar2130p: convert to dynamic IDs
UPSTREAM: interconnect: qcom: qdu1000: convert to dynamic IDs
UPSTREAM: interconnect: qcom: qcs8300: convert to dynamic IDs
UPSTREAM: interconnect: qcom: qcs615: convert to dynamic IDs
UPSTREAM: interconnect: qcom: x1e80100: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sm8250: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sdm845: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sc8280xp: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sc8180x: convert to dynamic IDs
UPSTREAM: interconnect: qcom: sc7280: convert to dynamic IDs
UPSTREAM: interconnect: qcom: icc-rpmh: convert link_nodes to dynamic array
FROMLIST: wifi: ath12k: Fix low MLO RX throughput on WCN7850
FROMLIST: wifi: ath12k: change MAC buffer ring size to 4096
