### PR TITLE
github/workflows: extract kas-container from the image 

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
+  KAS_CONTAINER: ${{ github.workspace }}/kas-container
   KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
 
 jobs:
@@ -41,8 +42,6 @@ jobs:
 
       - name: Setting up kas-container
         run: |
-          KAS_CONTAINER=$GITHUB_WORKSPACE/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           docker create --name kas ${KAS_CONTAINER_IMAGE}
           docker cp kas:/usr/local/bin/kas-container $KAS_CONTAINER
           LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
@@ -134,8 +133,6 @@ jobs:
 
       - name: Setting up kas-container
         run: |
-          KAS_CONTAINER=$GITHUB_WORKSPACE/kas-container
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
           chmod +x $KAS_CONTAINER
 
       - name: Setup cache variables (used by oe-selftest)

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -43,9 +43,12 @@ jobs:
         run: |
           KAS_CONTAINER=$GITHUB_WORKSPACE/kas-container
           echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
+          docker create --name kas ${KAS_CONTAINER_IMAGE}
+          docker cp kas:/usr/local/bin/kas-container $KAS_CONTAINER
           LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
-          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
-          chmod +x ${KAS_CONTAINER}
+          if ! grep -q "KAS_CONTAINER_SCRIPT_VERSION=\"${LATEST}\"" $KAS_CONTAINER ; then
+            echo "Version "${LATEST}" of kas is available, please update "KAS_CONTAINER_IMAGE: $KAS_CONTAINER_IMAGE""
+          fi
 
       - name: Run kas lock
         run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   CACHE_DIR: /efs/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
 
 jobs:
   kas-setup:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -41,6 +41,7 @@ on:
 
 env:
   KAS_CLONE_DEPTH: 1
+  KAS_CONTAINER: ${{ github.workspace }}/kas-container
   KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
 
 jobs:
@@ -61,12 +62,7 @@ jobs:
       - name: Setting up kas-container
         shell: bash
         run: |
-          KAS_CONTAINER=$GITHUB_WORKSPACE/kas-container
           chmod +x $KAS_CONTAINER
-          if [ -c /dev/kvm ]; then
-            KAS_CONTAINER="$KAS_CONTAINER --kvm"
-          fi
-          echo "KAS_CONTAINER=$KAS_CONTAINER" >> $GITHUB_ENV
 
       - name: Setup build variables
         shell: bash
@@ -123,6 +119,9 @@ jobs:
         if:  inputs.target
         shell: bash
         run: |
+          if [ -c /dev/kvm ]; then
+            KAS_CONTAINER="$KAS_CONTAINER --kvm"
+          fi
           $KAS_CONTAINER build ${KAS_YAMLS}
 
       - name: Kas build images (buildstats)

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -41,6 +41,7 @@ on:
 
 env:
   KAS_CLONE_DEPTH: 1
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
 
 jobs:
   reusable_compile_job:


### PR DESCRIPTION
In kas version 5.5, kas-container was included and distributed with the image.
