### PR TITLE
Re-enable armv7a world build

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -197,8 +197,10 @@ jobs:
       # coverage: nodistro (including the nogl variant) covers the plain OE
       # configuration and qcom-distro-catchall enables a superset of the
       # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
-      # combinations only repeat already-covered world builds.
-      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
+      # combinations only repeat already-covered world builds. qcom-armv7a has
+      # no qcom-distro-catchall variant, so its qcom-distro build is the
+      # distro-family world build for that machine.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall' || (matrix.machine == 'qcom-armv7a' && matrix.distro.name == 'qcom-distro')) && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}
@@ -456,8 +458,10 @@ jobs:
       # coverage: nodistro (including the nogl variant) covers the plain OE
       # configuration and qcom-distro-catchall enables a superset of the
       # qcom-distro DISTRO_FEATURES, so the remaining distro and kernel
-      # combinations only repeat already-covered world builds.
-      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall') && matrix.kernel.type == 'default' }}
+      # combinations only repeat already-covered world builds. qcom-armv7a has
+      # no qcom-distro-catchall variant, so its qcom-distro build is the
+      # distro-family world build for that machine.
+      world: ${{ (startsWith(matrix.distro.name, 'nodistro') || matrix.distro.name == 'qcom-distro-catchall' || (matrix.machine == 'qcom-armv7a' && matrix.distro.name == 'qcom-distro')) && matrix.kernel.type == 'default' }}
       machine: ${{matrix.machine}}
       distro_yaml: ${{matrix.distro.yamlfile}}
       distro_name: ${{matrix.distro.name}}

--- a/dynamic-layers/openembedded-layer/recipes-kernel/crash/crash/0001-Makefile-support-cross-compiling-for-32-bit-arm.patch
+++ b/dynamic-layers/openembedded-layer/recipes-kernel/crash/crash/0001-Makefile-support-cross-compiling-for-32-bit-arm.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 30 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Makefile: support cross compiling for 32-bit arm
+
+The CONF_TARGET_ARCH cross-compilation mapping enumerates aarch64,
+s390x, powerpc64, ppc64le, alpha, i386, mips, sparc64 and riscv64 but
+omits 32-bit arm. As a result, building with CROSS_COMPILE=arm-* (e.g.
+arm-poky-linux-gnueabi-) aborts at Makefile parse time with:
+
+    Makefile:75: *** The current Arch(arm) does not support cross compilation.  Stop.
+
+ARM is already a valid crash target (defs.h/configure.c), so map the
+normalized "arm" arch to CONF_TARGET_ARCH=ARM like every other arch.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 1111111..2222222 100644
+--- a/Makefile
++++ b/Makefile
+@@ -55,6 +55,8 @@ ifeq (${ARCH}, x86_64)
+ CONF_TARGET_ARCH := X86_64
+ else ifeq (${ARCH}, aarch64)
+ CONF_TARGET_ARCH := ARM64
++else ifeq (${ARCH}, arm)
++CONF_TARGET_ARCH := ARM
+ else ifeq (${ARCH}, s390x)
+ CONF_TARGET_ARCH := S390X
+ else ifeq (${ARCH}, powerpc64)
+--
+2.43.0

--- a/dynamic-layers/openembedded-layer/recipes-kernel/crash/crash_9.0.2.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-kernel/crash/crash_9.0.2.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom = " \
+    file://0001-Makefile-support-cross-compiling-for-32-bit-arm.patch \
+"


### PR DESCRIPTION
Re-enable world build for qcom-armv7 (which got disabled by mistake as part of https://github.com/qualcomm-linux/meta-qcom/commit/bf4b626d19d543155000a357aa334397d94a3edb), and bring the crash related fix from https://github.com/qualcomm-linux/meta-qcom-distro/pull/411 as initramfs-test-full-image depends on it (when meta-oe is available).