### PR TITLE
firmware-qcom-boot: update boot to 00137

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00135.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "8dcdbbedaf3ec0fc26cf438222e06d141c8c9a17ba87bbf7f888341145d9c8ef"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00137.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "a7db0177218ce14cf52d514d3f9413f905b83004a4318b279cbbf73242676fd3"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00135.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "43549a7dce32134f81706fd2d0e3550a655563ccdd708d11b89480281485003e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00137.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "24315170167192c63e4969d85d4b20b2bd9311f6b2a72220af571d2ebaa51e2a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00135.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "67b023c4b18188ac5f4c0f50b656902501cf8c735982b7b099493bea85da4a21"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00137.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "54c2b7634807a78dc77f3371004a63ab510b46ae1fc92dbfdc72de1b6d18459e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00135.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00135.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "2db1108f41ea9feddff0303be7e0b0af4fa66ce7405ee6e874749a9f4f266e82"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00137.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "6150c43a55ec95a9e11e288df1a1670a7dc75981485de93376969cb573c9a3c5"


### PR DESCRIPTION
This PR updates boot for QCM6490, QCS8300, QCS9100 and QCS615.

QCS615 Known fixes:
fix: resolve end-to-end secure boot failure on PMIC-based platforms in non-debug (non-JTAG) configurations
fix: address UEFI memory diagnostic utility crash causing device resets during DDR validation


QCM6490 Known fixes:
feat: update hypervisor memory region attributes in UEFI platform configuration for improved memory isolation and protection
feat: enable boot firmware image compression to reduce storage footprint and improve early-stage load efficiency
security: add subsystem image authentication and reset handling for virtualized execution environments (KVM-based)
fix: apply compiler flag to resolve atomics-related build failures on ARM cross-compilation targets


QCS9100 Known fixes:
feat: enable non-hypervisor (no-KVM) boot path to support direct kernel launch without a virtualization layer
feat: enable boot firmware image compression to reduce binary footprint across secure firmware components
feat: add host OS client and remote processor driver support for virtualized subsystem bring-up


QCS8300 Known fixes:
feat: enable boot firmware image compression across secure firmware components for reduced flash footprint
security: add subsystem image authentication and reset handling for virtualized execution environments
feat: add host OS client and remote processor driver support for virtualized subsystem bring-up