### PR TITLE
Gunyah boot support: el2gh compatibles and VendorDtbOverlays pre-seeding

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -338,6 +338,30 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          - machine: iq-615-evk
+            distro:
+                name: qcom-distro-gunyah
+                yamlfile: ':ci/qcom-distro-gunyah.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: iq-8275-evk
+            distro:
+                name: qcom-distro-gunyah
+                yamlfile: ':ci/qcom-distro-gunyah.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          - machine: iq-9075-evk
+            distro:
+                name: qcom-distro-gunyah
+                yamlfile: ':ci/qcom-distro-gunyah.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           - machine: rb3gen2-core-kit
             distro:
                 name: qcom-distro-kvm

--- a/ci/qcom-distro-gunyah.yml
+++ b/ci/qcom-distro-gunyah.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+local_conf_header:
+  gunyah: |
+        MACHINE_FEATURES:remove = "kvm"

--- a/classes/efi-volatile-vars.bbclass
+++ b/classes/efi-volatile-vars.bbclass
@@ -1,0 +1,31 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Pre-seed VolatileVars.bin, an EBBR-style UEFI variable persistence file,
+# into an EFI System Partition image so variables like VendorDtbOverlays
+# are available from first boot instead of waiting for firmware-side
+# generation.
+#
+
+# Empty by default; set to the desired overlay list for machines that need
+# VolatileVars.bin pre-seeded (see lib/qcom/efi_volatile_vars.py).
+QCOM_VENDOR_DTB_OVERLAYS ?= ""
+
+python do_qcom_vendor_dtb_overlays() {
+    dtboverlays = d.getVar('QCOM_VENDOR_DTB_OVERLAYS') or ""
+    if not dtboverlays:
+        return
+
+    import os
+    from qcom.efi_volatile_vars import build_vendor_dtb_volatile_vars
+
+    data = build_vendor_dtb_volatile_vars(dtboverlays)
+
+    out_dir = d.getVar('IMAGE_ROOTFS') + (d.getVar('ESPFOLDER') or '')
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, 'VolatileVars.bin'), 'wb') as f:
+        f.write(data)
+}
+addtask qcom_vendor_dtb_overlays after do_rootfs before do_image
+do_qcom_vendor_dtb_overlays[vardeps] += "QCOM_VENDOR_DTB_OVERLAYS"

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -14,180 +14,21 @@
 #
 # <compatible-encoded> is the DT compatible string with every comma replaced
 # by an underscore (BitBake flag names cannot contain commas).
+#
+# Add entries for combinations whose overlays are available only in
+# LINUX_QCOM_KERNEL_DEVICETREE. Move these to fit-dtb-compatible.inc once
+# the overlays are available in linux-yocto.
 
 require conf/machine/include/fit-dtb-compatible.inc
