### PR TITLE
ci: bump LAVA_TEST_PLANS_REF to include fastrpc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
+  LAVA_TEST_PLANS_REF: "4459d2f66596473523d63a4bd9f34ff2974bd226"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.07.19"
 


### PR DESCRIPTION
## Summary

Update the CI test dependency references used by the GitHub Actions test workflow:

- Update `LAVA_TEST_PLANS_REF` from `a20c74e6827b87ca39dff33eff4769d860e7942c` to `4459d2f66596473523d63a4bd9f34ff2974bd226`

## Included updates
### lava-test-plans
- FastRPC validation in the pre-merge basic test plan for supported devices.
- Shikra EVK test and test-plan exclusions for reported issues.
- Removal of the obsolete QDL `overlay_path` deployment setting.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>