### PR TITLE
iris-video-dlkm: upgrade v1.0.22 -> v1.0.26

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.26.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.26.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "b58ccfa846b9d8801ef8b30602cadffa452fd63c"
+SRCREV  = "5fb3b4746a53244147c3e5ef0484e03bbf1ae564"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.26 brings the following updates for Qcom Iris:

- Add generic PAS API support for QTEE/SCM and OP-TEE firmware loading
- Improve PAS compatibility with new kernel APIs and legacy fallback support
- Enable IR_PERIOD capability on Hamoa and consolidate common platform handling
- Add Glymur support and fix rotated output green line and downscale issues
- Add SLICE_MODE dependency for ENH_LAYER_COUNT across supported platforms
- Optimize Iris2 clock frequency scaling using measured frame rates