### PR TITLE
u-boot-qcom: Update U-Boot revision from 2026.07 to 2026.10-rc1

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -5,9 +5,9 @@ DEPENDS += "bc-native dtc-native gnutls-native python3-pyelftools-native qtestsi
 
 COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
-PV = "2026.07+git"
+PV = "2026.07+2026.10-rc1+git"
 
-SRCREV = "e35d929347b19b66db87995724f0fd94be057ff4"
+SRCREV = "7588f73ca1883188e422eadc0f8620da446cecb1"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Bump SRCREV and PV to pull in the latest fixes and updates from the Qualcomm U-Boot qcom-next branch, now rebased onto upstream v2026.10-rc1.

Changelog:
- Rebase qcom-next onto upstream v2026.10-rc1
- Add Shikra SoC support (clk, pinctrl, QUSB2 PHY, dtsi, defconfig)
- Add QCS8300/monaco-evk support (clk, pinctrl, interconnect, dts)
- Add PSCI reboot-mode framework (driver, EDL DT nodes, tests, docs)
- Corrected FIT multi-DTB selection support
- Add SMEM memory-map parsing and uncached MMU mappings
- Misc config updates (debug UART, NVMEM bit-field tests)