+
+# ---------- glymur ----------
+FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
+FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"
 
 # ---------- hamoa  ----------
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx hamoa-staging"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-el2kvm] = "hamoa-iot-evk hamoa-evk-camx x1-el2 hamoa-camx-el2"
-
-# ---------- purwa -----------
-FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2"
-
-# ---------- lemans ----------
-
-# Add entries for combinations whose overlays are available only in
-# LINUX_QCOM_KERNEL_DEVICETREE. Move these to fit-dtb-compatible.inc once
-# the overlays are available in linux-yocto.
-
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging lemans-el2 lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-staging] = \
-    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
-    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
-    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx] = \
-    "lemans-evk lemans-evk-camx lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx-staging] = \
-    "lemans-evk lemans-evk-camx lemans-staging lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
-    "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
-    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging lemans-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-emmc] = \
-    "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging-emmc] = \
-    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging lemans-evk-emmc"
-
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh-staging] = \
-    "qcs9100-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam] = \
-    "qcs9100-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
-    "qcs9100-ride lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
-    "qcs9100-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
-    "qcs9100-ride sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2gh-staging] = \
-    "qcs9100-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0] = \
-    "qcs9100-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
-    "qcs9100-ride-r3 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
-    "qcs9100-ride-r3 sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
-    "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
-
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-staging] = \
-    "sa8775p-ride lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam] = \
-    "sa8775p-ride lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
-    "sa8775p-ride lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-camx] = \
-    "sa8775p-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2gh-staging] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
-    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-staging] = \
-    "sa8775p-ride-r3 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0] = \
-    "sa8775p-ride-r3 lemans-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
-    "sa8775p-ride-r3 lemans-el2 lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx-staging] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
-    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
-
-# ---------- monaco ----------
-
-# Add entries for combinations whose overlays are available only in
-# LINUX_QCOM_KERNEL_DEVICETREE. Move these to fit-dtb-compatible.inc once
-# the overlays are available in linux-yocto.
-
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-emmc] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging-emmc] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging-emmc] = \
-    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx] = "monaco-evk monaco-evk-camx monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-emmc] = "monaco-evk monaco-evk-camx monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging] = \
-    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging-emmc] = \
-    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-emmc] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
-    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging-emmc] = \
-    "monaco-evk monaco-evk-camx monaco-staging monaco-el2 monaco-camx-el2 monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0-emmc] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1-emmc] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-emmc] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
-    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-sd-card"
-FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging-emmc] = \
-    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-emmc"
-
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride monaco-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = \
-    "qcs8300-ride monaco-el2 monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx] = "qcs8300-ride qcs8300-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx-staging] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
-    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
-
-# ---------- talos ----------
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2gh-staging] = \
-    "qcs615-ride talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = \
-    "qcs615-ride talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
-    "qcs615-ride talos-el2 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging talos-evk-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
-    "talos-evk talos-evk-camx talos-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = \
-    "talos-evk talos-evk-camx talos-el2"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx-staging] = \
-    "talos-evk talos-evk-camx talos-el2 talos-staging"
-# Compatible string "qcom,talos-evk-lvds-auo,g133han01-staging" encodes as
-# "qcom_talos-evk-lvds-auo_g133han01-staging" (both commas become underscores).
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2gh-staging] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
-FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
-    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
 
 # ---------- kodiak ----------
 FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"
