### PR TITLE
classes: make kernel deploy-time tasks safe in partially cached builds

### DIFF
--- a/classes-recipe/dtb-fit-image.bbclass
+++ b/classes-recipe/dtb-fit-image.bbclass
@@ -14,18 +14,14 @@ require conf/image-fitimage.conf
 LINUX_QCOM_FIT_DTB_COMPATIBLE ?= "conf/machine/include/fit-dtb-compatible.inc"
 require ${LINUX_QCOM_FIT_DTB_COMPATIBLE}
 
-DEPENDS += "\
-    u-boot-tools-native \
-"
-
 MKIMAGE ?= "${STAGING_BINDIR_NATIVE}/mkimage"
 
 QCOMFIT_DEPLOYDIR = "${WORKDIR}/qcom_fitimage_deploy-${PN}"
 
-do_generate_qcom_fitimage[depends] += "qcom-dtb-metadata:do_deploy"
+do_generate_qcom_fitimage[depends] += "qcom-dtb-metadata:do_deploy u-boot-tools-native:do_populate_sysroot"
 do_generate_qcom_fitimage[cleandirs] += "${QCOMFIT_DEPLOYDIR}"
 python do_generate_qcom_fitimage() {
-    import os, shutil
+    import os
     from qcom.dtb_only_fitimage import QcomItsNodeRoot
 
     fit_dir = d.getVar('QCOMFIT_DEPLOYDIR')
@@ -43,14 +39,16 @@ python do_generate_qcom_fitimage() {
     root_node.set_extra_opts(d.getVar("FIT_DTB_MKIMAGE_EXTRA_OPTS") or "")
 
     deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
-    dtb_dir = os.path.join(d.getVar('B'), "arch", d.getVar('ARCH'), "boot", "dts", "qcom")
+    # Consume the DTBs published by do_deploy: unlike ${B}, this location
+    # is also populated when do_deploy is restored from sstate.
+    dtb_dir = deploy_dir_image
+    if d.getVar('KERNEL_DEPLOYSUBDIR'):
+        dtb_dir = os.path.join(deploy_dir_image, d.getVar('KERNEL_DEPLOYSUBDIR'))
     os.makedirs(fit_dir, exist_ok=True)
 
     # Always include QCOM metadata first
-    qcom_meta_src = os.path.join(deploy_dir_image, 'qcom-metadata.dtb')
-    qcom_meta_dst = os.path.join(dtb_dir, 'qcom-metadata.dtb')
-    shutil.copy(qcom_meta_src, qcom_meta_dst)
-    root_node.fitimage_emit_section_dtb("qcom-metadata.dtb", qcom_meta_dst, compatible_str=None, dtb_type="qcom_metadata")
+    qcom_meta = os.path.join(deploy_dir_image, 'qcom-metadata.dtb')
+    root_node.fitimage_emit_section_dtb("qcom-metadata.dtb", qcom_meta, compatible_str=None, dtb_type="qcom_metadata")
 
     # KERNEL_DEVICETREE contains both .dtb and .dtbo
     files_set = {os.path.basename(x) for x in (d.getVar('KERNEL_DEVICETREE') or "").split()}
@@ -124,7 +122,7 @@ python do_generate_qcom_fitimage() {
 
     root_node.run_mkimage_assemble(itsfile, fitname)
 }
-addtask generate_qcom_fitimage after do_populate_sysroot do_packagedata before do_qcom_dtbbin_deploy
+addtask generate_qcom_fitimage after do_deploy before do_qcom_dtbbin_deploy
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_generate_qcom_fitimage"

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -32,6 +32,8 @@ do_image_qcomflash[depends] += "${@ ['', '${QCOM_PARTITION_CONF}:do_deploy'][d.g
                                 ${@ ['', '${QCOM_CDT_FIRMWARE}:do_deploy'][d.getVar('QCOM_CDT_FIRMWARE') != '']} \
                                 ${@ ['', '${QCOM_CAPSULE_FIRMWARE}:do_deploy'][d.getVar('QCOM_CAPSULE_FIRMWARE') != '']} \
                                 pigz-native:do_populate_sysroot virtual/kernel:do_deploy \
+				${@'virtual/kernel:do_qcom_dtbbin_deploy' if 'linux-qcom-dtbbin' in (d.getVar('KERNEL_CLASSES') or '').split() else ''} \
+				${@'virtual/kernel:do_qcom_img_deploy' if 'linux-qcom-bootimg' in (d.getVar('KERNEL_CLASSES') or '').split() else ''} \
 				${@'virtual/bootloader:do_deploy' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader') else  ''} \
 				${@'${QCOM_ESP_IMAGE}:do_image_complete' if d.getVar('QCOM_ESP_IMAGE') != '' else  ''} \
 				${@'abl2esp:do_deploy' if d.getVar('ABL_SIGNATURE_VERSION') else  ''}"

--- a/classes-recipe/qcom-capsule.bbclass
+++ b/classes-recipe/qcom-capsule.bbclass
@@ -128,6 +128,7 @@ do_compile[depends] += "${@'${QCOM_BOOT_FIRMWARE}:do_deploy' if d.getVar('QCOM_B
 
 # Pull in the kernel DTB when capsule includes a dtb entry.
 do_compile[depends] += "${@'virtual/kernel:do_deploy' if 'dtb' in d.getVar('CAPSULE_ENTRIES').split() else ''}"
+do_compile[depends] += "${@'virtual/kernel:do_qcom_dtbbin_deploy' if 'dtb' in d.getVar('CAPSULE_ENTRIES').split() and 'linux-qcom-dtbbin' in (d.getVar('KERNEL_CLASSES') or '').split() else ''}"
 
 python generate_fvupdate() {
     """Generate FvUpdate.xml from CAPSULE_ENTRIES when the variable is set."""

--- a/classes/linux-qcom-bootimg.bbclass
+++ b/classes/linux-qcom-bootimg.bbclass
@@ -45,12 +45,9 @@ python do_qcom_img_deploy() {
         if not initrd:
             bb.fatal("Could not find initramfs image %s for bundling" % d.getVar("INITRAMFS_IMAGE"))
 
-    B = d.getVar("B")
-    D = d.getVar("D")
-    kernel_output_dir = d.getVar("KERNEL_OUTPUT_DIR")
-    kernel_dtbdest = d.getVar("KERNEL_DTBDEST")
-    kernel = os.path.join(B, "kernel-dtb")
-    definitrd = os.path.join(B, "initrd.img")
+    workdir = d.getVar("WORKDIR")
+    kernel = os.path.join(workdir, "kernel-dtb")
+    definitrd = os.path.join(workdir, "initrd.img")
     mkbootimg = os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "skales", "mkbootimg")
     kernel_image_name = d.getVar("KERNEL_IMAGE_NAME")
     kernel_link_name = d.getVar("KERNEL_IMAGE_LINK_NAME")
@@ -64,6 +61,11 @@ python do_qcom_img_deploy() {
         kernel_name = "Image.gz"
     else:
         bb.fatal("Unuspported ARCH %s" % arch)
+
+    # Consume the kernel image and DTBs published by do_deploy: unlike
+    # ${B} and ${D}, DEPLOY_DIR_IMAGE is also populated when do_deploy
+    # is restored from sstate.
+    kernel_src = os.path.join(image_dir, kernel_name)
 
     if os.path.exists(output_img):
         os.unlink(output_img)
@@ -114,9 +116,9 @@ python do_qcom_img_deploy() {
 
         # prepare kernel image with appended dtb
         with open(kernel, 'wb') as wfd:
-            with open(os.path.join(kernel_output_dir, kernel_name), 'rb') as rfd:
+            with open(kernel_src, 'rb') as rfd:
                 shutil.copyfileobj(rfd, wfd)
-            with open(os.path.join(D, kernel_dtbdest, dtb), 'rb') as rfd:
+            with open(os.path.join(image_dir, dtb), 'rb') as rfd:
                 shutil.copyfileobj(rfd, wfd)
 
         rootfs = getVarDTB("QCOM_BOOTIMG_ROOTFS")
@@ -143,7 +145,7 @@ python do_qcom_img_deploy() {
 do_qcom_img_deploy[depends] += "skales-native:do_populate_sysroot"
 do_qcom_img_deploy[vardeps] = "QCOM_BOOTIMG_PAGE_SIZE QCOM_BOOTIMG_KERNEL_BASE KERNEL_CMDLINE_EXTRA QCOM_BOOTIMG_ROOTFS"
 
-addtask qcom_img_deploy after do_populate_sysroot do_packagedata do_bundle_initramfs before do_deploy
+addtask qcom_img_deploy after do_deploy before do_build
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_qcom_img_deploy"
@@ -154,7 +156,7 @@ python do_qcom_img_deploy_setscene () {
     sstate_setscene(d)
 }
 addtask do_qcom_img_deploy_setscene
-do_qcom_img_deploy[dirs] = "${QIMG_DEPLOYDIR} ${B}"
+do_qcom_img_deploy[dirs] = "${QIMG_DEPLOYDIR}"
 do_qcom_img_deploy[cleandirs] = "${QIMG_DEPLOYDIR}"
 do_qcom_img_deploy[stamp-extra-info] = "${MACHINE_ARCH}"
 

--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -12,6 +12,14 @@ DTBBIN_SIZE ?= "4096"
 do_qcom_dtbbin_deploy[depends] += "dosfstools-native:do_populate_sysroot mtools-native:do_populate_sysroot"
 do_qcom_dtbbin_deploy[cleandirs] = "${DTBBIN_DEPLOYDIR}"
 do_qcom_dtbbin_deploy() {
+    # Source the DTBs from what do_deploy published: unlike ${D}, which
+    # only exists when do_install ran in this build, DEPLOY_DIR_IMAGE is
+    # also populated when do_deploy is restored from sstate.
+    deployDir="${DEPLOY_DIR_IMAGE}"
+    if [ -n "${KERNEL_DEPLOYSUBDIR}" ]; then
+        deployDir="${DEPLOY_DIR_IMAGE}/${KERNEL_DEPLOYSUBDIR}"
+    fi
+
     for dtbf in ${KERNEL_DEVICETREE}; do
         bbdebug 1 " combining: $dtbf"
         dtb=`normalize_dtb "$dtbf"`
@@ -20,7 +28,7 @@ do_qcom_dtbbin_deploy() {
         [ "$dtb_ext" = "dtbo" ] && continue
         dtb_base_name=`basename $dtb .$dtb_ext`
         mkdir -p ${DTBBIN_DEPLOYDIR}/$dtb_base_name
-        cp ${D}/${KERNEL_DTBDEST}/$dtb_base_name.dtb ${DTBBIN_DEPLOYDIR}/$dtb_base_name/combined-dtb.dtb
+        cp $deployDir/$dtb_base_name.dtb ${DTBBIN_DEPLOYDIR}/$dtb_base_name/combined-dtb.dtb
         mkfs.vfat -S ${QCOM_VFAT_SECTOR_SIZE} -C ${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat ${DTBBIN_SIZE}
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-${dtb_base_name}-image.vfat" -vsmpQ ${DTBBIN_DEPLOYDIR}/$dtb_base_name/* ::/
         rm -rf ${DTBBIN_DEPLOYDIR}/$dtb_base_name
@@ -32,7 +40,7 @@ do_qcom_dtbbin_deploy() {
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-multi-dtb-image.vfat" -vsmpQ ${DEPLOY_DIR_IMAGE}/qclinuxfitImage ::/qclinux_fit.img
     fi
 }
-addtask qcom_dtbbin_deploy after do_populate_sysroot do_packagedata before do_deploy
+addtask qcom_dtbbin_deploy after do_deploy before do_build
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_qcom_dtbbin_deploy"

--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -32,7 +32,7 @@ do_qcom_dtbbin_deploy() {
         mcopy -i "${DTBBIN_DEPLOYDIR}/dtb-multi-dtb-image.vfat" -vsmpQ ${DEPLOY_DIR_IMAGE}/qclinuxfitImage ::/qclinux_fit.img
     fi
 }
-addtask qcom_dtbbin_deploy after do_populate_sysroot do_packagedata before qcom_img_deploy do_deploy
+addtask qcom_dtbbin_deploy after do_populate_sysroot do_packagedata before do_deploy
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_qcom_dtbbin_deploy"

--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -24,6 +24,10 @@ KERNEL_IMAGETYPE ?= "zImage"
 # To build an Android boot image
 KERNEL_CLASSES += "linux-qcom-bootimg"
 
+# Make every image build provide the Android boot images; the initramfs
+# image bundled into them is skipped to avoid a circular dependency.
+EXTRA_IMAGEDEPENDS += "${@'virtual/kernel:do_qcom_img_deploy' if d.getVar('PN') != d.getVar('INITRAMFS_IMAGE') else ''}"
+
 KERNEL_DEVICETREE ?= " \
     qcom/qcom-apq8064-asus-nexus7-flo.dtb \
     qcom/qcom-apq8064-ifc6410.dtb \

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -31,6 +31,10 @@ KERNEL_CLASSES += "linux-qcom-bootimg"
 # For dtb.bin generation
 KERNEL_CLASSES += "linux-qcom-dtbbin"
 
+# Make every image build provide the Android boot images; the initramfs
+# image bundled into them is skipped to avoid a circular dependency.
+EXTRA_IMAGEDEPENDS += "${@'virtual/kernel:do_qcom_img_deploy' if d.getVar('PN') != d.getVar('INITRAMFS_IMAGE') else ''}"
+
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 KERNEL_DEVICETREE ?= " \
     qcom/apq8016-sbc.dtb \


### PR DESCRIPTION
do_qcom_dtbbin_deploy, do_qcom_img_deploy (#2871) and
do_generate_qcom_fitimage read the kernel ${D}/${B} work directories, which
are empty when the kernel tasks were restored from sstate. If the custom task
itself misses the cache, it fails deterministically — this is what has been
failing the same 12 wrynose nightly compile jobs since the monthly sstate
cache rotation on Aug 1.

Move the three tasks after do_deploy and source their inputs from
DEPLOY_DIR_IMAGE, which is populated whether do_deploy executed or was
restored from sstate — a single code path for every build scenario. The
qcomflash/capsule consumers now depend on these tasks explicitly, since they
leave the do_deploy chain. Supersedes the f18d7eff workaround, fixes #2871.