### PR TITLE
ci/ci: enable ccache

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -29,7 +29,7 @@ env:
   CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
-  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:4b210b0be3c887875973c4f4c35470b4ecf3edd2346c9de1bdd33feae5b86e94 # 5.5
 
 jobs:
   kas-setup:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -29,7 +29,7 @@ env:
   CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
-  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:4b210b0be3c887875973c4f4c35470b4ecf3edd2346c9de1bdd33feae5b86e94 # 5.5
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:3f3d3257e8d4ca3adfcb2e0025e6da24339fb8d68a6999ca36c37381351582d5 # 5.5-9-g0555188
 
 jobs:
   kas-setup:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -46,7 +46,7 @@ on:
 env:
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
-  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:4b210b0be3c887875973c4f4c35470b4ecf3edd2346c9de1bdd33feae5b86e94 # 5.5
 
 jobs:
   reusable_compile_job:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -46,7 +46,7 @@ on:
 env:
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
-  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:4b210b0be3c887875973c4f4c35470b4ecf3edd2346c9de1bdd33feae5b86e94 # 5.5
+  KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas@sha256:3f3d3257e8d4ca3adfcb2e0025e6da24339fb8d68a6999ca36c37381351582d5 # 5.5-9-g0555188
 
 jobs:
   reusable_compile_job:

--- a/.github/workflows/sstate-cleanup.yml
+++ b/.github/workflows/sstate-cleanup.yml
@@ -20,5 +20,5 @@ jobs:
         run: |
           # bitbake refreshes the mtime of every sstate file a build uses, so
           # a file older than 15 days was not used by any build in 15 days
-          find "${CACHE_DIR}/sstate-cache" -type f -mtime +15 -delete
-          find "${CACHE_DIR}/sstate-cache" -mindepth 1 -type d -empty -delete
+          find "${CACHE_DIR}/sstate-cache" -not -path "*/ccache/*" -type f -mtime +15 -delete
+          find "${CACHE_DIR}/sstate-cache" -not -path "*/ccache/*" -mindepth 1 -type d -empty -delete

--- a/ci/ccache.yml
+++ b/ci/ccache.yml
@@ -11,3 +11,21 @@ local_conf_header:
     # required to build '-native' target
     HOSTTOOLS += "ccache"
     ASSUME_PROVIDED += "ccache-native"
+
+  ccache-recipe-contol: |
+    # disable all recipes
+    CCACHE_DISABLE = "1"
+    # table with enabled recipes
+    CCACHE_DISABLE:pn-clang = "0"
+    CCACHE_DISABLE:pn-clang-native = "0"
+    CCACHE_DISABLE:pn-gcc = "0"
+    CCACHE_DISABLE:pn-gcc-cross-aarch64 = "0"
+    CCACHE_DISABLE:pn-gcc-cross-arm = "0"
+    CCACHE_DISABLE:pn-glibc = "0"
+    CCACHE_DISABLE:pn-llvm = "0"
+    CCACHE_DISABLE:pn-llvm-native = "0"
+    CCACHE_DISABLE:pn-linux-qcom = "0"
+    CCACHE_DISABLE:pn-linux-qcom-next = "0"
+    CCACHE_DISABLE:pn-linux-yocto = "0"
+    CCACHE_DISABLE:pn-rust = "0"
+    CCACHE_DISABLE:pn-rust-native = "0"

--- a/ci/ccache.yml
+++ b/ci/ccache.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+local_conf_header:
+  ccache: |
+    INHERIT += "ccache"
+    CCACHE_MAXSIZE = "200G"
+    CCACHE_TOP_DIR = "${SSTATE_DIR}/ccache"
+    # required to build '-native' target
+    HOSTTOOLS += "ccache"
+    ASSUME_PROVIDED += "ccache-native"

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -4,6 +4,7 @@ header:
   version: 14
   includes:
   - ci/mirror.yml
+  - ci/ccache.yml
 
 local_conf_header:
   ci: |


### PR DESCRIPTION
The ccache can improve significantly our builds speeds when we can't take
advantage of the bitbake sstate cache, in sutch scenario we need to compile
the code. The cache storage needs to be available from the previous builds
so we need to store these ccache artifacts temporay on our permanent storage.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1051