### PR TITLE
camx-dlkm: import fixes for camera_kt driver

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm/0001-msm-camera-lrme-fix-context-leak-on-cam-server-crash.patch
+++ b/recipes-multimedia/camx/camx-dlkm/0001-msm-camera-lrme-fix-context-leak-on-cam-server-crash.patch
@@ -1,0 +1,51 @@
+From 23012375bfb1e9d8d5baf3096f5cc109336a90a0 Mon Sep 17 00:00:00 2001
+From: Jerry Bae <jbae@qti.qualcomm.com>
+Date: Sat, 8 Aug 2026 02:16:52 -0700
+Subject: [PATCH 1/2] msm: camera: lrme: fix context leak on cam-server crash
+
+__cam_lrme_ctx_release_dev_in_activated() returned early when
+stop_dev failed, skipping the cam_context_release_dev_to_hw() call.
+This leaves the LRME HW context slot in ACTIVATED state permanently.
+
+When cam-server crashes with in-flight requests, stop_dev fails
+because flush/sync operations encounter orphaned request state
+(session already torn down by cam_req_mgr_handle_core_shutdown()).
+Repeating the crash exhausts all 8 LRME HW slots, causing every
+subsequent cam-server start to fail until reboot.
+
+Fix: fall through to release_dev_to_hw even when stop_dev fails,
+matching the existing behavior of ICP (__cam_icp_release_dev_in_ready)
+and ISP (__cam_isp_ctx_release_dev_in_activated), which both continue
+to release the HW slot regardless of stop failure.
+
+Change-Id: If3543f280c7e4cfbb592318cb8f91aa566c853f0
+Signed-off-by: Jerry Bae <jbae@qti.qualcomm.com>
+Upstream-Status: Inappropriate [Yocto specific]
+---
+ camera_kt/drivers/cam_lrme/cam_lrme_context.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/camera_kt/drivers/cam_lrme/cam_lrme_context.c b/camera_kt/drivers/cam_lrme/cam_lrme_context.c
+index b2a35e9a7..cb06c9359 100644
+--- a/camera_kt/drivers/cam_lrme/cam_lrme_context.c
++++ b/camera_kt/drivers/cam_lrme/cam_lrme_context.c
+@@ -141,8 +141,14 @@ static int __cam_lrme_ctx_release_dev_in_activated(struct cam_context *ctx,
+ 
+ 	rc = __cam_lrme_ctx_stop_dev_in_activated(ctx, NULL);
+ 	if (rc) {
+-		CAM_ERR(CAM_LRME, "Failed to stop");
+-		return rc;
++		CAM_ERR(CAM_LRME,
++			"Failed to stop ctx %d (rc=%d), forcing hw release to avoid context leak",
++			ctx->ctx_id, rc);
++		/* Fall through: always release the HW slot even if stop fails.
++		 * When cam-server crashes with in-flight requests, stop_dev fails
++		 * because flush/sync operations encounter orphaned request state.
++		 * Skipping release_dev_to_hw here permanently leaks the LRME HW
++		 * context slot, exhausting all 8 slots after 4 crash cycles. */
+ 	}
+ 
+ 	rc = cam_context_release_dev_to_hw(ctx, cmd);
+-- 
+2.34.1
+

--- a/recipes-multimedia/camx/camx-dlkm/0002-msm-camera-lrme-fix-LRME-HW-context-leak-on-cam-serv.patch
+++ b/recipes-multimedia/camx/camx-dlkm/0002-msm-camera-lrme-fix-LRME-HW-context-leak-on-cam-serv.patch
@@ -1,0 +1,73 @@
+From 1ab59c2aa13fe11e64258ef24bde6a580ce8c14c Mon Sep 17 00:00:00 2001
+From: Jerry Bae <jbae@qti.qualcomm.com>
+Date: Sat, 8 Aug 2026 17:05:31 -0700
+Subject: [PATCH 2/2] msm: camera: lrme: fix LRME HW context leak on cam-server
+ crash
+
+Two bugs conspire to leak LRME HW contexts when cam-server crashes:
+
+1. cam_lrme_dev_close_internal (cam_lrme_dev.c):
+   CRM calls cam_node_shutdown via sd_handler exactly once, but
+   cam-server opens the LRME subdev multiple times (once per context
+   acquisition). open_cnt never reaches 0 from a single CRM-driven
+   call, so cam_node_shutdown is silently skipped and all contexts
+   remain ACTIVATED, exhausting all 8 (CAM_CTX_MAX) slots after
+   repeated crash cycles.
+
+   Fix: detect cam_req_mgr_is_shutdown() and force cam_node_shutdown
+   unconditionally, resetting open_cnt to 0.
+
+2. __cam_lrme_ctx_release_dev_in_activated (cam_lrme_context.c):
+   The function returned early when stop_dev failed, skipping
+   release_dev_to_hw entirely. When cam-server crashes with in-flight
+   requests, stop_dev fails because the session was already torn down
+   by cam_req_mgr_handle_core_shutdown(). The HW slot was never freed.
+
+   Fix: fall through to release_dev_to_hw even when stop_dev fails,
+   matching the existing behavior of ICP (__cam_icp_release_dev_in_ready)
+   and ISP (__cam_isp_ctx_release_dev_in_activated).
+
+Change-Id: I05a57cdc94c9753a8ab791a0223b9b0a5f547eea
+Signed-off-by: Jerry Bae <jbae@qti.qualcomm.com>
+Upstream-Status: Inappropriate [Yocto specific]
+---
+ camera_kt/drivers/cam_lrme/cam_lrme_dev.c | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/camera_kt/drivers/cam_lrme/cam_lrme_dev.c b/camera_kt/drivers/cam_lrme/cam_lrme_dev.c
+index 243f682ae..cf84b10c2 100644
+--- a/camera_kt/drivers/cam_lrme/cam_lrme_dev.c
++++ b/camera_kt/drivers/cam_lrme/cam_lrme_dev.c
+@@ -105,8 +105,28 @@ static int cam_lrme_dev_close_internal(struct v4l2_subdev *sd,
+ 		goto end;
+ 	}
+ 
+-	if (lrme_dev->open_cnt == 0)
++	/*
++	 * During a system-wide shutdown (process crash), CRM calls
++	 * cam_node_shutdown exactly once via sd_handler, but cam-server may
++	 * have opened the LRME subdev multiple times (once per context
++	 * acquisition). open_cnt therefore never reaches 0 from the single
++	 * CRM-driven call, so cam_node_shutdown would be silently skipped and
++	 * all LRME HW contexts remain ACTIVATED, exhausting all 8 (CAM_CTX_MAX)
++	 * slots after repeated crash cycles.
++	 *
++	 * Fix: when CRM is in shutdown state, call cam_node_shutdown
++	 * unconditionally and reset open_cnt to 0 so subsequent stale close
++	 * calls from the same cleanup pass are no-ops.
++	 */
++	if (cam_req_mgr_is_shutdown()) {
++		CAM_WARN(CAM_LRME,
++			"CRM shutdown: forcing node shutdown (open_cnt was %d)",
++			lrme_dev->open_cnt + 1);
++		lrme_dev->open_cnt = 0;
+ 		cam_node_shutdown(node);
++	} else if (lrme_dev->open_cnt == 0) {
++		cam_node_shutdown(node);
++	}
+ 
+ end:
+ 	mutex_unlock(&lrme_dev->lock);
+-- 
+2.34.1
+

--- a/recipes-multimedia/camx/camx-dlkm_1.0.5.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.5.bb
@@ -9,6 +9,11 @@ SRC_URI = " \
 
 SRCREV = "0f16924ff6a7f9bb56a7e958016da2ed8a174f2f"
 
+SRC_URI += " \
+    file://0001-msm-camera-lrme-fix-context-leak-on-cam-server-crash.patch \
+    file://0002-msm-camera-lrme-fix-LRME-HW-context-leak-on-cam-serv.patch \
+"
+
 inherit module
 
 MAKE_TARGETS = "modules"


### PR DESCRIPTION
Changes Included in this PR.

- Fix LRME HW context leak on cam-server crash.
- Fix context leak on cam-server crash.

This PR is temporary and not intended for merge.
It has been raised solely for sharing the proposed fixes with the customer for review and
validation purposes.