### PR TITLE
ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 9a25b3e72051a30794e147564028487a598ce82d
+            commit: d51c6e87a10c7c75a692ca86b71af9a818026ecb
         bitbake:
-            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
+            commit: 7a3cb0d55e3698e883a9ff8491febc9d155482ca
         meta-arm:
-            commit: 28606c721503b70e8343968731a24260cfe985bc
+            commit: 170b7e2a1c264c2f6360b4e298b16542196601af
         meta-openembedded:
-            commit: dc2335d63b279a4ee344a8b7034a61319f242101
+            commit: ea7c7c4f2e21a0aadb53d1691de6d5a85dc11a8e
         meta-virtualization:
-            commit: 099a08b2c251431c45f56de1fec9057609dfdbda
+            commit: cbaa5b92b046a13585105713166c886cdfd5de33
         meta-audioreach:
-            commit: b5a382aba0e5b1e4cfbd9f36256ea46e0d4cf002
+            commit: 714f81ba2467b16e494eaf61e3eb642e8cef5e02
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: a081e4927cba1dc98e887bd8aaaa5580de7a72c5
+            commit: 94ef61e04dc69e02874bdb8645de615d56f0b6a2
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
-            commit: ded70edc0937d939596a0c38b737af59afbb5e7b
+            commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:
-            commit: 60e38e2015f19058b467febd044f49bf70c4528f
+            commit: 3511d6c9669683fc232211eb72e1549d6db6e660

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -11,3 +11,28 @@ local_conf_header:
     FIRMWARE_COMPRESSION:qcom-armv8a = "zst"
     # Workaround needed due https://bugzilla.yoctoproject.org/show_bug.cgi?id=16010
     PACKAGE_CLASSES = "package_rpm"
+  parallelism: |
+    # Size the builds for the runners' memory, not just for their core count.
+    #
+    # The runners have 16 vCPUs and 64 GB of RAM, so bitbake defaults to 16
+    # concurrent tasks each running make with -j 16. That is fine while the
+    # sstate cache is warm, but the cache goes cold every month and every
+    # base.lock update moves the toolchain forward, and then the tail of an
+    # image build has clang, clang-native, gcc, rust, opencv, onnxruntime and
+    # the kernel compiling at the same time. Up to 256 compiler processes do
+    # not fit in memory: the build is killed and the job fails with exit code
+    # 137, and because the same recipes are killed on every attempt they never
+    # reach sstate, so re-running never helps.
+    #
+    # Leave the number of tasks alone, as warm builds are dominated by setscene
+    # and packaging tasks and lowering it would slow every build down, and cap
+    # the compilation instead: at most 8 recipes compiling at once with 4 make
+    # jobs each, which keeps the 16 cores busy while bounding the build to 32
+    # compiler processes (2 GB each). do_compile is restored from sstate on a
+    # warm build, so neither setting costs anything there.
+    #
+    # PARALLEL_MAKE is in BB_BASEHASH_IGNORE_VARS and number_threads is in
+    # BB_SIGNATURE_EXCLUDE_FLAGS, so none of this changes task signatures.
+    BB_PRESSURE_MAX_MEMORY = "15000"
+    PARALLEL_MAKE = "-j 4"
+    do_compile[number_threads] = "8"

