### PR TITLE
tfa-optee-uboot-fit: add recipe to generate SPL FIT image

### DIFF
--- a/recipes-bsp/tfa-optee-uboot-fit/files/tfa-optee-uboot-spl.its
+++ b/recipes-bsp/tfa-optee-uboot-fit/files/tfa-optee-uboot-spl.its
@@ -1,0 +1,82 @@
+/dts-v1/;
+
+/ {
+	description = "TFA + OP-TEE + U-Boot FIT Image for SPL";
+	#address-cells = <1>;
+
+	images {
+
+		/* ------------------------ */
+		/*  BL31 (ARM Trusted FW)   */
+		/* ------------------------ */
+		tfa {
+			description = "ARM Trusted Firmware";
+			data = /incbin/("bl31.bin");
+			type = "firmware";
+			arch = "arm64";
+			os = "arm-trusted-firmware";
+			compression = "none";
+			load = <0x1c200000>;
+			entry = <0x1c200000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		/* ------------------------ */
+		/*  BL32 (OP-TEE)           */
+		/* ------------------------ */
+		optee {
+			description = "OP-TEE Secure OS";
+			data = /incbin/("tee-raw.bin");
+			type = "tee";
+			arch = "arm64";
+			os = "tee";
+			compression = "none";
+			load = <0x1c300000>;
+			entry = <0x1c300000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		/* ------------------------ */
+		/*  BL33 (U-Boot)           */
+		/* ------------------------ */
+		uboot {
+			description = "U-Boot Bootloader";
+			data = /incbin/("u-boot.bin");
+			type = "standalone";
+			arch = "arm64";
+			os = "u-boot";
+			compression = "none";
+			load = <0xaf400000>;
+			entry = <0xaf400000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+	};
+
+	/* ---------------------------- */
+	/*  CONFIGURATION               */
+	/* ---------------------------- */
+	configurations {
+		default = "config-1";
+
+		config-1 {
+			description = "TFA + OP-TEE + U-Boot Configuration";
+			firmware = "tfa";
+			loadables = "uboot", "optee";
+
+			signature-1 {
+				algo = "sha256,rsa2048";
+				key-name-hint = "dev";
+				sign-images = "firmware", "loadables";
+			};
+		};
+	};
+};

--- a/recipes-bsp/tfa-optee-uboot-fit/tfa-optee-uboot-fit-qcom.bb
+++ b/recipes-bsp/tfa-optee-uboot-fit/tfa-optee-uboot-fit-qcom.bb
@@ -1,0 +1,58 @@
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+SUMMARY = "Qualcomm FIT image (TFA + OP-TEE + U-Boot)"
+DESCRIPTION = "Assembles a Flattened Image Tree (ITB) from a manual ITS file that bundles \
+BL31 (TF-A), BL32 (OP-TEE) and BL33 (U-Boot) into a single FIT image."
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
+
+SRC_URI = "file://tfa-optee-uboot-spl.its"
+
+inherit deploy nopackages
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "u-boot-tools-native"
+
+S = "${UNPACKDIR}"
+
+do_compile[depends] += " \
+    trusted-firmware-a-qcom:do_deploy \
+    optee-os-qcom:do_deploy \
+    u-boot-qcom:do_deploy \
+"
+
+MKIMAGE ?= "${STAGING_BINDIR_NATIVE}/mkimage"
+
+FITIMAGE_STAGING_DIR = "${WORKDIR}/fitimage-staging"
+
+do_compile[cleandirs] = "${FITIMAGE_STAGING_DIR}"
+
+do_compile() {
+    install -m 0644 "${DEPLOY_DIR_IMAGE}/trusted-firmware-a-qcom/bl31.bin" \
+        "${FITIMAGE_STAGING_DIR}/bl31.bin"
+    install -m 0644 "${DEPLOY_DIR_IMAGE}/optee/tee-raw.bin" \
+        "${FITIMAGE_STAGING_DIR}/tee-raw.bin"
+    install -m 0644 "${DEPLOY_DIR_IMAGE}/u-boot.bin" \
+        "${FITIMAGE_STAGING_DIR}/u-boot.bin"
+    install -m 0644 "${S}/tfa-optee-uboot-spl.its" \
+        "${FITIMAGE_STAGING_DIR}/tfa-optee-uboot-spl.its"
+
+    cd "${FITIMAGE_STAGING_DIR}"
+    ${MKIMAGE} -f tfa-optee-uboot-spl.its tfa-optee-uboot-spl.itb
+}
+
+do_install[noexec] = "1"
+
+do_deploy() {
+    install -d "${DEPLOYDIR}"
+    install -m 0644 "${FITIMAGE_STAGING_DIR}/tfa-optee-uboot-spl.itb" \
+        "${DEPLOYDIR}/tfa-optee-uboot-spl.itb"
+    install -m 0644 "${FITIMAGE_STAGING_DIR}/tfa-optee-uboot-spl.its" \
+        "${DEPLOYDIR}/tfa-optee-uboot-spl.its"
+}
+
+addtask deploy after do_compile before do_build


### PR DESCRIPTION
Add a recipe to generate the SPL FIT image from the supplied ITS file as part of the build flow.