### PR TITLE
firmware-qcom-boot: package and ship the boot firmware build metadata

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -109,7 +109,8 @@ create_qcomflash_pkg() {
                 -name 'qsahara_*.xml' -o \
                 -name 'sec.dat' -o \
                 -name 'soccp*.bin' -o \
-                -name 'xbl_config_devprg.elf'` ; do
+                -name 'xbl_config_devprg.elf' -o \
+                -name 'build-info.txt'` ; do
             install -m 0644 ${bfw} .
         done
 
@@ -153,7 +154,8 @@ create_qcomflash_pkg() {
                        -name '*.mbn' -o \
                        -name '*.melf' -o \
                        -name '*.xz' -o \
-                       -name 'qsahara_*.xml' \) \
+                       -name 'qsahara_*.xml' -o \
+                       -name 'build-info.txt' \) \
                     ! -name 'uefi_dtbs*.xz'` ; do
                 install -m 0644 ${bfw} spinor
             done

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -23,6 +23,10 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-yocto"
 VIRTUAL-RUNTIME_qcom-capsule-firmware ?= ""
 MACHINE_EXTRA_RRECOMMENDS += "${VIRTUAL-RUNTIME_qcom-capsule-firmware}"
 
+# Install the boot firmware build metadata of the machine's boot firmware
+QCOM_BOOT_FIRMWARE ?= ""
+MACHINE_EXTRA_RRECOMMENDS += "${QCOM_BOOT_FIRMWARE}"
+
 # Device Trees specific to linux-qcom family of kernels
 LINUX_QCOM_KERNEL_DEVICETREE ??= ""
 KERNEL_DEVICETREE:append:pn-linux-qcom = " ${LINUX_QCOM_KERNEL_DEVICETREE}"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -4,12 +4,62 @@ S = "${UNPACKDIR}/${BOOTBINARIES}"
 
 QCOM_BOOT_IMG_SUBDIR ?= ""
 
+# Rootfs directory holding the per-board boot firmware build metadata
+QCOM_BOOT_INFO_DIR ?= "${datadir}/qcom-boot-firmware"
+
 INHIBIT_DEFAULT_DEPS = "1"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
 inherit deploy
+
+python do_install() {
+    import os
+    import zipfile
+
+    # Prefer the SRC_URI entry named "bootbinaries"; legacy recipes don't
+    # name their sole archive, so fall back to the first .zip entry.
+    fetch = bb.fetch2.Fetch(d.getVar('SRC_URI').split(), d)
+    bootbin = None
+    for url in fetch.urls:
+        ud = fetch.ud[url]
+        if ud.parm.get('name') == 'bootbinaries':
+            bootbin = ud
+            break
+        if bootbin is None and ud.localpath.endswith('.zip'):
+            bootbin = ud
+
+    # Qualcomm releases embed build info (Meta_Build_ID, per-image build
+    # IDs) as the zip archive comment; releases in other archive formats
+    # or without a comment carry no such metadata.
+    comment = ''
+    if bootbin is not None and zipfile.is_zipfile(bootbin.localpath):
+        with zipfile.ZipFile(bootbin.localpath) as z:
+            comment = z.comment.decode('utf-8', errors='replace')
+        comment = comment.replace('\r\n', '\n').replace('\r', '\n').strip()
+
+    info = 'Recipe: %s\n' % d.getVar('PN')
+    info += 'Version: %s\n' % d.getVar('PV')
+    if bootbin is not None:
+        info += 'Archive: %s\n' % os.path.basename(bootbin.localpath)
+        sha256 = getattr(bootbin, 'sha256_expected', None)
+        if sha256:
+            info += 'Archive-SHA256: %s\n' % sha256
+    if comment:
+        info += '\n' + comment + '\n'
+
+    board = (d.getVar('QCOM_BOOT_IMG_SUBDIR') or '').strip('/').split('/')[0] \
+        or d.getVar('BPN')
+    destdir = os.path.join(d.getVar('D') + d.getVar('QCOM_BOOT_INFO_DIR'), board)
+    bb.utils.mkdirhier(destdir)
+    dest = os.path.join(destdir, 'build-info.txt')
+    with open(dest, 'w') as f:
+        f.write(info)
+    os.chmod(dest, 0o644)
+}
+
+FILES:${PN} += "${QCOM_BOOT_INFO_DIR}"
 
 do_deploy() {
     install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -73,6 +73,7 @@ do_deploy() {
     find "${S}" -maxdepth 1 -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name 'qsahara_*.xml' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
     find "${S}" -maxdepth 1 -name '*.xz' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    install -m 0644 ${D}${QCOM_BOOT_INFO_DIR}/*/build-info.txt ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}/
 
 }
 addtask deploy before do_build after do_install


### PR DESCRIPTION
Qualcomm boot firmware releases embed their build information (meta build ID,
per-image build IDs such as TZ, BOOT, AOP) as the zip archive comment, which
is discarded today, leaving images with no record of the boot firmware
release they ship alongside.

Extract it (with a generated recipe/version/archive header, header-only when
no comment is available) into
`/usr/share/qcom-boot-firmware/<board>/build-info.txt` in the recipes'
previously-empty main package. Board machines install their own board's
package via `QCOM_BOOT_FIRMWARE`. The file is also deployed next to
the boot binaries so the qcomflash bundle self-describes.

Can be used as a replacement for /usr/lib/firmware/qcom/qcs9100/Ver_Info.txt
that is available in QLI 1.x (produced by the meta build, which we don't build anymore
in QLI 2.x).