### PR TITLE
kgsl-dlkm: Update v1.0.10 ->  v1.0.11

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.11.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.11.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "35c8f193149983c38709a7713c72af7c6b7876af"
+SRCREV = "72383caaef29830f77c5314945cddcd293d817f2"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.11 brings below fixes:

- Gate apb_pclk lookups behind CONFIG_QCOM_KGSL_QDSS_STM.
- Use kthread_run_worker() to immediately run kthreads.
- Reject mmap from processes with a different mm

 Signed-off-by: Sumant Gupta <sumagupt@qti.qualcomm.com>