--- a/recipes-bsp/u-boot/u-boot-scr-qcom-fit.bb
+++ b/recipes-bsp/u-boot/u-boot-scr-qcom-fit.bb
@@ -8,9 +8,11 @@ SRC_URI = "file://boot.cmd.in"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-inherit kernel-arch deploy nopackages
+inherit deploy nopackages
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+UBOOT_ARCH = "${@oe.kernel.map_uboot_arch(d)}"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
Relevant changes for oe-core:
- d51c6e87a util-linux: inherit upstream-stable-release-point
- 074a5d9c4 ruby: Avoid build-time race condition
- 83d11b337 glibc: remove obsolete parallelism flag handling
- 9a3d36299 python3-numpy: remove HOSTTOOLS_DIR from __config__.py
- ff04ad509 systemd: add missing libucontext dependency on musl
- d59efa6c6 libarchive: backport fix for archive_read_append_filter test failure
- 07e95ed78 devtool: upgrade: diff git-log-style changelogs by commit hash
- 8caf730a1 devtool: upgrade: call subprocess.run() instead of bb.process.run()
- 933981a21 sdk: fold SDK_TOOLCHAIN_LANGS into SDK_FEATURES
- dd78ed32c bitbake.conf: add an SDK_FEATURES lever
- 9db020032 rust: patch uninative loader into snapshot's self-contained lld
- c5d07f676 clang: Exclude intermittently failing ldm-merge-struct.ll test on arm64
- 8d1d548e3 image_types: make oe_mkext234fs reproducible
- da08c6466 opkg: fix sha256 support
- 896803e42 ruby: scrub build host paths from rbconfig.rb for nativesdk too
- a391725f0 python_pyo3: Ensure native recipe sstate signatures work
- 2a7e73e90 mirrors: Disable YP mirrors on autobuilder
- 119a3356a classes/sign*: Drop obsolete inherit
- 7dc971dd5 bitbake.conf: Add timeout to HOSTTOOLS
- 5c0342681 rpm-sequoia-crypto-policy: upgrade to latest revision
- 949a25a10 python3-setuptools: upgrade 83.0.0 -> 84.0.0
- 88b02bcdc libmicrohttpd: upgrade 1.0.9 -> 1.0.10
- 1ff21abe7 libffi: upgrade 3.7.1 -> 3.8.0
- 4b470d9b6 python3-vcs-versioning: upgrade 2.2.3 -> 2.2.4
- f793ed650 python3-uv-build: upgrade 0.12.1 -> 0.12.3
- 0dfb0a81c python3-pycairo: upgrade 1.29.0 -> 1.29.1
- db3188e08 diffoscope: upgrade 326 -> 327
- 27a491718 fontconfig: upgrade 2.18.2 -> 2.18.3
- f7a59cdfe repo: upgrade 2.65 -> 2.66
- 21a2c91cc p11-kit: upgrade 0.26.4 -> 0.26.5
- 26490a3eb oe-selftest: devtool ide-sdk: wait for lldb-server readiness
- 335670e4c devtool: ide-sdk: wait for lldb-server readiness
- 24905528a linux-yocto/6.18: update to v6.18.43
- 197a98e6e linux-yocto/6.18: update to v6.18.41
- 20f678d82 python_pep517.bbclass: export _PYTHON_HOST_PLATFORM to match our cross-compile target
- 6aebec069 ptest.bbclass: strip build machine triplet from installed ptest Makefiles
- 1295627cb libtool: strip build system triplet from installed libtool script
- 51e41574c python3-pip: use the flit_core build backend
- 17ccbc491 python3-iniconfig: use the setuptools build backend
- 1e7832f8d python3: upgrade 3.14.6 -> 3.14.7
- 40f22582f lttng-tools: inherit upstream-stable-release-point
- 22cd1dfc8 sqlite3: inherit upstream-stable-release-point
- 97caf8a11 libgcrypt: inherit upstream-stable-release-point
- e61767b8d binutils: inherit upstream-stable-release-point
- 75f78c58c openssl: inherit upstream-stable-release-point
- e49e23720 python3: inherit upstream-stable-release-point
- a9fd7975e libxml2: inherit upstream-stable-release-point
- 9bb9763c4 spdx_common: In get_patched_src() ensure kernel dir name to be ${BP}
- aa44a0f0e spdx_common: modify UNPACKDIR instead of WORKDIR in get_patched_src()
- e0bf8e7c5 spdx_common: simplify get_patched_src() implementation
- 99e39feb4 glibc: remove redundant tzselect interpreter option patch
- 288dd18ab glibc: update patch status
- 92c867aea cross-localedef-native: prune patch list
- 2222a4fb0 binutils: set status for CVE-2026-4647
- 864344f31 dhcpcd: upgrade 10.3.2 -> 10.5.0
- 4d813e569 nfs-utils: upgrade 2.9.1 -> 2.9.2
- 42ab7ba5a systemd: upgrade to 261.2
- 623e042b2 python3-packaging: upgrade 26.2 -> 26.3
- dbeef84da oe-selftest: devtool ide-sdk: add test for ide=none LLDB/clang support
- e6290f191 oe-selftest: devtool ide-sdk: add clang/LLDB test
- 6f6eb45f9 meta-selftest: refactor cpp examples into .inc files and add clang variants
- 0b156a99d devtool: ide-sdk: add LLDB support for ide=none (clang toolchain)
- e81d8971f devtool: ide-sdk add LLDB support for clang toolchain
- 292a35234 devtool: ide-sdk: wait for gdbserver port before returning
- 446011f56 devtool: ide-sdk debugger back-end abstraction
- 5b28d4172 oe-selftest: devtool ide-sdk: add real debug coverage for meson+code
- cf5587673 oe-selftest: devtool ide-sdk: cover breakpoints in exe, header and library
- a48a731a2 devtool: deploy-target: fix run strip under pseudo
- e093539cc python3-pip: upgrade 26.1.2 -> 26.2
- dbcbfd686 gn: upgrade to latest revision
- 9a68d3f4b pseudo: 1.9.10 -> 1.9.11
- 2b228490b kernel-yocto-rust: Add clang toolchain check for riscv64
- e4a360ee1 libsndfile1: patch CVE-2026-37555
- 4359d85f9 libarchive: set status for CVE-2026-4424
- 74a2bc6bd gnutls: set status for CVE-2026-42010 and CVE-2026-42010
- 6383e239f tiff: set status for CVE-2026-4775
- 1f875a76c ppp: set status for CVE-2020-15704
- 0353d7f67 openssl: set status for CVE-2015-3216
- d202f8cb5 pulseaudio: set status for CVE-2020-15710 and CVE-2020-16123
- 1ac5e0796 ovmf: set status of CVE-2017-5731 and CVE-2019-14584
- 85babe370 glibc: set status for CVE-2011-0536 and CVE-2025-0577
- 9d9b944d3 gnutls: set status for CVE-2023-0361
- 65f08d040 glibc: remove obsolete EGLIBC_KNOWN_INTERPRETER_NAMES
- a9ffb0db9 glibc: remove obsolete KSHELL assignment
- 2662cedbd glibc: remove obsolete shell override for make-syscalls.sh
- 090ef6fc6 oeqa/selftest/glibc: remove obsolete parallel make assignment
- ed4467f06 libgit2: set correct homepage URL
- 35eead39b libssh2: fix CVE-2026-66032
- a7e3c8fdf xwininfo: use meson to build
- 00c4d8af6 xvinfo: use meson to build
- 80e85c2a7 xmodmap: use meson to build
- a64ac03a6 classes/cargo: merge oe_cargo_build into cargo_do_compile
- 907928377 classes/cargo-c: pass flags via CARGO_BUILD_FLAGS
- 89e986af9 classes/cargo-c: remove CARGO_C_BUILD/CARGO_C_INSTALL variables
- 8130050e1 classes/cargo_c: inherit cargo_common
- 32c44d640 rust: clean up dependencies
- d539873ea classes/cargo: consolidate dependencies
- f654865f7 classes/cargo: move general assignments to cargo_common.bbclass
- 6a5a31690 classes/rust: remove unused variables
- b20adb82e classes/cargo_common: move PKG_CONFIG_ALLOW_CROSS export to oe_cargo_fix_env
- becb88b02 libjpeg-turbo: use system zlib instead of bundled copy
- 1c9d4bb85 devtool: upgrade: ignore changelogs from 3rd party
- 8e7a293bc oeqa/selftest/clang: Add oe-selftests for Clang/LLVM/LLD test suites
- c926c4f9f clang: Enable cmake flags for llvm, clang, lld tests
- 789d416dd clang-tools-extra: disable tests
- ab72d4c6b classes/setuptools_build_meta: clean the build directory in configure
- 2f87a30bf bluez5: restrict delta=0 RSSI to proximity filters
- b6ab21c7e xserver-xorg: set status for CVE-2026-55999 and CVE-2026-56000
- 8e2a45871 qemuboot: Correct task dependency tree
- b98fe7d44 coreutils: Backport a fix recommended by upstream
- fadb9e5e7 devtool: ide-sdk: fix meson compile_commands.json
- 85beec6dc devtool: ide-sdk: fix $@ overwritten by set in install_and_deploy script
- 6b89edfe4 devtool: ide-sdk: fix duplicate -p flag in _target_ssh_args
- 3cec69c26 oe-selftest: devtool: use stat for reading user/group names in ide-sdk tests
- 90e0db919 libtool: 2.5.4 -> 2.6.2
- 3c354d335 libunwind: Disable cxx exceptions for riscv64
- 45d9c3f1a libva-utils: 2.23.0 -> 2.24.0
- bc9018a7f libva: update 2.23.0 -> 2.24.1
- a0488f2e1 Revert "python3-websockets: enable ptest"
- 07f2da2dc python3-websockets: upgrade 16.1.1 -> 17.0.1
- 9948c11dd python3-uv-build: upgrade 0.11.32 -> 0.12.1
- 6d73a99d3 python3-cryptography{-vectors}: upgrade 49.0.0 -> 50.0.0
- 5928cf198 sbom-cve-check-update-nvd-native: update to version 2026.08.03-000011
- 25e68deb8 sbom-cve-check-update-cvelist-native: update to version 2026-08-03
- 7feb4e30b python3-sbom-cve-check: update to version 1.3.3
- 1a1d2e417 ruby: upgrade 4.0.5 -> 4.0.6
- 8b0db9576 mesa-demos: upgrade to latest revision
- 1cec2f875 python3-cffi: upgrade 2.1.0 -> 2.1.1
- 7ef4fd816 python3-numpy: Upgrade 2.5.0 -> 2.5.1
- d021c3a43 python3-pyproject-metadata: upgrade 0.11.0 -> 0.12.1
- bf3344af1 libadwaita: upgrade 1.9.2 -> 1.9.3
- 7dce54c9b xmodmap: Upgrade 1.0.11 -> 1.0.12
- 8b1c297ce xwininfo: Upgrade 1.1.6 -> 1.1.7
- ebd0fe7ab xvinfo: Upgrade 1.1.5 -> 1.1.6
- 9325384d0 taglib: upgrade 2.3 -> 2.3.1
- 9ed24f38e libgit2: upgrade 1.9.4 -> 1.9.6
- 96872cac8 bitbake.conf: remove 'extend_recipe_sysroot' from BB_HASHEXCLUDE_COMMON
- a60d5ead5 gcc-runtime: add 'extend_recipe_sysroot' to 'vardepsexclude'
- 62a68ba88 wic-tool: add 'extend_recipe_sysroot' to 'vardepsexclude'
- 06fe4b113 native: add 'extend_recipe_sysroot' to 'vardepsexclude'
- d84e8a427 cross: add 'extend_recipe_sysroot' to 'vardepsexclude'
- 4d3729d5b staging: add 'extend_recipe_sysroot' to 'vardepsexclude'
- 8b15cdc4b u-boot: always use GCC to build
- 2faf8e366 barebox-tools: upgrade 2026.06.1 -> 2026.07.0
- fca850002 libssh2: fix CVE-2026-66035
- 33352fb49 libssh2: fix CVE-2026-66034
- 2ae378e81 libssh2: fix CVE-2026-66033
- de0bf5771 useradd.bbclass: drop groupmems from sysroot setup
- 58f5400f1 shadow: upgrade 4.19.4 -> 4.20.0
- 89a5224cf sanity: Drop unreachable code
- 4efa61f04 sanity: Move code to lib/oe
- b1bb2b1b3 lib/oe/lsb: Merge distro_identifier functions
- 4e04ca516 utils: Move functions from utils.bbclass to utils.py
- a817ad48c utils: Drop explode_deps function
- 350281188 kernel-devicetree: Add missing function prefixes
- 06057ac24 linux-kernel-base: Fold remainder into kernel-arch and drop
- de9fbb577 linux-yocto-fitimage: Drop obsolete dependency on linux-kernel-base
- 635f85b7b kernel-arch: Move ARCH usage into target classes
- 09dbddd3c toolchain-scripts: Drop usage of kernel-arch
- cfc53f0e1 linux-libc-headers: Drop kernel-arch and set ARCH directly
- bdcd04bbc kernel-arch: Drop UBOOT_ARCH
- 3fd96d924 linux-yocto-fitimage: Set UBOOT_ARCH
- d45e6d99c kernel-fit-image: Swap UBOOT_ARCH for oe.kernel.map_uboot_arch call
- 2a40cf1d1 image_types/kernel-uimage: Swap UBOOT_ARCH for oe.kernel.map_uboot_arch call
- dabb172b4 lib/oe/kernel: Simplify map_uboot_arch
- 7705c78e4 barebox: Separate out from kernel-arch.bbclass
- 8fb547084 u-boot: Separate out from kernel-arch.bbclass
- 43de755c2 kernel-arch: Don't export UBOOT_ARCH
- 4619ebef9 kernel-arch: Simplify KERNEL_ARCH variable usage
- 5719be21c kernel-arch: Move kernel and uboot arch functions to lib/oe/kernel.py
- 376a05ef5 kernel-yocto: Simplify code for cleanliness and slight performance
- 945f3faa4 lib/oe/kernel: Move python functions from linux-kernel-base to library code
- b1db993c1 linux-kernel-base: Delete unused function
- 9a82c0ce9 sstatesig: Use kernel.bbclass instead of linux-kernel-base.bbclass
- 73ae055e5 perl: inherit upstream-stable-release-point
- 4300d9a70 git: inherit upstream-stable-release-point
- e336ba1ed xz: inherit upstream-stable-release-point
- 63948049e dbus: inherit upstream-stable-release-point
- 8de7017a3 glib-2.0: inherit upstream-stable-release-point
- c19dd5b2a systemd: inherit upstream-stable-release-point
- 11a058252 image_types_wic: gate syslinux-native on the target, not the build host
- e15d4865f wic: add runtime dependencies on the tools it invokes
- 5eb21599c image_types_wic, wic-tools: drop the obsolete cross-binutils dependency
- 78c9b1025 wic-tools: drop the target bootloader firmware
- d934735fc glibc: set status for CVE-2026-5435
- 8042c1652 rust-target-config: set MIPS ABI in the target JSON
- 1eb39abee qemu: allow building for mingw targets
- 59509be41 opkg: enable sha256 checksum verification by default
- 3f50b047b package_manager/ipk: skip checksums for unsigned local feeds
- cf5b6271a kernel-devsrc: Install sources required for BPF host tools
- a927fccc4 ncurses: stop moving terminfo files from /usr/share to /etc
- c025102d8 python3-uv-build: add missing build dependencies
- 5b4a898fc python3-maturin: add missing build dependencies
- d20e3170f cargo-c: add missing build dependencies
- 85b7ca631 cargo: add missing build dependencies
- 6634a9a27 cargo: centralise anti-vendoring environment variables
- 7624b1e16 classes/rust-common: don't export rustlibdir
- f3f78bffd patchtest: detect leftover AUH changelog-truncation notice
- 62a73618e oeqa/selftest/wic: drop redundant per-test PATH overrides
- fc6e38918 oeqa/selftest/wic: drop dead COREBASE/scripts wic lookup
- 050e92402 mpg123: upgrade 1.33.6 -> 1.33.7
- cb7e61a0a python3-pyopenssl: upgrade 26.3.0 -> 26.4.0
- 156d0375e pkgconf: upgrade 3.0.4 -> 3.0.5
- 3a29f6b3d libpsl: upgrade 0.23.0 -> 0.23.1
- 827ca9f8a libmicrohttpd: upgrade 1.0.8 -> 1.0.9
- 2beeeeace at-spi2-core: upgrade 2.60.5 -> 2.60.6
- 880bbbef3 ttyrun: upgrade 2.43.0 -> 2.44.0
- 05c4a67bc spirv-llvm-translator: upgrade 22.1.2 -> 22.1.5
- b4a89bebb msmtp: upgrade 1.8.32 -> 1.8.34
- b41a2e4c4 hwdata: upgrade 0.409 -> 0.410
- 1825f108a harfbuzz: upgrade 14.2.1 -> 14.3.0
- 3f05e701d cmake: upgrade 4.4.1 -> 4.4.2
- d44fcc043 glib-2.0: upgrade 2.88.2 -> 2.88.3
- 669928006 nghttp2: upgrade 1.69.0 -> 1.70.0
- bb1bb66b7 mesa: upgrade 26.1.5 -> 26.1.6
- 365611ae2 python3-markdown: upgrade 3.10.2 -> 3.10.3
- 7ecef871d diffoscope: upgrade 325 -> 326
- 8aed1d9b1 gstreamer1.0*: upgrade 1.28.4 -> 1.28.5
- e23059318 busybox: patch CVE-2026-38754
- 175bc4a39 gstreamer1.0: set status for CVE-2026-5056
- 84ca70839 util-linux: set status for CVE-2026-3184
- 6c99410bd bison: patch CVE-2026-56389
- 3406d8563 diffutils: patch CVE-2026-53910
- 120492d2e coreutils: fix CVE-2026-56392
- 3a18c6f1d coreutils: fix CVE-2026-56391
- 3ff9dac5f oeqa/selftest/sstatetests: Work around the removal of i686 uninative
- 8fb0fe3ef yocto-uninative: Update to 5.2 for glibc 2.44
- 6a91494f2 selftest: uboot: remove duplicated KVM presence test
- 015711096 libgit: Add nativesdk variant
- 9b69f9659 vulkan*: Upgrade 1.4.250.1 -> 1.4.357.0
- de0d17da7 spirv-tools: Upgrade 1.4.350.1 -> 1.4.357.0
- 5570906b1 vulkan-headers: upgrade 1.4.350.1 -> 1.4.357.0
- 25447315e vulkan-volk: upgrade 1.4.350.1 -> 1.4.357.0
- 38a29334a spirv-headers: upgrade 1.4.350.1 -> 1.4.357.0
- 73d4a7996 glslang: upgrade 1.4.350.1 -> 1.4.357.0
- 9949e7d68 classes/cmake: use correct CMAKE_SYSTEM_NAME for baremetal arm target
- 1086a56d2 systemd: enable coredump by default
- 338798379 oeqa/selftest/devtool: cover srcrev update mode guessing for gitsm://
- 9307c3763 devtool: standard: guess srcrev update mode for gitsm:// recipes too
- f17e8750c libzip: import recipe from meta-oe
- 51250c46f python3-vcs-versioning: upgrade 2.2.2 -> 2.2.3
- dd90e7de8 libmicrohttpd: upgrade 1.0.6 -> 1.0.8
- 86c79c6a0 appstream: update 1.1.3 -> 1.1.5
- e2db3079f cmake: upgrade 4.4.0 -> 4.4.1
- 12cf41490 libarchive: fix ptest failure when built without crypto library
- de9afb193 libarchive: upgrade 3.8.8 -> 3.8.9
- 3c2bb7bce cpan_build: disable .packlist and html doc
- 443f8c62a tcf-agent: Pass sbindir to make install to handle binmerge
- 2bf18f990 bootchart2: Handle bindir == sbindir
- 036700267 perl: upgrade 5.42.2 -> 5.44.0
- 4232a7cc5 pseudo: Update to 1.9.10
- f6f07f9e8 binutils: Upgrade to 2.47 release
- 9c348d83b glibc: Upgrade to 2.44 release
- dd1ce4091 m4: Fix ptest hang with glibc 2.44
- b0734d8d3 rust: Move do_update_snapshot to rust-source
- 395fe1613 rust: refactor source handling into a shared work-shared recipe
- d69cab542 rust: Fix reproducibility with shared source trees
- 3271add7c libarchive: ptest: run tests from tmpfs to avoid inode overflow failures
- 5266eed8f gawk: skip randtest in ptest suite
- a30cd6999 patch: Fix CVE-2026-56288
- 48c1aa91e patch: Fix CVE-2026-56289
- a28b6b43b python3: fix CVE-2026-4360
- 8a77e7384 wget: fix CVE-2026-58472
- f55c2f60d wget: fix CVE-2026-58469
- 61bd26565 sstate.bbclass: Correct a typo in an error message
- a67f44021 spdx30_tasks: fix missing SPDX runtime dependencies
- 3a2b032f0 gstreamer1.0-plugins-rs: add new package
- 9aee6b23a ncurses: put symlinks to basic terminfo files in ncurses-terminfo-base package
- 5213ca88c sstate: Update unpack touch code to be consistent
- cc07895f9 sstate: Update mtime/atime for sig/siginfo files in sstate_checkhashes()
- 1b8d8c25e volatile-binds: order systemd-timesyncd after /var/lib
- d6e5f99e2 scripts: contrib: Fix reserved typo in improve_kernel_cve_report script
- 9638671c5 wget: enable libpsl in target builds
- 7c8f24923 curl: enable libpsl in target builds
- 6a16ae584 curl: add option for libpsl, the Public Suffix List library
- 523fcc489 libpsl: Fix meson configure failure when docs are enabled
- 34161aa32 libpsl: Do not embed the build path in suffixes_dafsa.h
- 3e8b28c49 libpsl: convert to meson build system
- f7a5eb6c1 libpsl: upgrade 0.22.0 -> 0.23.0
- 969693a4f bzip2: add bzip2:bzip2 to CVE_PRODUCT
- 695462fcf libinput: set status for CVE-2026-35094
- 5b2046bf7 connman: remove connection_manager from CVE_PRODUCTS
- aabb2b44e openssh: set status for CVE-2026-55653
- a486abd48 python3-pip: set CVE_PRODUCT
- cec486b0f mpg123: fix lack of NEON usage on aarch64
- a3d381bd8 libgit2: remove library paths from installed .cmake
- 5ea5eaf7c libxpm: Fix license
- a2963198c glib-networking: clarify the LICENSE
- 0aa251fa2 python3-certifi: enable ptest
- 7d7fa3a3c python3-certifi: upgrade 2026.6.17 -> 2026.7.22
- b0f0ffc46 ethtool: upgrade 7.0 -> 7.1
- edd5b3cfe pkgconf: upgrade 3.0.3 -> 3.0.4
- 741b539cc lighttpd: upgrade 1.4.84 -> 1.4.85
- 29d28c343 vim: upgrade 9.2.0782 9.2.0843
- 9277bbca1 bind: upgrade 9.20.24 -> 9.20.26
- ac6c2f23a stress-ng: upgrade 0.21.03 -> 0.21.04
- 65fe86c68 btrfs-tools: upgrade 7.0 -> 7.1
- a4e1b7dde libseccomp: upgrade 2.6.0 -> 2.6.1
- b8a78502b python3-setuptools-scm: upgrade 10.2.0 -> 10.2.1
- 9a2af09e2 python3-uv-build: upgrade 0.11.29 -> 0.11.32
- 1a4fc629b python3-uritools: upgrade 6.1.2 -> 6.1.3
- 06855d795 gnupg: upgrade 2.5.20 -> 2.5.21
- ab13a5919 dropbear: upgrade 2026.92 -> 2026.94
- 301a3fbea sqlite3: upgrade 3.53.3 -> 3.53.4
- e2ae55aed qemu/qemu-system-native: Upgrade 11.0.2 -> 11.0.3
- 93dcb56b1 python3-cython: upgrade 3.2.8 -> 3.2.9
- 327279fb8 python3-pytz: upgrade 2026.2 -> 2026.3
- 22a05965f libical: upgrade 4.0.3 -> 4.0.4
- d557b97ae u-boot: Update git server and branch

