### PR TITLE
firmware-boot: remove stale qcs615/qcs6490/qcs8300/qcs9100 boot recipes

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00128.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "541e9439e34a8910fca6f12b0141f57001a278bf48b386662869aebba20b216b"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00128.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00128.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a322c3a2abae3376c0bb8b01daf3e50827f87cf0abbe6a29a0c8e410f9db002a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00130.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00130.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "e202c36dd5b5dcb81a3014dca3cafaef0044d71dda5e3a8adbb355655b4b2a81"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00130.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00130.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "4e4fe94a4dad8a31319b6e1aca28d089f8a363db81aaf0bb3ef8fc8c6e7d187b"


### PR DESCRIPTION
The "update boot to 00135" commits for qcs615, qcs6490, qcs8300 and
qcs9100 (e99c6807, 62542396, 136c92d9, 58466005) were created against
an older tree: each removed the already-gone 00126 recipe instead of
the 00128/00130 version that was current on master, so the layer ended
up carrying two versions of each boot firmware recipe.

Remove the leftover 00128/00130 recipes, which should have been dropped
by the commits that introduced 00135. Nothing references the older
versions (no PREFERRED_VERSION pins), so bitbake now just picks the
sole remaining 00135 recipes.