@@ -244,6 +85,173 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine-camx kodiak-staging"
-# ---------- glymur ----------
-FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
-FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"
+
+# ---------- lemans ----------
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-el2 lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging lemans-el2 lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-camx-staging] = \
+    "lemans-evk lemans-evk-camx lemans-el2 lemans-camx-el2 lemans-staging lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-emmc] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging-emmc] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging lemans-evk-emmc"
+
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam] = \
+    "qcs9100-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-staging] = \
+    "qcs9100-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx] = \
+    "qcs9100-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-camx-staging] = \
+    "qcs9100-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0] = \
+    "qcs9100-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-staging] = \
+    "qcs9100-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-camx-staging] = \
+    "qcs9100-ride-r3 sa8775p-ride-camx lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam] = \
+    "sa8775p-ride lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-staging] = \
+    "sa8775p-ride lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0] = \
+    "sa8775p-ride-r3 lemans-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-staging] = \
+    "sa8775p-ride-r3 lemans-el2 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
+
+# ---- lemans gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-staging] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx] = \
+    "lemans-evk lemans-evk-camx lemans-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx-staging] = \
+    "lemans-evk lemans-evk-camx lemans-staging lemans-evk-sd-card"
+
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh-staging] = \
+    "qcs9100-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2gh-staging] = \
+    "qcs9100-ride-r3 lemans-staging"
+
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-staging] = \
+    "sa8775p-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-camx] = \
+    "sa8775p-ride sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2gh-staging] = \
+    "sa8775p-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-staging] = \
+    "sa8775p-ride-r3 lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx-staging] = \
+    "sa8775p-ride-r3 sa8775p-ride-camx lemans-staging"
+
+# ---------- monaco ----------
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-staging-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging] = \
+    "monaco-evk monaco-evk-camx monaco-el2 monaco-camx-el2 monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-camx-staging-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-staging monaco-el2 monaco-camx-el2 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype0-emmc] = "monaco-ac-evk monaco-evk-camera-imx577 monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype1-emmc] = "monaco-ac-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-emmc] = "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging-emmc] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-emmc"
+
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride monaco-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = \
+    "qcs8300-ride monaco-el2 monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
+
+# ---- monaco gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx] = "monaco-evk monaco-evk-camx monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-emmc] = "monaco-evk monaco-evk-camx monaco-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging] = \
+    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging-emmc] = \
+    "monaco-evk monaco-evk-camx monaco-staging monaco-evk-emmc"
+
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx] = "qcs8300-ride qcs8300-ride-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx-staging] = \
+    "qcs8300-ride qcs8300-ride-camx monaco-staging"
+
+# ---------- purwa -----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2"
+
+# ---------- talos ----------
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = \
+    "qcs615-ride talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-staging] = \
+    "qcs615-ride talos-el2 talos-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging talos-evk-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
+    "talos-evk talos-evk-camx talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = \
+    "talos-evk talos-evk-camx talos-el2"
+
+# Compatible string "qcom,talos-evk-lvds-auo,g133han01-staging" encodes as
+# "qcom_talos-evk-lvds-auo_g133han01-staging" (both commas become underscores).
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
+
+# ---- talos gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2gh-staging] = \
+    "qcs615-ride talos-staging"
+
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
+    "talos-evk talos-evk-camera-imx577 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx-staging] = \
+    "talos-evk talos-evk-camx talos-el2 talos-staging"
+
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2gh-staging] = \
+    "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -139,6 +139,8 @@ FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-camx-staging] = \
     "sa8775p-ride-r3 sa8775p-ride-camx lemans-el2 lemans-camx-el2 lemans-staging"
 
 # ---- lemans gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh] = \
+    "lemans-evk lemans-evk-camera-csi1-imx577 lemans-evk-sd-card"
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-staging] = \
     "lemans-evk lemans-evk-camera-csi1-imx577 lemans-staging lemans-evk-sd-card"
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx] = \
@@ -146,17 +148,21 @@ FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx] = \
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-el2gh-camx-staging] = \
     "lemans-evk lemans-evk-camx lemans-staging lemans-evk-sd-card"
 
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh] = "qcs9100-ride"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh-staging] = \
     "qcs9100-ride lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2gh] = "qcs9100-ride-r3"
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-r2.0-el2gh-staging] = \
     "qcs9100-ride-r3 lemans-staging"
 
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh] = "sa8775p-ride"
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-staging] = \
     "sa8775p-ride lemans-staging"
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-camx] = \
     "sa8775p-ride sa8775p-ride-camx"
-FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-camx-el2gh-staging] = \
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-el2gh-camx-staging] = \
     "sa8775p-ride sa8775p-ride-camx lemans-staging"
+FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh] = "sa8775p-ride-r3"
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-staging] = \
     "sa8775p-ride-r3 lemans-staging"
 FIT_DTB_COMPATIBLE[qcom_sa8775p-qam-r2.0-el2gh-camx] = \
@@ -201,6 +207,10 @@ FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-camx-staging] = \
     "qcs8300-ride qcs8300-ride-camx monaco-el2 monaco-camx-el2 monaco-staging"
 
 # ---- monaco gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-evk-sd-card"
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-emmc] = \
+    "monaco-evk monaco-evk-camera-imx577 monaco-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging] = \
     "monaco-evk monaco-evk-camera-imx577 monaco-staging monaco-evk-sd-card"
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-staging-emmc] = \
@@ -212,6 +222,7 @@ FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging] = \
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-el2gh-camx-staging-emmc] = \
     "monaco-evk monaco-evk-camx monaco-staging monaco-evk-emmc"
 
+FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh] = "qcs8300-ride"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx] = "qcs8300-ride qcs8300-ride-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-camx-staging] = \
@@ -231,10 +242,10 @@ FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = \
     "talos-evk talos-evk-camera-imx577 talos-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-staging] = \
     "talos-evk talos-evk-camera-imx577 talos-el2 talos-staging talos-evk-staging"
-FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
-    "talos-evk talos-evk-camx talos-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx] = \
     "talos-evk talos-evk-camx talos-el2"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-camx-staging] = \
+    "talos-evk talos-evk-camx talos-el2 talos-staging"
 
 # Compatible string "qcom,talos-evk-lvds-auo,g133han01-staging" encodes as
 # "qcom_talos-evk-lvds-auo_g133han01-staging" (both commas become underscores).
@@ -244,14 +255,19 @@ FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
 
 # ---- talos gunyah (el2gh) ----
+FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2gh] = "qcs615-ride"
 FIT_DTB_COMPATIBLE[qcom_qcs615-adp-el2gh-staging] = \
     "qcs615-ride talos-staging"
 
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh] = \
+    "talos-evk talos-evk-camera-imx577"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-staging] = \
-    "talos-evk talos-evk-camera-imx577 talos-staging"
+    "talos-evk talos-evk-camera-imx577 talos-staging talos-evk-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx] = "talos-evk talos-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-el2gh-camx-staging] = \
-    "talos-evk talos-evk-camx talos-el2 talos-staging"
+    "talos-evk talos-evk-camx talos-staging"
 
+FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2gh] = \
+    "talos-evk talos-evk-lvds-auo_g133han01"
 FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-el2gh-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-staging"

--- a/conf/machine/include/fit-dtb-compatible.inc
+++ b/conf/machine/include/fit-dtb-compatible.inc
@@ -46,8 +46,21 @@ FIT_DTB_COMPATIBLE[qcom_hamoa-evk] = \
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-el2kvm] = \
     "hamoa-iot-evk hamoa-iot-evk-camera-imx577 x1-el2"
 
-# ---------- purwa ----------
-FIT_DTB_COMPATIBLE[qcom_purwa-evk-el2kvm] = "purwa-iot-evk x1-el2"
+# ---------- kodiak ----------
+FIT_DTB_COMPATIBLE[qcom_qcm6490-idp] = "qcm6490-idp"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot] = "qcs6490-rb3gen2"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot] = "qcs6490-rb3gen2"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
+
+FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
 
 # ---------- lemans ----------
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot] = \
@@ -65,6 +78,9 @@ FIT_DTB_COMPATIBLE[qcom_qcs8275-iot] = \
 
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride"
 
+# ---------- purwa ----------
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-el2kvm] = "purwa-iot-evk x1-el2"
+
 # ---------- shikra ----------
 FIT_DTB_COMPATIBLE[qcom_shikracqm-itp] = "shikra-cqm-evk shikra-cqm-evk-imx577-camera"
 FIT_DTB_COMPATIBLE[qcom_shikracqs-itp] = "shikra-cqs-evk shikra-cqm-evk-imx577-camera"
@@ -75,19 +91,3 @@ FIT_DTB_COMPATIBLE[qcom_qcs615-adp] = "qcs615-ride"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot] = "talos-evk talos-evk-camera-imx577"
 FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
     "talos-evk talos-evk-lvds-auo_g133han01"
-
-# ---------- kodiak ----------
-FIT_DTB_COMPATIBLE[qcom_qcm6490-idp] = "qcm6490-idp"
-
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot] = "qcs6490-rb3gen2"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot] = "qcs6490-rb3gen2"
-
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine"
-
-FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"
-FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2] = \
-    "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine"

