### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "0b3897c9c10d41752e431744c8a5a6502a27828e"
+SRCREV = "e77a50d42f5b290b95ad8c33f32ed8f9c23bcc5e"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Ali Erdinc Koroglu (2):
    packaging: add license-files to pyproject.toml
    qcom_ptool: drop shebangs and executable bits from package modules

Fang Wu (1):
    platforms/qcs615-ride: add uefivarstore partition to UFS layout

Vivek Puar (2):
    platforms/shikra-evk: update additional_chipid in contents.xml.in
    platforms/contents.xml.in: fix Crashscope 'Unsupported' error for Nightly builds