### PR TITLE
qcom-fastcv-binaries: upgrade FastCV recipe to 1.8.8

### DIFF
--- a/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
+++ b/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
@@ -5,11 +5,11 @@ LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/${PN}/NOLOGINBINARYLICENSE
                     file://${UNPACKDIR}/usr/share/doc/${PN}/NOTICE;md5=4b722aa0574e24873e07b94e40b92e4d "
 
 PBT_BUILD_DATE = "260707"
-ARTIFACTORY_URL = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/computervision-fastcv.qclinux.0.1/${PBT_BUILD_DATE}/prebuilt_yocto_master"
+ARTIFACTORY_URL = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/computervision-fastcv.qclinux.0.1/${PBT_BUILD_DATE}/prebuilt_yocto_wrynose"
 PBT_ARCH = "armv8a"
 
 SRC_URI = "${ARTIFACTORY_URL}/${BPN}_${PV}_${PBT_ARCH}.tar.gz"
-SRC_URI[sha256sum] = "b1e8292f0fda9fc2ba432c04181bf34bd162e0fa24068d9be3a7624abcd8830b"
+SRC_URI[sha256sum] = "b580381bb987dae572cda20f4ab1457c22e1cddb2a2a06bd41c1bb3856a4c2db"
 S = "${UNPACKDIR}"
 
 DEPENDS += "glib-2.0 fastrpc"


### PR DESCRIPTION
Bump version to 1.8.8, update PBT_BUILD_DATE and SRC_URI checksum to match the new prebuilt binaries.
This release resolves lintian errors on the FastCV CPU and DSP libs.