--- a/conf/machine/include/qcom-qcs615.inc
+++ b/conf/machine/include/qcom-qcs615.inc
@@ -7,6 +7,10 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
+# Without the kvm machine feature the board boots under Gunyah, so pre-seed
+# the VendorDtbOverlays UEFI variable with the el2gh overlay selector.
+QCOM_VENDOR_DTB_OVERLAYS ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "", "el2gh", d)}"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs615-soc \

--- a/conf/machine/include/qcom-qcs8300.inc
+++ b/conf/machine/include/qcom-qcs8300.inc
@@ -11,6 +11,10 @@ require conf/machine/include/arm/arch-armv8-2a.inc
 # More details at https://lore.kernel.org/all/3fcf6614-ee83-4a06-9024-83573b2e642e@quicinc.com/
 KERNEL_CMDLINE_EXTRA:append = " arm64.nopauth"
 
+# Without the kvm machine feature the board boots under Gunyah, so pre-seed
+# the VendorDtbOverlays UEFI variable with the el2gh overlay selector.
+QCOM_VENDOR_DTB_OVERLAYS ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "", "el2gh", d)}"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs8300-soc \

--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -7,6 +7,10 @@ require conf/machine/include/qcom-common.inc
 DEFAULTTUNE = "armv8-2a-crypto"
 require conf/machine/include/arm/arch-armv8-2a.inc
 
+# Without the kvm machine feature the board boots under Gunyah, so pre-seed
+# the VendorDtbOverlays UEFI variable with the el2gh overlay selector.
+QCOM_VENDOR_DTB_OVERLAYS ?= "${@bb.utils.contains("MACHINE_FEATURES", "kvm", "", "el2gh", d)}"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-qcom-boot-essential \
     packagegroup-machine-essential-qcom-qcs9100-soc \

--- a/lib/oeqa/selftest/cases/qcom_fitimage.py
+++ b/lib/oeqa/selftest/cases/qcom_fitimage.py
@@ -49,8 +49,10 @@ class QcomFitImageTests(OESelftestTestCase):
         "sku0", "softsku0", "softsku1",
     }
 
-    # Suffixes allowed by the metadata-check script's blacklist
-    COMPAT_EXTENSIONS = {"camx", "el2kvm", "staging"}
+    # Suffixes allowed by the metadata-check script's blacklist.
+    # el2kvm/el2gh select the hypervisor (KVM or Gunyah) and, like camx and
+    # staging, are not board metadata so they have no qcom-metadata node.
+    COMPAT_EXTENSIONS = {"camx", "el2gh", "el2kvm", "staging"}
 
     # ------------------------------------------------------------------
     # Helpers
@@ -578,7 +580,7 @@ class QcomFitImageIntegrationTests(OESelftestTestCase):
     _meta_nodes = None
 
     # Suffixes allowed by the metadata-check blacklist
-    COMPAT_SKIP_PATTERNS = {"camx", "el2kvm", "staging"}
+    COMPAT_SKIP_PATTERNS = {"camx", "el2gh", "el2kvm", "staging"}
 
     # ------------------------------------------------------------------
     # Helpers
@@ -772,7 +774,7 @@ class QcomFitImageIntegrationTests(OESelftestTestCase):
 
         Every dash-separated suffix in each compatible string must
         either be a node name in the metadata DTS or be listed in
-        the skip patterns (camx, el2kvm).
+        the skip patterns (camx, el2gh, el2kvm, staging).
 
         This replicates the core check from check-fitimage-metadata.sh
         without requiring dtc.