Relevant changes for bitbake:
- 7a3cb0d asyncrpc: Close the client event loop when the client is collected
- f7608f3 tests/fetch: restore and extend npm/npmsw test coverage
- 9e45e00 fetch/{npm,npmsw}: re-enable fetchers now that checksums come from SRC_URI
- e82cedc doc/bitbake-user-manual-environment-setup: cross-reference DL_DIR
- a1ad1da doc/bitbake-user-manual-ref-variables: fix reference to non-existing entry in variable glossary
- 5c01237 doc/bitbake-user-manual-environment-setup: fix reference to non-existing term
- 4c4734a doc: bitbake-user-manual-metadata: fix missing whitespace around '=' operator
- 81d18e1 doc: bitbake-user-manual-metadata.rst: fix append example
- c870f5b data: Return a list from exported_vars()
- d188633 parse/ast: improve error handling for invalid task dependencies
- ee61431 tests/setup: Drop win32 platform reference
- 5f8b9ab hashserv: server: Fix formatting
- c251833 Update typing_extensions with vendoring
- 3fde2c1 vendor.txt: Add typing_extensions for bs4
- 0f9c58e Update vendorized modules
- afca4a4 Add vendor patches
- 70b54fd Add pyproject.toml and vendor.txt for vendoring
- 585c43c fetch2: Ensure UntrustedUrl.msg is str
- e8d531c bitbake-setup: use bb.fetch for buildtools installer download
- 02c4ff2 bitbake-setup: handle dict entries in oe-fragments
- bfb34c6 gitignore: Ignore temporary staging directory
- d4411ce pypi: Add packaging documentation for developers
- 6b51b93 pypi: Add PyPI packaging for bitbake-setup
- 0e39aca bitbake-setup: Add version option
- b8f9060 doc/README: update broken yocto-docs cgit URL

