### PR TITLE
recipes-graphics: backport A722 GPU support patch

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI:append:qcom = " \ 
     file://0001-freedreno-Add-chip-id-support-for-A830v1.patch \
+    file://0001-freedreno-Add-chip-support-for-a722.patch \
 "
 
 # Enable freedreno driver

--- a/recipes-graphics/mesa/mesa/0001-freedreno-Add-chip-support-for-a722.patch
+++ b/recipes-graphics/mesa/mesa/0001-freedreno-Add-chip-support-for-a722.patch
@@ -1,0 +1,49 @@
+From c2a322551a1941a69188b47fe849d468a6bcaa9d Mon Sep 17 00:00:00 2001
+From: Sahitya Kandru <kandru@qti.qualcomm.com>
+Date: Wed, 12 Aug 2026 14:27:43 +0530
+Subject: [PATCH] Add chip support for a722
+
+Basic support for a722 gpu added. Magic register values are taken from
+A730 as a starting baseline and will be refined once bringup traces are
+available.
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/803731f7ed4aa8e8265fe0aff08b85efb3f3c7e9?merge_request_iid=43101]
+
+Signed-off-by: Sahitya Kandru <kandru@qti.qualcomm.com>
+---
+ src/freedreno/common/freedreno_devices.py | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/freedreno/common/freedreno_devices.py b/src/freedreno/common/freedreno_devices.py
+index 87b41904132..ca78f2a0764 100644
+--- a/src/freedreno/common/freedreno_devices.py
++++ b/src/freedreno/common/freedreno_devices.py
+@@ -991,6 +991,25 @@ a740_raw_magic_regs = [
+         [A6XXRegs.REG_A6XX_UCHE_UNKNOWN_0E12, 0],
+     ]
+ 
++add_gpus([
++        GPUId(chip_id=0x43020100, name="Adreno (TM) 722"),
++        GPUId(chip_id=0xffff43020100, name="Adreno (TM) 722"),
++    ], A6xxGPUInfo(
++        CHIP.A7XX,
++        [a7xx_base, a7xx_gen1],
++        num_ccu = 1,
++        tile_align_w = 64,
++        tile_align_h = 16,
++        tile_max_w = 1024,
++        tile_max_h = 1024,
++        num_vsc_pipes = 32,
++        cs_shared_mem_size = 32 * 1024,
++        wave_granularity = 2,
++        fibers_per_sp = 128 * 2 * 16,
++        magic_regs = a730_magic_regs,
++        raw_magic_regs = a730_raw_magic_regs,
++    ))
++
+ add_gpus([
+         # These are named as Adreno730v3 or Adreno725v1.
+         GPUId(chip_id=0x07030002, name="FD725"),
+-- 
+2.43.0
+


### PR DESCRIPTION
Place an upstream Mesa patch under recipes-graphics/mesa/mesa/ and wire it into the build through mesa.bbappend. This enables Adreno A722 support in freedreno until oe-core's mesa version catches up.