--- a/lib/qcom/efi_volatile_vars.py
+++ b/lib/qcom/efi_volatile_vars.py
@@ -1,0 +1,77 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Builds an EBBR-style VolatileVars.bin for pre-seeding UEFI variables, in
+# the format read by the firmware's UpdateVariableFromRTVolatileBin().
+#
+# Format (all little-endian):
+#
+# EFI_VARIABLE_FILE header (24 bytes):
+#     UINT64 Reserved      (0)
+#     UINT8  Magic[7]      "UbEfiVa"
+#     UINT8  Revision      1
+#     UINT32 Length        total file size
+#     UINT32 Crc32         zlib crc32 over everything after the header
+#
+# EFI_VARIABLE_ENTRY, repeated, each 8-byte aligned (32-byte header + name + data):
+#     UINT32   DataSize
+#     UINT32   Attributes
+#     UINT64   Reserved     (0)
+#     EFI_GUID VendorGuid   (16 bytes)
+#     CHAR16   Name[]       UCS-2, NUL-terminated
+#     UINT8    Data[DataSize]
+#     <pad to 8-byte alignment>
+
+import struct
+import uuid
+import zlib
+
+MAGIC = b"UbEfiVa"
+REVISION = 1
+ALIGNMENT = 8
+
+EFI_VARIABLE_NON_VOLATILE = 0x00000001
+EFI_VARIABLE_BOOTSERVICE_ACCESS = 0x00000002
+EFI_VARIABLE_RUNTIME_ACCESS = 0x00000004
+
+VENDOR_DTB_OVERLAYS_GUID = "882f8c2b-9646-435f-8de5-f208ff80c1bd"
+VENDOR_DTB_OVERLAYS_ATTRIBUTES = (
+    EFI_VARIABLE_NON_VOLATILE
+    | EFI_VARIABLE_BOOTSERVICE_ACCESS
+    | EFI_VARIABLE_RUNTIME_ACCESS
+)
+
+
+def build_entry(guid_str, name, data, attributes):
+    guid_bytes = uuid.UUID(guid_str).bytes_le
+    name_bytes = name.encode("utf-16-le") + b"\x00\x00"
+    header = struct.pack("<IIQ", len(data), attributes, 0) + guid_bytes
+    entry = header + name_bytes + data
+    pad = (-len(entry)) % ALIGNMENT
+    return entry + b"\x00" * pad
+
+
+def build_volatile_vars(entries):
+    """entries: list of dicts with keys guid, name, data (bytes), attributes"""
+    body = b"".join(
+        build_entry(e["guid"], e["name"], e["data"], e["attributes"])
+        for e in entries
+    )
+    length = 24 + len(body)
+    crc32 = zlib.crc32(body) & 0xFFFFFFFF
+    header = struct.pack("<Q7sBII", 0, MAGIC, REVISION, length, crc32)
+    return header + body
+
+
+def build_vendor_dtb_volatile_vars(vendor_dtb_overlays):
+    """Build a VolatileVars.bin containing only the VendorDtbOverlays entry."""
+    entries = [
+        {
+            "guid": VENDOR_DTB_OVERLAYS_GUID,
+            "name": "VendorDtbOverlays",
+            "data": vendor_dtb_overlays.encode("utf-8"),
+            "attributes": VENDOR_DTB_OVERLAYS_ATTRIBUTES,
+        }
+    ]
+    return build_volatile_vars(entries)

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -4,7 +4,7 @@ PACKAGE_INSTALL = " \
     systemd-boot \
 "
 
-inherit image uki uki-esp-image features_check
+inherit image uki uki-esp-image efi-volatile-vars features_check
 
 require esp-qcom-common.inc
 


### PR DESCRIPTION
On Gunyah-capable SoCs (lemans, monaco, talos) the plain DT compatible string
selects KVM and carries the `<soc>-el2` overlay, while the `el2gh` variant
selects the Gunyah hypervisor and drops those overlays. This series completes
that split and makes a Gunyah boot selectable at build time:

- provide the `el2gh` compatible strings that were missing, so every KVM
string on a Gunyah-capable SoC has a counterpart.

- add an EBBR-style `VolatileVars.bin` to the ESP so firmware sees the
`VendorDtbOverlays` UEFI variable on first boot, instead of waiting for
firmware-side generation to create it.