Relevant changes for meta-arm:
- 170b7e2a arm/fvps: change COMPATIBLE_HOST default
- 683f9680 arm/fvps: remove unused files
- c9b21728 arm/fvp: Update FVP Base to 11.32.19
- b08f6b0b arm-bsp/docs:corstone1000: Clarify secure debug setup
- fba4a2d1 arm-bsp/docs:corstone1000/a320: Use kas shell for capsule generation
- fd397fc7 arm-bsp/firmware-image-juno: remove dependency on Linaro firmware archive
- 5ff5de46 arm-bsp/external-system: update HOMEPAGE
- 3f9a9c8c arm-bsp/corstone1000-external-sys-tests: update HOMEPAGE
- 16766176 arm/fvp-common: refresh LICENSE statement
- 0bb23ce4 arm-toolchain/external-arm-toolchain: fix license
- dc8a847b recipes: port LICENSE to SPDX

Relevant changes for meta-openembedded:
- ea7c7c4f2 bpftool: start builds from a clean build dir
- fe79e6e5c python3-pikepdf: Enable tests
- 38e02a08e python3-python-xmp-toolkit: Add recipe
- bb4e8aa7f exempi: Add recipe
- 9e93c5307 uutils-coreutils: upgrade 0.9.0 -> 0.10.0
- 289638e6f python3-dateparser: upgrade 1.4.1 -> 1.4.2
- 2d1932c68 python3-argcomplete: upgrade 3.7.0 -> 3.7.1
- 53a4733f3 python3-h2: upgrade 4.4.0 -> 4.4.1
- 3a85fbdfe thin-provisioning-tools: upgrade 1.3.1 -> 1.3.3
- b44581a6c flatcc: upgrade 0.6.2 -> 0.6.3
- f0d0a6b62 cjose: Fix build with clang by initializing decoded buffer lengths
- d1384edec net-snmp: Backport upstream fix for explicit library linking
- 69e2b9e79 rrdtool: Fix do_configure by exporting ABS_TOP_BUILDDIR for perl bindings
- 3379535ca python3-pikepdf: Upgrade 10.10.0 -> 10.11.0
- 37bd33a8e libp11: backport fix for missing p11_ver.h in installed headers
- 5f6c8eb03 apitrace: Fix link failure with BMI2 capable tunes
- 8622d004b apitrace: upgrade 13.0 -> 14.0
- cb626ab10 ntpsec: upgrade 1.2.4 -> 1.2.5
- 767404c10 ngtcp2: upgrade 1.22.1 -> 1.25.0
- 26459d01a babeld: upgrade 1.13.1 -> 1.14
- 41c2b1e76 gst-instruments: upgrade 0.3.1 -> 0.3.2
- 149877fbd libdvdcss: upgrade 1.5.0 -> 1.6.0
- fde276485 gvfs: upgrade 1.60.1 -> 1.60.2
- 2a4ad6ae3 gdm: upgrade 50.1 -> 50.2
- 57623e3e5 libsdl-image: Fix link failure by pointing OBJC at CC
- dc537b280 python3-cucumber-tag-expressions: Use python_uv_build and drop the uv_build upper bound
- 451fe283c python3-bleak: Use python_uv_build and drop the uv_build upper bound
- f4cb6efc4 hdf5: Fix CVE-2026-26197
- 12ff50b94 hdf5: Fix CVE-2026-26199
- ac621838b unbound: upgrade 1.25.2 -> 1.26.0
- dd876a79a python3-pandas: upgrade 3.0.4 -> 3.0.5
- 5c609751a python3-django: upgrade 6.0.7 -> 6.0.8
- 8a4bf31e7 python3-django: upgrade 5.2.16 -> 5.2.17
- 0135c3278 python3-pika: Enable tests
- 356b5ef58 python3-pytest-timeout: Add runtime dependencies
- cd774fc8b vboxguestdrivers: Provide target kernel version
- 376d0ae06 thunar: upgrade 4.21.5 -> 4.21.6
- be6485ff6 python3-linux-procfs: upgrade 0.7.3 -> 0.7.4
- b3167db26 python3-fastjsonschema: upgrade 2.21.1 -> 2.22.1
- 97e440ea4 python3-charset-normalizer: upgrade 3.4.7 -> 3.4.9
- 9828a6cb2 python3-cachetools: upgrade 7.1.4 -> 7.1.7
- f3768d323 librav1e: Drop need for a dependency on libgit2
- fd8610403 zchunk: upgrade 1.5.3 -> 1.5.4
- b523a0b23 tuna: upgrade 0.20 -> 0.21
- 765332530 sip: upgrade 6.15.3 -> 6.16.0
- 9043fbe51 python3-virtualenv: upgrade 21.7.0 -> 21.7.1
- 974fbff81 python3-twine: upgrade 6.2.0 -> 7.0.0
- 83c617538 python3-ruff: upgrade 0.16.0 -> 0.16.1
- 653f1db55 python3-redis: upgrade 8.0.1 -> 8.1.0
- e7bec6a27 python3-rarfile: upgrade 4.4 -> 4.5
- 3c07f6f71 python3-nltk: upgrade 3.10.0 -> 3.10.1
- 6694b1852 python3-ipython: upgrade 9.15.0 -> 9.16.0
- 670cba439 python3-inline-snapshot: upgrade 0.35.2 -> 0.35.3
- e163f885e python3-huey: upgrade 3.3.0 -> 3.3.2
- e3fa88e4d python3-fsspec: upgrade 2026.6.0 -> 2026.7.0
- eb9f0da75 python3-filelock: upgrade 3.32.0 -> 3.32.2
- a849d0ce1 python3-engineio: upgrade 4.13.3 -> 4.13.4
- 4f3db1bff python3-dunamai: upgrade 1.26.1 -> 1.26.2
- 7c4622018 python3-discovery: upgrade 1.5.0 -> 1.5.1
- 9a1825c9e python3-coverage: upgrade 7.15.2 -> 7.15.3
- 7a05c3434 python3-cbor2: upgrade 6.1.3 -> 6.1.4
- 9df4452b2 python3-bitarray: upgrade 3.9.2 -> 3.10.0
- 0afbcce19 python3-aiohue: upgrade 4.8.1 -> 4.9.0
- 690984ae6 pegtl: upgrade 4.0.0 -> 4.0.1
- 76510c505 pax-utils: upgrade 1.3.10 -> 1.3.11
- c347929f8 nanomsg: upgrade 1.2.2 -> 1.2.4
- c8222ee30 nano: upgrade 9.1 -> 9.2
- a8cad54c2 libtevent: upgrade 0.17.1 -> 0.17.2
- 7b9a3f2ea libtalloc: upgrade 2.4.4 -> 2.5.0
- 2a6a932c4 ctags: upgrade 6.2.20260726.0 -> 6.2.20260802.0
- 703672013 uim: Fix uim-module-manager segfault from a GC'd require filename
- 787d1b73e meta-oe: repair broken recipe upstream version-checks
- 0a60011ec nushell: add missing build dependencies
- bb46aa517 lsd: add missing libgit2 build dependency
- 62fc6e612 librice: allow building bundled rice-proto
- 7bf5f6c24 librav1e: add missing libgit2 build dependency
- 0b8685f28 image_types_sparse: switch ext* conversion to ext2simg_android
- 01d621f63 android-tools: export libsparse/libbase/liblog headers and libs to sysroot
- 048bdb8a0 e2fsprogs-ext4sparse-native: compiles ext2simg.c using android-tools-native
- 91ca86a43 crash-cross-canadian: Use oe.utils.all_multilib_tune_values in the docs
- 4fc7c36af kernel-selftest: Drop obsolete dependency on linux-kernel-base
- 058e0c139 liburing: upgrade 2.12 -> 2.15
- 6034c7f14 crow: upgrade 1.3.2 -> 1.3.3
- 568b12546 cjose: upgrade 0.6.2.4 -> 0.6.2.7
- f5d901b67 libplacebo: upgrade 7.351.0 -> 7.360.1
- 9c4278ac1 gtkwave: upgrade 3.3.127 -> 3.3.128
- c683fc0fd drm-info: upgrade 2.9.0 -> 2.10.0
- de818f92b meta-oe: Drop obsolete INC_PR declarations
- 8ac0b70c8 rsyslog: add autoconf-archive-native to DEPENDS
- a3d22fd0f libcec: update 7.1.1 -> 8.1.3
- 6a5660078 python3-typer: add missing runtime dependencies
- 45e6e4749 python3-rich: add missing runtime dependencies
- 29ce577f1 parallel: upgrade 20260522 -> 20260722
- fa3fde557 libwmf: upgrade 0.2.13 -> 0.2.15
- 53bb5b9f4 mbpoll: upgrade 1.5.2 -> 1.5.4
- d9d2f6652 jsoncpp: upgrade 1.9.7 -> 1.9.8
- 89b5f39b2 unbound: upgrade 1.25.1 -> 1.25.2
- 7462895d7 tcpreplay: upgrade 4.5.2 -> 4.5.5
- 0f1dbf97a usbredir: upgrade 0.14.0 -> 0.15.0
- 274e45f28 sngrep: upgrade 1.8.3 -> 1.8.4
- ef5488c9c cifs-utils: upgrade 7.4 -> 7.7
- 43f5daaa2 nghttp3: upgrade 1.15.0 -> 1.18.0
- 13ba198f5 ulogd2: upgrade 2.0.8 -> 2.0.9
- 34a4496d7 libmodule: update branch in the SRC_URI
- 2a1d19e80 openal-soft: include tag in the SRC_URI
- f2aad7144 liblc3: include tag in the SRC_URI
- 117829f76 libmatroska: include tag in the SRC_URI
- 2ba9dd882 python3-mpv: propagate ffmpeg's commercial LICENSE_FLAGS
- 5f4e021e2 mpv: propagate ffmpeg's commercial LICENSE_FLAGS
- e8ad55a0e turbostat: Use oe.kernel.get_version_file
- 198ec7461 zabbix: Use oe.kernel.get_version_headers
- ba6048b0a fwupd: Only enable hsi on x86
- aad68a656 xdg-desktop-portal-wlr: upgrade 0.8.2 -> 0.8.4
- fffa3eab7 gerbera: upgrade 3.0.0 -> 3.2.1
- 70dfb6465 srt: upgrade 1.5.4 -> 1.5.6
- 87f2c3105 tinycompress: upgrade 1.2.13 -> 1.2.16
- f0c9cab9e openal-soft: upgrade 1.24.3 -> 1.25.2
- fdf95268f nv-codec-headers: upgrade 13.0.19.0 -> 13.1.15.0
- 7205920b8 fluidsynth: upgrade 2.5.3 -> 2.5.7
- 1f046fc34 python3-pillow-heif: upgrade 1.1.1 -> 1.5.0
- fa672e0f9 libdvdread: upgrade 7.0.1 -> 7.1.1
- 9a5c3f43f gupnp-tools: upgrade 0.12.2 -> 0.12.4
- 575122a4a gupnp: upgrade 1.6.9 -> 1.6.10
- 229235401 gssdp: upgrade 1.6.4 -> 1.6.6
- 4dcdd5cbf mpd: upgrade 0.24.9 -> 0.24.13
- 4b033d534 ncmpc: upgrade 0.49 -> 0.53
- 600204405 gst-shark: upgrade 0.8.1 -> 0.9.1
- 41619e7ac libsrtp: upgrade 2.7.0 -> 2.8.0
- d98bc9596 libupnp: upgrade 1.14.25 -> 1.14.31
- ed7427b8b liblc3: upgrade 1.0.4 -> 1.1.3
- ca912668d libavif: upgrade 1.4.1 -> 1.4.2
- 99ca84156 libde265: upgrade 1.0.18 -> 1.0.19
- 69d615b17 aom: upgrade 3.13.1 -> 3.14.1
- ce2a27d67 libmpdclient: upgrade 2.24 -> 2.26
- 0392f862a svt-av1: upgrade 4.1.0 -> 4.2.0
- 9c05bf41b libmodule: upgrade 5.0.1 -> 5.0.2
- 74ef26d0e libmatroska: upgrade 1.7.1 -> 1.7.2
- bf9ebecd0 libebml: upgrade 1.4.5 -> 1.4.7
- d2ac54a6d apache-websocket: update to latest master (0ee34c7 -> 18ad4ae)
- eb4d6ede5 webmin: upgrade 2.641 -> 2.653
- 53f762b75 netdata: upgrade 1.47.5 -> 2.10.4
- bc0502151 cockpit: upgrade 352 -> 364
- 1c1a63b2a fluidsynth: fix branch after recipe update
- f4f7c09de colord: set proper home-dir
- 9b10f27d0 rygel: upgrade 45.0 -> 45.2
- 48b523136 zenity: upgrade 4.1.99 -> 4.2.2
- d548ec8b1 gnome-panel: upgrade 3.47.1 -> 3.58.1
- 14274de9c appstream-glib: upgrade 0.8.3 -> 0.8.4
- 573a27715 gnome-console: upgrade 47.1 -> 50.0
- df1722391 gnome-bluetooth: upgrade 47.1 -> 47.2
- c07617f93 eog: upgrade 50.1 -> 50.2
- 918fc9d3c imagemagick: upgrade 7.1.28 -> 7.1.29
- ade08ee06 xmlrpc: fix Upstream-Status
- 9dc293d14 libhtml-tree-perl, libmodule-build-tiny-perl: Drop obsolete TMPDIR scrubbing
- 8c224de97 libsdl3: Fix build with cmake 4.4
- a884b55ac oprofile: Fix build with binutils 2.47
- bfe1438fd python3-fastapi: Upgrade 0.140.0 -> 0.141.1
- 2cf9295bf python3-annotated-doc: Upgrade 0.0.4 -> 0.0.5
- bdee39658 python3-unidiff: Upgrade 0.7.5 -> 1.0.0
- ba40fb6ba php: upgrade 8.5.8 -> 8.5.9
- 4103e94dc python3-pika: Upgrade 1.4.1 -> 1.4.2
- dedf599cc python3-wrapt: Upgrade 2.2.2 -> 2.3.0
- c80bfaad6 sdbus-c++-libsystemd: add .git to github repository url
- 3554f9b4f boinc-client: also add tag information
- 7b6e350c6 boinc-client: update to 8.2.15
- 53ffdf7bc python3-py7zr: Enable tests
- e3d88ee0a python3-pytest-httpserver: Add recipe
- aecd8432d exfatprogs: upgrade 1.4.1 -> 1.4.2
- 094e0b9fe xfstests: upgrade 2025.04.27 -> 2026.06.21
- 117bd160b nilfs-utils: upgrade v2.2.11 -> v2.3.1
- 7f897a5c1 yaffs2-utils: update to latest git (20221209 -> 20260629)
- a4b0ad095 zfs: upgrade 2.4.1 -> 2.4.3
- bf1d8cdac bats: upgrade 1.13.0 -> 1.14.0
- 43c1ac7c3 nodejs: upgrade 24.18.0 -> 24.18.1
- d47873c51 python3-pytokens: Extend to native and nativesdk
- 7e38d9fe8 python3-black: Extend to native and nativesdk
- 6ac6d8adb bcc: Stop baking the build directory into the ptest binaries
- 41f6014d1 python3-wxgtk4: Skip the pep517-backend QA check
- aa1707f90 python3-uefi-firmware: Switch to python_setuptools_build_meta
- fde067288 python3-canopen: Switch to python_setuptools_build_meta
- 4208cf107 python3-thrift: Switch to python_setuptools_build_meta
- 4c7ab4994 tmux: upgrade 3.6b -> 3.7
- bd5c50a4c tcsh: upgrade 6.24.12 -> 6.24.16
- 7d6962a3d redis: upgrade 8.8.0 -> 8.8.1
- 956f5fcfb gst-editing-services: upgrade 1.22.12 -> 1.28.4
- 1fe4273b9 cloc: upgrade 2.08 -> 2.10
- 7e4e63d27 zabbix: upgrade 7.0.27 -> 7.0.29
- 6340a9b20 fwupd: upgrade 2.0.19 -> 2.1.7
- c01375da4 rsyslog: upgrade 8.2604.0 -> 8.2606.0
- 592c858d0 ttf-tlwg: upgrade 0.6.1 -> 0.7.4
- 4a33c1ac0 cfengine-masterfiles: upgrade 3.27.1 -> 3.28.0
- ac1b55d4d cairomm-1.16: upgrade 1.18.1 -> 1.19.1
- 417e03231 xmlsec1: upgrade 1.3.11 -> 1.3.12
- a0c57b604 pv: upgrade 1.10.5 -> 1.11.0
- cc7d6a955 poppler: upgrade 26.06.0 -> 26.07.0
- 6e7e661c1 pcsc-lite: upgrade 2.5.0 -> 2.5.1
- 0880f3483 lcov: upgrade 2.4 -> 2.5
- 64385b0e3 ccid: upgrade 1.8.0 -> 1.8.2
- 686a6c92a atop: upgrade 2.12.1 -> 2.13.0
- f7fe727a1 fuse-archive: Fix build with libarchive where RPM is a format
- f9f40f5bb vboxguestdrivers: Upgrade to 7.2.14
- 7d30c1b74 python3-textparser: Enable tests
- ff28575a4 python3-pydantic: Enable test_docs.py
- 97dc08e35 python3-devtools: Add recipe
- 013a8e417 python3-pytest-examples: Add recipe
- 2b483e913 python3-ruff: Add recipe
- ed5c76bdd uutils-coreutils: Exclude from world unless it is the selected provider
- 05fdd161d python3-defusedxml: Add nativesdk to BBCLASSEXTEND
- 19d0dccbc tbb: Restrict libhwloc runtime dependency to target builds
- 583ba5347 uml-utilities: remove recipe
- 3a8eaec29 python3-google-auth: upgrade 2.56.0 -> 2.56.2
- d12c45974 python3-rarfile: upgrade 4.3 -> 4.4
- b5d19cac0 python3-soupsieve: upgrade 2.9 -> 2.9.1
- 7859fc7d8 python3-tox: upgrade 4.57.0 -> 4.58.0
- c0e91238e python3-tqdm: upgrade 4.69.0 -> 4.69.1
- aa4b5ae15 sg3-utils: upgrade 1.48 -> 1.49
- b7824ff65 python3-typeguard: upgrade 4.5.2 -> 4.6.0
- 28c5f6c28 python3-sh: upgrade 2.3.0 -> 2.4.0
- da6602102 tesseract: upgrade 5.5.2 -> 5.5.3
- 2a86f452a python3-h2: upgrade 4.3.0 -> 4.4.0
- 7f64ddad2 python3-huey: upgrade 3.2.1 -> 3.3.0
- e5640e059 python3-httpx2: upgrade 2.4.0 -> 2.9.1
- d7cab3970 python3-prompt-toolkit: upgrade 3.0.52 -> 3.0.53
- 5fcef7720 python3-pyproject-api: upgrade 1.10.1 -> 1.11.0
- 1cda98504 python3-pre-commit: upgrade 4.6.0 -> 4.6.1
- 1f6a49834 python3-greenlet: upgrade 3.5.3 -> 3.5.4
- a0184a866 python3-pytest-env: upgrade 1.6.0 -> 1.7.0
- 25e141006 python3-aiohttp: upgrade 3.14.1 -> 3.14.3
- e329d9f07 python3-faker: upgrade 40.35.0 -> 40.36.0
- 116fef98c python3-annotated-types: upgrade 0.7.0 -> 0.8.0
- d675a8ee4 python3-bitarray: upgrade 3.9.1 -> 3.9.2
- 5701eb286 python3-discovery: upgrade 1.4.4 -> 1.5.0
- 5e93c8864 python3-fastapi: upgrade 0.138.1 -> 0.140.0
- 4962b2af7 python3-gevent: upgrade 26.5.0 -> 26.7.0
- 54a61db01 python3-filelock: upgrade 3.31.1 -> 3.32.0
- 334fe216f hiawatha: upgrade 12.2 -> 12.3
- 3a987c645 ctags: upgrade 6.2.20260705.0 -> 6.2.20260726.0
- 2256bf7a5 dialog: upgrade 1.3-20260107 -> 1.3-20260721
- 07b9b543d gflags: upgrade 2.3.0 -> 2.3.1
- d2906ca31 imagemagick: upgrade 7.1.2-27 -> 7.1.2-28
- b226b53ca libosip2: upgrade 5.3.1 -> 5.3.2
- bf785563c libraqm: upgrade 0.10.5 -> 0.11.0
- 0af3dd4bb malcontent: update 1.13.1 -> 1.14.0
- ea93de06f libxmp: upgrade 4.7.1 -> 4.7.2
- d601c7c03 swagger-ui: upgrade 5.32.9 -> 5.32.11
- 28248b3a0 xrdp: upgrade 0.10.6 -> 0.10.6.1
- 40598b804 transmission: upgrade 4.1.1 -> 4.1.3
- 5bccca887 netplan: upgrade 1.2.1 -> 1.2.2
- d729bb139 libiec61850: upgrade 1.6.1 -> 1.6.2
- be7e0aa50 bluealsa: upgrade 4.3.0 -> 4.3.1
- bba60ac12 imx-cst: upgrade 3.4.1 -> 4.0.1
- 86f430b5b anthy: port to anthy-unicode 1.0.0.20260213
- 02a651096 gnome-terminal: replace deprecated GFDL-1.3 with GFDL-1.3-no-invariants-only
- c9b783f2e libiio: Move sysvinit script to libiio-iiod package
- 26c4d0bed python3-textparser: Upgrade 0.24.0 -> 0.26.2
- 04118c6eb python3-faker: Upgrade 40.31.0 -> 40.35.0
- 5950b7767 python3-virtualenv: Upgrade 21.6.1 -> 21.7.0
- 5500c1148 liboauth2: upgarde 2.2.0 -> 2.3.0
- 43a4e8dbd libp11: upgrade 0.4.18 -> 0.4.19
- 64a7f6443 jq: upgrade 1.8.1 -> 1.8.2
- ec1029f71 libusb-compat: upgrade 0.1.8 -> 0.1.9
- 250c286bc htop: upgrade 3.5.1 -> 3.5.2
- 019ec101f valkey: upgrade 9.1.0 -> 9.1.1
- 6fe25e39d simpleiot: upgrade 0.18.4 -> 0.18.5
- 0192e9313 cryptsetup: upgrade 2.8.6 -> 2.8.7
- 06bfa1bc3 gensio: upgrade 3.0.2 -> 3.0.3
- 44e1e5e95 iozone3: upgrade 508 -> 510
- 416abdb4e colord: upgrade 1.4.7 -> 1.4.8
- 11c12a623 iperf2: Fix compilation with --disable-ipv6
- 84d73eb5d xdotool: fix do_install failure due to missing pc.sh
- 45e1dde3d tomoyo-tools: Update HOMEPAGE
- 5ed31339c xkbprint: upgrade 1.0.7 -> 1.0.8
- cc23e1b25 xfsprogs: upgrade 7.0.1 -> 7.1.1
- df1628fe8 swagger-ui: upgrade 5.32.8 -> 5.32.9
- 86462a9d2 sexpect: upgrade 2.3.15 -> 2.4.0
- 232ce4768 python3-yarl: upgrade 1.24.2 -> 1.24.5
- c839cb4f4 python3-typer: upgrade 0.26.8 -> 0.27.0
- a3559b8dd python3-tqdm: upgrade 4.68.4 -> 4.69.0
- 3029ca99a python3-tox: upgrade 4.56.4 -> 4.57.0
- 625081775 python3-tomlkit: upgrade 0.15.0 -> 0.15.1
- 5c172c6c8 python3-soupsieve: upgrade 2.8.4 -> 2.9
- 5ff2c3e20 python3-rich-toolkit: upgrade 0.20.1 -> 0.20.3
- 696c0a756 python3-regex: upgrade 2026.7.10 -> 2026.7.19
- b3d5d14a0 python3-pybcj: upgrade 1.0.7 -> 1.0.8
- 00542fc3b python3-platformdirs: upgrade 4.10.0 -> 4.10.1
- 58053045a python3-jdatetime: upgrade 5.3.0 -> 6.0.1
- 6887dc53c python3-inline-snapshot: upgrade 0.34.2 -> 0.35.2
- aa7e9f63a python3-google-auth: upgrade 2.55.2 -> 2.56.0
- 8a39c0ff8 python3-filelock: upgrade 3.29.7 -> 3.31.1
- b25d6cb1d python3-faker: upgrade 40.28.1 -> 40.31.0
- 837a71bc0 python3-eventlet: upgrade 0.41.0 -> 0.41.1
- 674fa34a2 python3-coverage: upgrade 7.15.1 -> 7.15.2
- 7bb676414 python3-colorlog: upgrade 6.10.1 -> 6.11.0
- cbec79f68 python3-cmd2: upgrade 4.1.1 -> 4.1.2
- 635e95c9e python3-bumble: upgrade 0.0.232 -> 0.0.233
- a18e29275 python3-bitarray: upgrade 3.9.0 -> 3.9.1
- 5d4bf38da ntfs-3g-ntfsprogs: upgrade 2026.2.25 -> 2026.7.7
- 355272aa9 nss: upgrade 3.125 -> 3.126
- 842a0e3f5 nbdkit: upgrade 1.47.9 -> 1.48.0
- def0ad622 mcelog: upgrade 211 -> 212
- 9d62f313d libwacom: upgrade 2.19.0 -> 2.19.1
- d2f1f7bf8 libraw: upgrade 0.22.1 -> 0.22.2
- ccd0d2d3d libnet-dns-perl: upgrade 1.55 -> 1.56
- 11e34895a libdbi-perl: upgrade 1.650 -> 1.651
- f90025c6a libcppconnman: upgrade 1.0.0 -> 2.0.0
- 7ea8756b6 iscsi-initiator-utils: upgrade 2.1.11 -> 2.1.12
- 0733f720b freerdp3: upgrade 3.28.0 -> 3.30.0
- 4c56043a9 dash: upgrade 0.5.13.4 -> 0.5.13.5
- d19ffe745 sysdig: pin Curses to target sysroot so chisel uses LuaJIT lua.h

