### PR TITLE
linux-qcom-dtbbin: run qcom_dtbbin_deploy before qcom_img_deploy

### DIFF
--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -32,7 +32,7 @@ do_qcom_dtbbin_deploy() {
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-multi-dtb-image.vfat" -vsmpQ ${DEPLOY_DIR_IMAGE}/qclinuxfitImage ::/qclinux_fit.img
     fi
 }
-addtask qcom_dtbbin_deploy after do_populate_sysroot do_packagedata before do_deploy
+addtask qcom_dtbbin_deploy after do_populate_sysroot do_packagedata before qcom_img_deploy do_deploy
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_qcom_dtbbin_deploy"


### PR DESCRIPTION
There is race condiction when do_qcom_img_deploy is executed and sometimes the kernel image is not available when the task is executed. If we run qcom_dtbbin_deploy before qcom_img_deploy, we guarantee we'll fix this problem.

Fix https://github.com/qualcomm-linux/meta-qcom/issues/2871