### PR TITLE
ci: base.lock: Update meta-audioreach to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -13,7 +13,7 @@ overrides:
         meta-virtualization:
             commit: cbaa5b92b046a13585105713166c886cdfd5de33
         meta-audioreach:
-            commit: 714f81ba2467b16e494eaf61e3eb642e8cef5e02
+            commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:


### PR DESCRIPTION
Following changes are included
3f673ee Merge pull request https://github.com/qualcomm-linux/
meta-qcom/pull/176 from mpratyus/shikra-audioreach-kernel-bump
9c26208 Merge pull request https://github.com/qualcomm-linux/
meta-qcom/pull/175 from mpratyus/shikra-kernel-headers-bump
bbcd286 audioreach-kernel-headers: srcrev bump 9a003d1...7a3f415
7c26350 Merge pull request https://github.com/qualcomm-linux/
meta-qcom/pull/172 from qti-sbojja/master
2b28077 ci/qcom-distro.yml: Enable meta-ai layer
de90bf8 Merge pull request https://github.com/qualcomm-linux/
meta-qcom/pull/174 from mpratyus/shikra-audio-component-bumps
26b0f16 audioreach-graphservices: enable MDSP build for Shikra
4d46581 audioreach-graphservices: srcrev bump d1a26ff...4ce3037
46f8107 audioreach-kernel: srcrev bump 9a003d1...7a3f415
37995d7 audioreach-pal: move PAL headers into main recipe
f8a384d audioreach-pal: srcrev bump 2fa9b82...158ee86
a7db88d audioreach-conf: srcrev bump 72504e0...a1ad7d6