Relevant changes for meta-virtualization:
- cbaa5b92 qemuboot-xen-dtb: Fix task dependency
- e4aed393 docs: container-yocto-builder.md: clarify pexpect/ptyprocess rationale
- ec16c67c vcontainer-bbmask.inc: add python3-pexpect,-ptyprocess
- a4818b81 libvirt: remove unused 0001-messon.build-remove-build-path-information-to-avoid-.patch

Relevant changes for meta-audioreach:
- 32c3920 audioreach-graphmgr: srcrev bump b5587a7...a39867a
- 7d92c05 audioreach-kernel: srcrev bump 71324eb...9a003d1
- 1d2e43d Align PR workflow triggers and decouple LAVA execution
- 4f5ed30 audioreach-kernel: srcrev bump 6adfec6...71324eb
- 5daeff5 audioreach-graphservices: srcrev bump 8445aee...d1a26ff
- 86add7e audioreach-conf: srcrev bump 7143e0f...72504e0
- 0c83557 audioreach-graphservices: Add audio_dma_support PACKAGECONFIG entry

Relevant changes for meta-updater:
- 94ef61e wic: bootimg_sota_efi: fix oe.path import for wic >= 0.3.1

Relevant changes for meta-dpdk:
- 6a59b0c dpdk: fix builds for 32-bit ARM machines
- 74e7c18 dpdk/25.11: upgrade 25.11.1 -> 25.11.2

Relevant changes for meta-ai:
- 3511d6c build(deps): bump actions/stale from 10 to 11
- 1a97309 litert: add recipe for LiteRT 2.1.6 (Google AI Edge runtime)