### PR TITLE
ci: base.lock: Update meta-audioreach to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -15,7 +15,7 @@ overrides:
         meta-virtualization:
             commit: ff03b1e118c4788f17d7ae45b820b00e3194634a
         meta-audioreach:
-            commit: ad92f6fc436575275d106eee264d62715735f66b
+            commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:
             commit: 1c3a699f363167571ab39fecb0fe6f56691a4e20
         meta-updater:


### PR DESCRIPTION
Following changes are included:

3f673ee Merge pull request #176 from mpratyus/
shikra-audioreach-kernel-bump
9c26208 Merge pull request #175 
from mpratyus/shikra-kernel-headers-bump
bbcd286 audioreach-kernel-headers: srcrev bump 9a003d1...7a3f415
7c26350 Merge pull request #172 from qti-sbojja/master
2b28077 ci/qcom-distro.yml: Enable meta-ai layer
de90bf8 Merge pull request #174 
from mpratyus/shikra-audio-component-bumps
26b0f16 audioreach-graphservices: enable MDSP build for Shikra
4d46581 audioreach-graphservices: srcrev bump d1a26ff...4ce3037
46f8107 audioreach-kernel: srcrev bump 9a003d1...7a3f415
37995d7 audioreach-pal: move PAL headers into main recipe
f8a384d audioreach-pal: srcrev bump 2fa9b82...158ee86
a7db88d audioreach-conf: srcrev bump 72504e0...a1ad7d6
714f81b Merge pull request #170 from sauravk-git/
update-srcrev-graphmgr-kernel