### PR TITLE
dTPM: declare TPM2 machine feature on iq-615-evk

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs615.inc
 
-MACHINE_FEATURES += "efi kvm pci"
+MACHINE_FEATURES += "efi kvm pci tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \


### PR DESCRIPTION
Talos-EVK boards has a discrete TPM (ST33HTPH2X32AHE4) chip connected over SPI. Without tpm2 in MACHINE_FEATURES the TPM2 stack and related recipes are not pulled in for these targets.

Add tpm2 to MACHINE_FEATURES for both machines to properly enable dTPM hardware support