### PR TITLE
ort-qnn: Fix ORT header include path

### DIFF
--- a/dynamic-layers/ai/recipes-ml/onnxruntime-qnn/files/0002-QNN-EP-Fix-ORT-header-include-path-and-multiarch-li.patch
+++ b/dynamic-layers/ai/recipes-ml/onnxruntime-qnn/files/0002-QNN-EP-Fix-ORT-header-include-path-and-multiarch-li.patch
@@ -1,0 +1,64 @@
+From 3e022f533a36699ef5af89b1ed178e9cdf19be38 Mon Sep 17 00:00:00 2001
+From: qti-mbadnara <mbadnara@qti.qualcomm.com>
+Date: Tue, 11 Aug 2026 12:13:57 -0700
+Subject: [PATCH] [QNN EP] Fix ORT header include path and multiarch library
+ path for Debian builds (#706)
+
+Upstream-Status: Backport [3e022f533a36699ef5af89b1ed178e9cdf19be38]
+---
+ cmake/external/onnxruntime_prebuilt.cmake | 20 +++++++++++++++++---
+ qcom/linters/check_private_ort_headers.py |  2 ++
+ 2 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/external/onnxruntime_prebuilt.cmake b/cmake/external/onnxruntime_prebuilt.cmake
+index 5f0b4455f7d..945b4a646f2 100644
+--- a/cmake/external/onnxruntime_prebuilt.cmake
++++ b/cmake/external/onnxruntime_prebuilt.cmake
+@@ -5,8 +5,8 @@ include(ExternalProject)
+ 
+ set(ORT_SOURCE_DIR "${ort_core_SOURCE_DIR}")
+ set(ORT_BUILD_DIR "${ort_core_BINARY_DIR}")
+-message(STATUS "ORT_SOURCE_DIR: " ${ORT_SOURCE_DIR})
+-message(STATUS "ORT_BUILD_DIR: " ${ORT_BUILD_DIR})
++message(STATUS "ORT_SOURCE_DIR: ${ORT_SOURCE_DIR}")
++message(STATUS "ORT_BUILD_DIR: ${ORT_BUILD_DIR}")
+ 
+ # Determine the correct path for the test executable based on generator type
+ # Single-config generators (like Ninja) don't have config subdirectories
+@@ -23,8 +23,22 @@ endif()
+ if(onnxruntime_ORT_HOME)
+     message(STATUS "Use prebuilt from MS only at ${onnxruntime_ORT_HOME}. ORT Core will NOT be built from source")
+     set(ORT_BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping ORT_BUILD_COMMAND")
+-    set(ORT_PREBUILT_SOURCE "${onnxruntime_ORT_HOME}/lib")
++    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_LIBRARY_ARCHITECTURE AND
++       EXISTS "${onnxruntime_ORT_HOME}/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
++        set(ORT_PREBUILT_SOURCE "${onnxruntime_ORT_HOME}/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
++    else()
++        set(ORT_PREBUILT_SOURCE "${onnxruntime_ORT_HOME}/lib")
++    endif()
++    message(STATUS "ORT_PREBUILT_SOURCE: ${ORT_PREBUILT_SOURCE}")
+     set(ONNXRUNTIME_APPLICATION_INCLUDES "${onnxruntime_ORT_HOME}/include")
++    # Debian/Ubuntu system packages install ORT headers flat under include/onnxruntime/
++    # (e.g. include/onnxruntime/onnxruntime_cxx_api.h). Source files use bare
++    # "core/session/..." includes, so the include root must be include/onnxruntime/ rather
++    # than include/. QLI 2.0 and NuGet prebuilts have no such subdirectory; EXISTS is false.
++    if(EXISTS "${onnxruntime_ORT_HOME}/include/onnxruntime/onnxruntime_cxx_api.h")
++        set(ONNXRUNTIME_APPLICATION_INCLUDES "${onnxruntime_ORT_HOME}/include/onnxruntime")
++    endif()
++    message(STATUS "ONNXRUNTIME_APPLICATION_INCLUDES: ${ONNXRUNTIME_APPLICATION_INCLUDES}")
+ else()
+     # Use Python to run build.py
+     find_package(Python3 REQUIRED COMPONENTS Interpreter)
+diff --git a/qcom/linters/check_private_ort_headers.py b/qcom/linters/check_private_ort_headers.py
+index a7021a60341..450885fd177 100644
+--- a/qcom/linters/check_private_ort_headers.py
++++ b/qcom/linters/check_private_ort_headers.py
+@@ -109,6 +109,8 @@ def check_cc_file(path: str) -> list[dict]:
+     {
+         # onnxruntime_ORT_HOME (prebuilt) branch
+         '"${onnxruntime_ORT_HOME}/include"',
++        # Debian/Ubuntu system-package layout: headers under include/onnxruntime/
++        '"${onnxruntime_ORT_HOME}/include/onnxruntime"',
+         # build-from-source branch
+         '"${ORT_SOURCE_DIR}/include/onnxruntime/core/session"',
+         '"${ORT_SOURCE_DIR}/include/onnxruntime/core/providers/cpu"',

--- a/dynamic-layers/ai/recipes-ml/onnxruntime-qnn/onnxruntime-qnn_2.4.0.bb
+++ b/dynamic-layers/ai/recipes-ml/onnxruntime-qnn/onnxruntime-qnn_2.4.0.bb
@@ -18,6 +18,7 @@ DEPENDS = " \
 SRC_URI = "git://github.com/onnxruntime/onnxruntime-qnn.git;protocol=https;nobranch=1;tag=v${PV};name=ort-qnn \
     git://github.com/dcleblanc/SafeInt.git;protocol=https;nobranch=1;name=safeint;tag=3.0.28;destsuffix=safeint \
     file://0001-cmake-Rename-pkg-config-output-to-libonnxruntime_pr.patch \
+    file://0002-QNN-EP-Fix-ORT-header-include-path-and-multiarch-li.patch \
 "
 
 SRCREV_FORMAT = "ort-qnn_safeint"
@@ -34,12 +35,6 @@ COMPATIBLE_MACHINE:aarch64 = "(.*)"
 # string literals embedded in the compiled libraries.
 CFLAGS:append   = " -ffile-prefix-map=${WORKDIR}=."
 CXXFLAGS:append = " -ffile-prefix-map=${WORKDIR}=."
-
-# onnxruntime headers are installed under usr/include/onnxruntime/ in the
-# sysroot, but the onnxruntime-qnn source includes them without that prefix
-# Add the subdirectory explicitly.
-CFLAGS:append   = " -I${STAGING_INCDIR}/onnxruntime"
-CXXFLAGS:append = " -I${STAGING_INCDIR}/onnxruntime"
 
 inherit cmake
 


### PR DESCRIPTION
Replace the CFLAGS/CXXFLAGS -I workaround for locating onnxruntime headers under usr/include/onnxruntime/ with an upstream commit that fixes the actual root cause in onnxruntime_prebuilt.cmake