### PR TITLE
linux-qcom-next: update to tag qcom-next-7.2-rc5-20260816

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-# Default reviewers for all changes in entire repository,
-# unless a later match takes precedence
-*  @vkraleti @ricardosalveti @sbanerjee-quic @ndechesne @lumag @anujm1 @koenkooi
-
-# Reviewers to be assigned for any changes in ci/ subdirectory
-ci/*  @quaresmajose @ricardosalveti @sbanerjee-quic @ndechesne @mwasilew @lumag
+# Reviewers intentionally removed for the staging repository.

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -119,7 +119,7 @@ runs:
       with:
         path: ./uploads
         destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
-        s3_bucket: qcom-prd-gh-artifacts
+        s3_bucket: qcom-stg-gh-artifacts
 
     - name: "Print output"
       shell: bash

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -202,6 +202,30 @@ jobs:
           - type: default
             dirname: ""
             yamlfile: ""
+        include:
+          # One early build per non-default kernel flavor, so a single job
+          # refreshes the kernel git mirror tarballs (a SRCREV bump makes the
+          # first fetcher regenerate them while holding the per-repository
+          # DL_DIR lock) and lands the first kernel sstate in the shared
+          # cache before the matrix fans out. The same combinations are
+          # excluded from the compile matrix below, like the other warm_up
+          # builds.
+          - machine: qcom-armv8a
+            distro:
+                name: nodistro
+                yamlfile: ""
+            kernel:
+                type: 6.18
+                dirname: "_linux-qcom-6.18"
+                yamlfile: ":ci/linux-qcom-6.18.yml"
+          - machine: qcom-armv8a
+            distro:
+                name: nodistro
+                yamlfile: ""
+            kernel:
+                type: rt-6.18-distro-kvm
+                dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
+                yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
@@ -326,6 +350,16 @@ jobs:
                 name: qcom-distro
             kernel:
                 type: default
+          - machine: qcom-armv8a
+            distro:
+                name: nodistro
+            kernel:
+                type: 6.18
+          - machine: qcom-armv8a
+            distro:
+                name: nodistro
+            kernel:
+                type: rt-6.18-distro-kvm
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -31,8 +31,8 @@ env:
 
 jobs:
   kas-setup:
-    if: github.repository_owner == 'qualcomm-linux'
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    if: github.repository_owner == 'qualcomm-linux-stg'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     steps:
       - name: Setting up kas-container
         run: |
@@ -64,7 +64,7 @@ jobs:
 
   github-cache-check:
     needs: kas-setup
-    if: github.repository_owner == 'qualcomm-linux'
+    if: github.repository_owner == 'qualcomm-linux-stg'
     runs-on: ubuntu-latest
     outputs:
       cache_hit: ${{ steps.restore.outputs.cache-hit == 'true' }}
@@ -115,9 +115,9 @@ jobs:
   yocto-run-checks:
     needs: [kas-setup, github-cache-check]
     if: |
-      github.repository_owner == 'qualcomm-linux' &&
+      github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -159,7 +159,7 @@ jobs:
           ci/kas-container-shell-helper.sh ci/oe-selftest.sh
 
   compile-env:
-    if: github.repository_owner == 'qualcomm-linux'
+    if: github.repository_owner == 'qualcomm-linux-stg'
     runs-on: ubuntu-latest
     outputs:
       CACHE_DIR: ${{ steps.compile_env.outputs.CACHE_DIR }}
@@ -172,7 +172,7 @@ jobs:
   compile_warm_up:
     needs: [kas-setup, github-cache-check, compile-env]
     if: |
-      github.repository_owner == 'qualcomm-linux' &&
+      github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     strategy:
       fail-fast: true
@@ -211,7 +211,7 @@ jobs:
   compile_sdk:
     needs: [github-cache-check, compile_warm_up, compile-env]
     if: |
-      github.repository_owner == 'qualcomm-linux' &&
+      github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     uses: ./.github/workflows/compile.yml
     with:
@@ -229,7 +229,7 @@ jobs:
   compile:
     needs: [github-cache-check, compile_warm_up, compile-env]
     if: |
-      github.repository_owner == 'qualcomm-linux' &&
+      github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     strategy:
       fail-fast: false
@@ -472,7 +472,7 @@ jobs:
   publish_summary:
     needs: [github-cache-check, compile, compile_sdk]
     if: |
-      always() && github.repository_owner == 'qualcomm-linux' &&
+      always() && github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     runs-on: ubuntu-latest
     steps:
@@ -488,7 +488,7 @@ jobs:
   github-cache-save:
     needs: [github-cache-check, compile, compile_sdk]
     if: |
-      github.repository_owner == 'qualcomm-linux' &&
+      github.repository_owner == 'qualcomm-linux-stg' &&
       inputs.skip_if_github_cached == true &&
       needs.github-cache-check.outputs.cache_hit != 'true' &&
       needs.compile.result == 'success'
@@ -504,7 +504,7 @@ jobs:
           key: build-success-${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.github-cache-check.outputs.run_hash }}
 
   build_successful:
-    if: github.repository_owner == 'qualcomm-linux'
+    if: github.repository_owner == 'qualcomm-linux-stg'
     needs: [compile, compile_sdk]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -245,6 +245,16 @@ jobs:
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     strategy:
       fail-fast: false
+      # Bound how many matrix jobs hit the shared caches at once. On a cold
+      # run (routine after a base.lock bump invalidates most of the sstate
+      # cache) an uncapped matrix rebuilds everything ~90 times in parallel:
+      # sstate availability is computed at job start, so concurrent jobs
+      # cannot reuse each other's output, and they serialize on the
+      # per-repository fetch locks in the shared DL_DIR. With waves, earlier
+      # jobs land their sstate in the shared cache and later waves reuse it
+      # instead of rebuilding it. Warm runs are barely affected; tune as
+      # staging data comes in.
+      max-parallel: 40
       matrix:
         machine:
           - glymur-crd

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -223,9 +223,9 @@ jobs:
                 name: nodistro
                 yamlfile: ""
             kernel:
-                type: rt-6.18-distro-kvm
-                dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
-                yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
+                type: rt-6.18
+                dirname: "_linux-qcom-rt-6.18"
+                yamlfile: ":ci/linux-qcom-rt-6.18.yml"
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
@@ -315,9 +315,14 @@ jobs:
           - type: 6.18
             dirname: "_linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
-          - type: rt-6.18-distro-kvm
-            dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
-            yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
+          # Plain rt kernel provider only: ci/qcom-distro-kvm.yml must not ride
+          # on the kernel axis — it includes ci/qcom-distro.yml, whose distro
+          # and targets override the distro row (nodistro/qcom-distro/catchall
+          # x rt-kvm all built the identical qcom-distro image set). The kvm
+          # coverage lives in the dedicated qcom-distro-kvm jobs below.
+          - type: rt-6.18
+            dirname: "_linux-qcom-rt-6.18"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
         exclude:
           # Exclude jobs from compile_warm_up
           - machine: glymur-crd
@@ -359,7 +364,7 @@ jobs:
             distro:
                 name: nodistro
             kernel:
-                type: rt-6.18-distro-kvm
+                type: rt-6.18
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a
@@ -402,6 +407,16 @@ jobs:
                 type: default
                 dirname: ""
                 yamlfile: ""
+          # Keep one rt + kvm combination now that the kvm fragment no longer
+          # rides on the rt kernel axis
+          - machine: rb3gen2-core-kit
+            distro:
+                name: qcom-distro-kvm
+                yamlfile: ':ci/qcom-distro-kvm.yml'
+            kernel:
+                type: rt-6.18
+                dirname: "_linux-qcom-rt-6.18"
+                yamlfile: ":ci/linux-qcom-rt-6.18.yml"
           - machine: qcom-armv7a
             distro:
                 name: nodistro

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -324,16 +324,6 @@ jobs:
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
     strategy:
       fail-fast: false
-      # Bound how many matrix jobs hit the shared caches at once. On a cold
-      # run (routine after a base.lock bump invalidates most of the sstate
-      # cache) an uncapped matrix rebuilds everything ~90 times in parallel:
-      # sstate availability is computed at job start, so concurrent jobs
-      # cannot reuse each other's output, and they serialize on the
-      # per-repository fetch locks in the shared DL_DIR. With waves, earlier
-      # jobs land their sstate in the shared cache and later waves reuse it
-      # instead of rebuilding it. Warm runs are barely affected; tune as
-      # staging data comes in.
-      max-parallel: 40
       matrix:
         machine:
           # Machines with a unique DEFAULTTUNE (their own sstate population)

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -26,7 +26,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
+  # Shared build cache root on the FSx mount, POSIX shared filesystem
+  # semantics like the EFS folder it replaces: DL_DIR (downloads/) and the
+  # monthly SSTATE_DIR folders live under it, both read-write through the
+  # kas-container bind mounts, and the monthly workflow prunes the rotated
+  # sstate folders.
+  CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
 
 jobs:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -226,6 +226,28 @@ jobs:
                 type: rt-6.18
                 dirname: "_linux-qcom-rt-6.18"
                 yamlfile: ":ci/linux-qcom-rt-6.18.yml"
+          # qcom-distro-catchall is its own sstate population (different
+          # DISTRO name and feature set), so seed its world here — the world
+          # expression below enables it automatically for catchall + default.
+          - machine: qcom-armv8a
+            distro:
+                name: qcom-distro-catchall
+                yamlfile: ':ci/qcom-distro-catchall.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
+          # sm8750-mtp uses its own tune (armv8-7a DEFAULTTUNE), a separate
+          # sstate population no other machine seeds, so give it a warm_up
+          # build of its own.
+          - machine: sm8750-mtp
+            distro:
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
@@ -281,6 +303,10 @@ jobs:
       max-parallel: 40
       matrix:
         machine:
+          # Machines with a unique DEFAULTTUNE (their own sstate population)
+          # come first, so their universes are seeded by the earliest waves
+          # instead of forming a cold tail at the end of the matrix.
+          - sm8750-mtp
           - glymur-crd
           - iq-615-evk
           - iq-8275-evk
@@ -296,7 +322,6 @@ jobs:
           - rb1-core-kit
           - rb3gen2-core-kit
           - shikra-evk
-          - sm8750-mtp
         distro:
           - name: nodistro
             yamlfile: ""
@@ -365,6 +390,16 @@ jobs:
                 name: nodistro
             kernel:
                 type: rt-6.18
+          - machine: qcom-armv8a
+            distro:
+                name: qcom-distro-catchall
+            kernel:
+                type: default
+          - machine: sm8750-mtp
+            distro:
+                name: qcom-distro
+            kernel:
+                type: default
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -148,8 +148,15 @@ jobs:
 
       - name: Setup cache variables (used by oe-selftest)
         run: |
+          # Git clone dirs are kept job-local like the compile jobs do via
+          # ci/ci.yml (git-dl): GIT_CLONEDIR_JOB_LOCAL makes ci/oe-selftest.sh
+          # point GITDIR at the kas workspace and generate the git2_*.tar.gz
+          # mirror tarballs, so the shared DL_DIR only ever carries whole-file
+          # atomic artifacts. The flag rides on KAS_OPTS --runtime-args since
+          # kas-container only forwards a fixed set of environment variables.
           echo "DL_DIR=${CACHE_DIR}/downloads" >> $GITHUB_ENV
           echo "SSTATE_DIR=${CACHE_DIR}/sstate-cache-$(date '+%Y-%m')" >> $GITHUB_ENV
+          echo "KAS_OPTS=--runtime-args --env=GIT_CLONEDIR_JOB_LOCAL=1" >> $GITHUB_ENV
 
       - name: Run Yocto patchreview
         run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -181,8 +181,32 @@ jobs:
         run: |
           echo "CACHE_DIR=${{env.CACHE_DIR}}" >> $GITHUB_OUTPUT
 
-  compile_warm_up:
+  # First warm_up tier: a single job that builds the common core (native
+  # tools, toolchain, the generic target world) exactly once. The second
+  # tier's seed jobs all reuse this sstate instead of each cold-building the
+  # core in parallel, which both shortens the warm_up barrier and removes
+  # most of its redundant compute on a cold cache.
+  compile_warm_up_core:
     needs: [kas-setup, github-cache-check, compile-env]
+    if: |
+      github.repository_owner == 'qualcomm-linux-stg' &&
+      (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
+    uses: ./.github/workflows/compile.yml
+    with:
+      name: qcom-armv8a/nodistro
+      world: true
+      machine: 'qcom-armv8a'
+      distro_yaml: ''
+      distro_name: 'nodistro'
+      kernel_yaml: ''
+      kernel_dirname: ''
+      cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+
+  # Second warm_up tier: one seed build per sstate population the matrix
+  # depends on (distro families, kernel flavors, unique-tune machines), each
+  # reusing the core tier's sstate.
+  compile_warm_up:
+    needs: [github-cache-check, compile_warm_up_core, compile-env]
     if: |
       github.repository_owner == 'qualcomm-linux-stg' &&
       (inputs.skip_if_github_cached != true || needs.github-cache-check.outputs.cache_hit != 'true')
@@ -191,7 +215,6 @@ jobs:
       matrix:
         machine:
           - glymur-crd
-          - qcom-armv8a
           - rb3gen2-core-kit
         distro:
           - name: nodistro
@@ -203,6 +226,16 @@ jobs:
             dirname: ""
             yamlfile: ""
         include:
+          # qcom-armv8a nodistro (world) moved to compile_warm_up_core; its
+          # qcom-distro build stays here as a plain include.
+          - machine: qcom-armv8a
+            distro:
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
+            kernel:
+                type: default
+                dirname: ""
+                yamlfile: ""
           # One early build per non-default kernel flavor, so a single job
           # refreshes the kernel git mirror tarballs (a SRCREV bump makes the
           # first fetcher regenerate them while holding the per-repository

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   reusable_compile_job:
     if: inputs.enabled
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     name: ${{ inputs.name }}
     steps:
       - uses: actions/checkout@v6
@@ -222,7 +222,7 @@ jobs:
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
-          s3_bucket: qcom-prd-gh-artifacts
+          s3_bucket: qcom-stg-gh-artifacts
           object_tag: ${{ env.OBJECT_TAG }}
           build_type: ${{ env.BUILD_TYPE }}
           build_branch: "branch=${{ github.base_ref || github.ref_name }}"

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,13 +1,14 @@
 name: Monthly job
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "22 10 5 * *"   # montly job - at "random" time - top of hour can be busy in github
 
 jobs:
   sstate-cache-cleanup:
-    if: github.repository_owner == 'qualcomm-linux'
-    runs-on: [self-hosted, qcom-sm-u2404, sm-amd64]
+    if: github.repository_owner == 'qualcomm-linux-stg'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64-ssd]
     timeout-minutes: 720
     steps:
       - name: Clean up the persistant sstate-cache dir

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - name: Clean up the persistant sstate-cache dir
         run: |
-          rm -rf $(find /efs/qli/meta-qcom -name 'sstate-cache-*' -maxdepth 1 -type d -ctime +30)
+          rm -rf $(find /efsx/qli/meta-qcom -name 'sstate-cache-*' -maxdepth 1 -type d -ctime +30)

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,9 +1,7 @@
 name: Build on push
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 permissions:
   checks: write
@@ -14,7 +12,11 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/build-yocto.yml
+  # Hardware tests (test.yml) are disabled for staging validation: the run
+  # only exercises the full build matrix and the S3 sstate cache, not LAVA.
+  # Skipping "test" also skips "publish-test-results" via its needs.
   test:
+    if: false
     uses: ./.github/workflows/test.yml
     needs: [build]
     secrets: inherit

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -24,3 +24,5 @@ overrides:
             commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:
             commit: 3511d6c9669683fc232211eb72e1549d6db6e660
+        meta-qcom-distro:
+            commit: fc472762d0f70662e81e69e63981b544536e2663

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -36,3 +36,18 @@ local_conf_header:
     BB_PRESSURE_MAX_MEMORY = "15000"
     PARALLEL_MAKE = "-j 4"
     do_compile[number_threads] = "8"
+  git-dl: |
+    # Git clone dirs are mutated in place on every update (git fetch, repack,
+    # pack-refs, prune-packed under DL_DIR/git2), which is unsafe when many
+    # parallel jobs share DL_DIR on a network mount: another job's repack
+    # between this job's do_fetch and do_unpack can make the shared clonedir
+    # transiently look stale or corrupt (seen as opencv do_unpack "clone
+    # directory not available or not up to date" during staging validation,
+    # and as corrupt clonedirs with current refs but missing objects on the
+    # shared EFS DL_DIR before that). The per-download lock does not cover
+    # the fetch-to-unpack window, so instead keep the mutable clone dirs
+    # job-local and share git history through the atomically renamed
+    # git2_*.tar.gz mirror tarballs in DL_DIR, which the fetcher restores
+    # from automatically.
+    GITDIR = "${TMPDIR}/git2"
+    BB_GENERATE_MIRROR_TARBALLS = "1"

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -51,3 +51,24 @@ local_conf_header:
     # from automatically.
     GITDIR = "${TMPDIR}/git2"
     BB_GENERATE_MIRROR_TARBALLS = "1"
+  git-shallow-kernels: |
+    # All qcom kernel flavors fetch the same multi-gigabyte kernel
+    # repository, and with the clone dirs job-local every job must
+    # materialize it while holding the shared per-repository DL_DIR lock
+    # (bitbake holds it across the whole download and the whole unpack),
+    # serializing the matrix behind multi-gigabyte transfers whenever
+    # kernel sstate is missing. The recipes pin SRCREV, take their version
+    # from LINUX_VERSION and kernel.bbclass pins LOCALVERSION, so nothing
+    # reads the git history: fetch these kernels shallow. do_fetch is then
+    # served straight from the depth-1 gitshallow_*.tar.gz in DL_DIR when
+    # present (no clone dir restore at all), shrinking the lock-held
+    # payload from gigabytes to a few hundred megabytes. Generation needs
+    # no extra switch (BB_GENERATE_SHALLOW_TARBALLS defaults to
+    # BB_GENERATE_MIRROR_TARBALLS above), and the tarball name embeds the
+    # revision, so a SRCREV bump regenerates a fresh tarball via whichever
+    # job fetches first. linux-yocto is deliberately not shallow: its
+    # kern-tools machinery relies on the kernel metadata branches.
+    BB_GIT_SHALLOW:pn-linux-qcom = "1"
+    BB_GIT_SHALLOW:pn-linux-qcom-rt = "1"
+    BB_GIT_SHALLOW:pn-linux-qcom-next = "1"
+    BB_GIT_SHALLOW:pn-linux-qcom-next-rt = "1"

--- a/ci/kas-container-shell-helper.sh
+++ b/ci/kas-container-shell-helper.sh
@@ -17,4 +17,6 @@ SCRIPT=${SCRIPT#$TOPDIR/}
 # on ci the kas-container is not on the default path
 KAS_CONTAINER=${KAS_CONTAINER:-$(which kas-container)}
 
-exec $KAS_CONTAINER shell $TOPDIR/ci/base.yml --command "/repo/$SCRIPT /repo /work"
+# KAS_OPTS optionally carries extra kas-container options, e.g. forwarding an
+# environment variable into the container (--runtime-args --env=NAME=value)
+exec $KAS_CONTAINER ${KAS_OPTS:-} shell $TOPDIR/ci/base.yml --command "/repo/$SCRIPT /repo /work"

--- a/ci/oe-selftest.sh
+++ b/ci/oe-selftest.sh
@@ -79,4 +79,15 @@ if [ -n "$DL_DIR" ]; then
     echo "DL_DIR = \"$DL_DIR\"" >> conf/local.conf
 fi
 
+# Keep the mutable git clone dirs job-local and share git history through the
+# atomically renamed git2_*.tar.gz mirror tarballs in DL_DIR instead, matching
+# what ci/ci.yml (git-dl) does for the image builds: clone dirs are mutated in
+# place on every update, which is unsafe on a shared network DL_DIR. Opt-in
+# via environment so local developer runs keep using DL_DIR/git2 as their
+# persistent clone cache.
+if [ -n "$GIT_CLONEDIR_JOB_LOCAL" ]; then
+    echo "GITDIR = \"$WORK_DIR/git2\"" >> conf/local.conf
+    echo "BB_GENERATE_MIRROR_TARBALLS = \"1\"" >> conf/local.conf
+fi
+
 oe-selftest --run-tests "$TEST_CASES"

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -16,6 +16,10 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    patches:
+      redis-xxhash-og:
+        repo: meta-qcom
+        path: patches/meta-openembedded/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
     layers:
       meta-filesystems:
       meta-gnome:

--- a/patches/meta-openembedded/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
+++ b/patches/meta-openembedded/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
@@ -1,0 +1,55 @@
+From c9b9261ed546ce1d381c69d65d4238a23094cc57 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Date: Sat, 15 Aug 2026 04:06:28 +0000
+Subject: [meta-oe][PATCH] redis: fix build of the bundled xxHash with -Og
+
+redis 8.8 started bundling a post-0.8.3 xxHash snapshot in deps/xxhash,
+which is built and linked into redis-server. Its XXH3 accumulate and
+scramble routines are marked always_inline but are only ever reached
+through function pointers, so the compiler has to resolve the indirect
+call before it can honour the attribute.
+
+xxHash drops those inline hints on its own when __NO_INLINE__ is
+defined, which covers -O0 and -fno-inline, but nothing covers -Og.
+Recent GCC no longer resolves the indirect calls at that optimisation
+level, so every build with DEBUG_BUILD = "1" fails:
+
+  xxhash.h:5476:1: error: inlining failed in call to 'always_inline'
+  'XXH3_scrambleAcc_neon': function not considered for inlining
+  make[2]: *** [Makefile:108: xxhash] Error 2
+  ld: cannot find ../deps/xxhash/libxxhash.a: No such file or directory
+
+Upstream xxHash closed this as not fixable in code (Cyan4973/xxHash#943)
+and instead documents XXH_NO_INLINE_HINTS as the supported way to
+compile with -Og. Define it when -Og is the selected optimisation,
+leaving regular builds untouched so xxHash keeps its inline hints there.
+
+AI-Generated: Uses Claude Code
+Signed-off-by: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Upstream-Status: Pending
+---
+ meta-oe/recipes-extended/redis/redis_8.8.1.bb | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/meta-oe/recipes-extended/redis/redis_8.8.1.bb b/meta-oe/recipes-extended/redis/redis_8.8.1.bb
+index 09a7c3aeac..eb9177a408 100644
+--- a/meta-oe/recipes-extended/redis/redis_8.8.1.bb
++++ b/meta-oe/recipes-extended/redis/redis_8.8.1.bb
+@@ -43,6 +43,14 @@ EXTRA_OEMAKE += "${PACKAGECONFIG_CONFARGS}"
+ 
+ TARGET_LDFLAGS:append = " ${DEBUG_PREFIX_MAP}"
+ 
++# The bundled xxHash marks its XXH3 vector paths always_inline but only reaches
++# them through function pointers. It drops the inline hints on its own when
++# __NO_INLINE__ is defined (-O0, -fno-inline) but never for -Og, and recent GCC
++# no longer resolves those indirect calls at -Og, so deps/xxhash fails to
++# build. Upstream xxHash closed this as not fixable in code and documents
++# XXH_NO_INLINE_HINTS as the supported way to compile with -Og.
++CFLAGS:append = "${@' -DXXH_NO_INLINE_HINTS' if '-Og' in (d.getVar('SELECTED_OPTIMIZATION') or '') else ''}"
++
+ do_compile:prepend() {
+     oe_runmake -C deps hdr_histogram fpconv hiredis lua linenoise
+ }
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-qcom-6.18/configs/localversion.cfg
+++ b/recipes-kernel/linux/linux-qcom-6.18/configs/localversion.cfg
@@ -1,0 +1,4 @@
+# The kernel release is fully determined by KERNEL_LOCALVERSION (derived
+# from SRCREV, see linux-qcom-localversion.inc); do not let setlocalversion
+# inspect the git tree state at build time.
+# CONFIG_LOCALVERSION_AUTO is not set

--- a/recipes-kernel/linux/linux-qcom-localversion.inc
+++ b/recipes-kernel/linux/linux-qcom-localversion.inc
@@ -1,0 +1,39 @@
+# Derive a deterministic kernel localversion from the recipe metadata.
+#
+# The qcom kernels build from the upstream arm64 defconfig, which leaves
+# CONFIG_LOCALVERSION_AUTO enabled: kbuild's setlocalversion then derives
+# the kernel release from the state of the git tree at whatever moment a
+# kernel task runs it. In a parallel build that string is not stable:
+# concurrent tasks touching the shared work-shared source tree can
+# transiently mark it dirty, so the kernel can package itself under a
+# "-dirty" release while the module dependencies were computed from the
+# clean one, and the git-describe output also changes with the clone
+# shape (a shallow clone has no tags, dropping the commit count).
+#
+# The revision is already pinned metadata, so compute the same -g<sha>
+# suffix from SRCREV instead, and disable LOCALVERSION_AUTO through the
+# localversion.cfg fragment in each consuming recipe. AUTOREV variants
+# (where SRCREV expands to AUTOINC) ask the fetcher for the revision
+# resolved for this build: still a deterministic function of the task
+# signatures, unlike the git working tree state.
+#
+# Consumers set:
+#   KERNEL_LOCALVERSION = "${@qcom_kernel_localversion(d)}"
+# and add file://configs/localversion.cfg to SRC_URI.
+
+def qcom_kernel_localversion(d):
+    rev = d.getVar('SRCREV_machine') or d.getVar('SRCREV')
+    if not rev or rev in ('AUTOINC', 'INVALID'):
+        # AUTOREV: resolve through the fetcher, like SRCPV would
+        try:
+            fetcher = bb.fetch2.Fetch(d.getVar('SRC_URI').split(), d)
+            scms = [ud for ud in fetcher.ud.values() if ud.method.supports_srcrev()]
+            machine = [ud for ud in scms if ud.name == 'machine']
+            ud = (machine or scms)[0]
+            rev = ud.method.sortable_revision(ud, d, ud.name)[1]
+        except (bb.fetch2.BBFetchException, IndexError):
+            return ''
+    rev = (rev or '').lower()
+    if len(rev) < 12 or any(c not in '0123456789abcdef' for c in rev):
+        return ''
+    return '-g' + rev[:12]

--- a/recipes-kernel/linux/linux-qcom-localversion.inc
+++ b/recipes-kernel/linux/linux-qcom-localversion.inc
@@ -17,6 +17,12 @@
 # resolved for this build: still a deterministic function of the task
 # signatures, unlike the git working tree state.
 #
+# When the recipe applies patches on top of that revision, a -p<count>
+# suffix records it (the same idea as meta-freescale's +p<count>): the
+# release then says "this base, plus N known patches" instead of relying
+# on setlocalversion's -dirty, which only ever reflected which patch tool
+# was used and when the tree state was sampled.
+#
 # Consumers set:
 #   KERNEL_LOCALVERSION = "${@qcom_kernel_localversion(d)}"
 # and add file://configs/localversion.cfg to SRC_URI.
@@ -36,4 +42,12 @@ def qcom_kernel_localversion(d):
     rev = (rev or '').lower()
     if len(rev) < 12 or any(c not in '0123456789abcdef' for c in rev):
         return ''
-    return '-g' + rev[:12]
+    ver = '-g' + rev[:12]
+    try:
+        import oe.patch
+        patches = len(oe.patch.src_patches(d))
+    except (bb.fetch2.BBFetchException, ImportError):
+        patches = 0
+    if patches:
+        ver += '-p%d' % patches
+    return ver

--- a/recipes-kernel/linux/linux-qcom-next/configs/localversion.cfg
+++ b/recipes-kernel/linux/linux-qcom-next/configs/localversion.cfg
@@ -1,0 +1,4 @@
+# The kernel release is fully determined by KERNEL_LOCALVERSION (derived
+# from SRCREV, see linux-qcom-localversion.inc); do not let setlocalversion
+# inspect the git tree state at build time.
+# CONFIG_LOCALVERSION_AUTO is not set

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -10,7 +10,7 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "7.1+7.2-rc3"
+LINUX_VERSION ?= "7.1+7.2-rc5"
 
 PV = "${LINUX_VERSION}+git"
 
@@ -18,8 +18,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag: qcom-next-7.2-rc3-20260731
-SRCREV ?= "8d5dbc1b17adf8fe86a41adcda686785e73f5414"
+# tag: qcom-next-7.2-rc5-20260816
+SRCREV ?= "49dbe0dae5cfb7a1eb3434cde6fc7ba37924fe94"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -24,11 +24,15 @@ SRCREV ?= "8d5dbc1b17adf8fe86a41adcda686785e73f5414"
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"
 
+require linux-qcom-localversion.inc
+KERNEL_LOCALVERSION = "${@qcom_kernel_localversion(d)}"
+
 SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
 
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://configs/localversion.cfg \
 "
 
 # To build tip of qcom-next branch set preferred

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -26,6 +26,9 @@ SRCREV ?= "3167b12384380f1463ccf3b42f83adcac5a3f754"
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"
 
+require linux-qcom-localversion.inc
+KERNEL_LOCALVERSION = "${@qcom_kernel_localversion(d)}"
+
 SRC_URI = " \
     git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https \
     file://0001-tools-use-basename-to-identify-file-in-gen-mach-type.patch \
@@ -34,6 +37,7 @@ SRC_URI = " \
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://configs/localversion.cfg \
 "
 
 # To build tip of qcom-6.18.y branch set preferred

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -12,7 +12,21 @@ SRC_URI:append:qcom = " \
 # Include additional kernel configs.
 SRC_URI:append:qcom = " \
     file://configs/qcom.cfg \
+    file://configs/localversion.cfg \
 "
+
+# Make the kernel release deterministic: the defconfig leaves
+# CONFIG_LOCALVERSION_AUTO enabled, so setlocalversion derives the release
+# from the git tree state at build time — unstable in a parallel build
+# (transient -dirty from concurrent tasks in the shared source tree) and,
+# with the qcom patches applied as git commits, dependent on per-build
+# commit timestamps. Derive the -g<sha> suffix from the revision the
+# fetcher resolved instead (localversion.cfg above disables the AUTO scm
+# inspection), and drop the -yoctodev-standard extension so uname -r keeps
+# its current <version>-g<sha> form.
+require linux-qcom-localversion.inc
+KERNEL_LOCALVERSION:qcom = "${@qcom_kernel_localversion(d)}"
+LINUX_VERSION_EXTENSION:qcom = ""
 
 # When a defconfig is provided, the linux-yocto configuration
 # uses the filename as a trigger to use a 'allnoconfig' baseline

--- a/recipes-kernel/linux/linux-yocto-dev/configs/localversion.cfg
+++ b/recipes-kernel/linux/linux-yocto-dev/configs/localversion.cfg
@@ -1,0 +1,4 @@
+# The kernel release is fully determined by KERNEL_LOCALVERSION (derived
+# from the resolved revision, see linux-qcom-localversion.inc); do not let
+# setlocalversion inspect the git tree state at build time.
+# CONFIG_LOCALVERSION_AUTO is not set


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.2-rc5-20260816, which corresponds to kernel version v7.2-rc5

Changelog:
Name                                  SHA                                  Commits
------------------------------------------------------------------------------------
tech/bsp/clk              d8a14b94230bd89676818c2ba22807ff63dd45ca         30
tech/bsp/devfreq          480953456f9e3ec33a295dcca3ae1ad3fc55ac6e          7
tech/security/firmware-smc de7413c5885e6106c7da9650d992ff2c0293525c          6
tech/bsp/soc-infra        ff6ff7b65a2f4ba4822a6a5343f949b43cd6e87f         22
tech/bsp/pinctrl          79149ef6a826d6237346aa74eca65ccbe19d761f          1
tech/bsp/remoteproc       39a86aa1e9c03be4b388d65a70fac68e69476be0         13
tech/bus/peripherals      fedd8c628af7b28992224012386fec13483c514c          6
tech/bus/pci/all          9f6650aeee7a42a9fc041aa452d757e33644b29d         43
tech/bus/pci/phy          66e44c2741ecc5bc40d8e66ee62ea5c5c179cbc7         14
tech/bus/usb/dwc          9dd47ad7e5c1dea9cfbcdd3f5e84af8d647af95f          3
tech/bus/usb/phy          c3aa7d5c9b171a9fb9ae9d1a9adf4dab251508f9         35
tech/debug/hwtracing      27d6059813d700717fdaf6c144693ab6a236d6e4         23
tech/pmic/misc            5d2c2d7398d2c5395a8bc63825a0514ed4fd159d         12
tech/mem/iommu            cdc9e8034c64ae939077d3780be625bea6b923e9          9
tech/mm/audio/all         88b8f29570c5211e654cec357e6a1282f92737b7          8
tech/mm/camss             3bcce109b344b86cfb74af481d8d786dc16fdf76         47
tech/mm/drm               9e407ef2aaca21e8e9c2ebd8c5135f66c4563b38         68
tech/mm/fastrpc           7afcba9c20a55cd0265b0f9254bfce2cd6f21dee         12
tech/mm/video             d5379b446bc58783f702c928299ff2ce01daad94        122
tech/mm/gpu               0b8d9f42795065bb8e25714b5a169b59ae7e23a2          7
tech/mproc/rpmsg          55dc46433784180276e93105b359bdce601d492e          1
tech/net/ath              900d23710fe0c165804dc8c25f7df5756d00db0f         29
tech/net/bluetooth        33aa6a3d201fcfea2158f463a0bfb3ddc62df6d0          1
tech/pm/power             bb887016f3998f14184b38d1ae3ced78a6d80567         13
tech/pm/thermal           9fdfd8098c17c12e50322a03da455c354dbe9424         12
tech/security/crypto      1f60c0a2ca909753004854053ebac4cd45719e92         23
tech/security/ice         beabac03036a596434bb02c3f91b7c9672ea7c15          9
tech/storage/all          cef1b3c7fc3078e27ca66dd58e8f9fe86b0e077a          5
tech/all/dt/qcs6490       740676bbcc99769adabe7b3037019b06167777c8         27
tech/all/dt/qcs9100       0a48d61247aa4306f7ff83ceb8fdcbb7c06e55cc         92
tech/all/dt/qcs8300       5cb63a5ffd1a0aaded5cb13cebebea47c16e32c6         25
tech/all/dt/qcs615        9a58c35e3d57c1330179010a8b236b158e243c50          9
tech/all/dt/agatti        c828f10cd2c53b7ff2cc061e73b239973ee17bc6          1
tech/all/dt/eliza         ddb736b66734eced8150adede4f8e235b8a7783b         23
tech/all/dt/hamoa         2e751daa3d1219206d7af2646722c8212bbca6b4         42
tech/all/dt/glymur        d288220fabe63109566fcff0ced31e128bb888c7         52
tech/all/dt/kaanapali     625c17193ba48e659936f4b252f6895c852f82d4         21
tech/all/dt/pakala        960924d516b2476657df65d735d81844d9b5bb60         13
tech/all/config           90a294dc9c7c1006322d48bb86d527a842530812         72
tech/overlay/dt           b895d0e7537337daeeb814cea5cf764664b1bc36         78
tech/all/workaround       a2ced8808906bb574def108940af56addd80b53f         20
tech/mproc/all            104969c5b070fdc7bf93c7109c625b8b655a93ee          2
tech/noup/debug/all       80bf7fe7995cf60fef5293b067f8bdafa0638d5f         26
tech/hwe/unoq             a2d85fe547167dbd8fc59618907c20a6f17d2e5a          4
early/hwe/shikra/drivers  b19d2ec290c8ae6fa2d3e8c1955413c4f20d4c3e        184
early/hwe/shikra/dt       dd90d88cfaad62aec33e4278bdd69b95aff0480d        130