### PR TITLE
ci/performance: enable root-only initramfs udev trigger

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -4,3 +4,4 @@ header:
 local_conf_header:
   cmdline-perf: |
     KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"
+    KERNEL_CMDLINE_EXTRA:append = "${@' initramfs.udev-root-only=1' if d.getVar('INITRAMFS_IMAGE') == 'initramfs-rootfs-image' else ''}"


### PR DESCRIPTION
## Summary

Follow up on #1839 by reducing unnecessary udev processing in `initramfs-rootfs-image`.

The initramfs udev module currently replays add events for the complete device tree and waits for all resulting events. The regular rootfs initramfs only needs the root block device before mounting the real root filesystem, while the remaining devices will be enumerated again after switching to systemd.

Add an opt-in `initramfs.udev-root-only=1` kernel parameter that triggers udev only for the root partition. Enable it through `ci/performance.yml` for `initramfs-rootfs-image`.

## Implementation

For supported root specifications, the initramfs extracts the corresponding kernel uevent property:

- `PARTLABEL=<label>` is matched using `PARTNAME=<label>`;
- `PARTUUID=<uuid>` is matched using `PARTUUID=<uuid>`.

A dry-run is performed first because `udevadm trigger` succeeds even when no device matches. The targeted trigger is used only when the root partition can be identified unambiguously.

## Scope and fallback

This is narrower than the original proposal in #1839, which triggered the entire block subsystem.
The implementation preserves the existing full coldplug path when:

- the root specification is unsupported;
- the root partition is not yet present in sysfs;
- no device matches the requested partition;
- the targeted udev trigger fails.

This also addresses the USB and network-root concerns raised in #1839:

- a USB-backed root is optimized only when its root partition is already discoverable; otherwise full coldplug is used;
- network roots do not match the partition selectors and retain full coldplug.

No udev rules are removed. Without the kernel parameter, the existing OE-Core behavior remains unchanged.

The parameter is enabled only by the meta-qcom performance configuration when `INITRAMFS_IMAGE` is `initramfs-rootfs-image`. SOTA and other specialized initramfs images retain their existing device discovery behavior.

## Performance results

Test configuration:

- Machine: `rb3gen2-core-kit` (RB3 Gen 2)
- KAS configuration:
  `ci/rb3gen2-core-kit.yml:ci/qcom-distro.yml:ci/performance.yml`
- Initramfs: `initramfs-rootfs-image`
- Root specification: `PARTLABEL=rootfs`
- Number of measured boots: 3 (full coldplug), 2 (root-only)

| Measurement | Full coldplug | Root-only trigger | Improvement |
|---|---:|---:|---:|
| initramfs udev trigger + settle | 981.6 ms | 109.8 ms | −871.8 ms |
| `Run /init` → rootfs `EXT4-fs mounted` | 1340.2 ms | 441.1 ms | −899.1 ms |