### PR TITLE
image_types_qcom: drop tar --sparse for qcomflash tarball

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -199,7 +199,7 @@ create_qcomflash_pkg() {
     ln -rsf ${QCOMFLASH_DIR} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash
 
     # Create qcomflash tarball
-    ${IMAGE_CMD_TAR} --sparse --numeric-owner --transform="s,^\./,${IMAGE_BASENAME}-${MACHINE}/," -cf- . | pigz -p ${BB_NUMBER_THREADS} -9 -n --rsyncable > ${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash.tar.gz
+    ${IMAGE_CMD_TAR} --numeric-owner --transform="s,^\./,${IMAGE_BASENAME}-${MACHINE}/," -cf- . | pigz -p ${BB_NUMBER_THREADS} -9 -n --rsyncable > ${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash.tar.gz
     ln -sf ${IMAGE_NAME}.qcomflash.tar.gz ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash.tar.gz
 }
 


### PR DESCRIPTION
The --sparse flag in create_qcomflash_pkg() makes GNU tar emit sparse members (typeflag 'S'), a GNU-private extension outside POSIX/ustar.  Extractors that don't implement it (e.g. on Windows) fail to restore rootfs.img correctly. Since the tarball is gzip'd,  --sparse barely affects the size anyway: building qcom-multimedia-image for iq-x7181-evk gave a 969.1 MiB tarball with --sparse and 974.9 MiB without (GNU tar 1.35). The flag can therefore be dropped, keeping the flash tarball
portable across extractors.

local validation:
 $ ls -lh qcom-multimedia-image-iq-x7181-evk.rootfs-20260807025631.qcomflash*.tar.gz
-rw-r--r-- 1 guanquan users **970M** Aug  7 13:50 qcom-multimedia-image-iq-x7181-evk.rootfs-20260807025631.qcomflash.**sparse**.tar.gz
-rw-r--r-- 1 guanquan users **975M** Aug  7 11:57 qcom-multimedia-image-iq-x7181-evk.rootfs-20260807025631.qcomflash.tar.gz