### PR TITLE
fastrpc: upgrade 1.0.6 -> 1.0.7

### DIFF
--- a/recipes-support/fastrpc/fastrpc_1.0.7.bb
+++ b/recipes-support/fastrpc/fastrpc_1.0.7.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b67986b6880754696d418dbaa2cf51d1"
 DEPENDS = "libbsd libyaml"
 
-SRCREV = "5f0b6a33a19f3f7f0c06709846752a2caf64e413"
+SRCREV = "228d98b5f143ed917789cde017a8aa548e65b80b"
 SRC_URI = "\
     git://github.com/qualcomm/fastrpc.git;branch=main;protocol=https;tag=v${PV} \
     file://run-ptest \
@@ -35,7 +35,6 @@ do_install:append() {
 }
 
 FILES:${PN} += " \
-    ${libdir}/rfsa \
     ${libdir}/libadsp_default_listener.so \
     ${libdir}/libcdsp_default_listener.so \
     ${libdir}/libsdsp_default_listener.so \
@@ -57,6 +56,7 @@ INSANE_SKIP:${PN} = "dev-so"
 PACKAGE_BEFORE_PN += "${PN}-tests"
 
 FILES:${PN}-tests += " \
+    ${bindir}/dsp_check \
     ${bindir}/fastrpc_test \
     ${libdir}/fastrpc_test/*.so \
     ${datadir}/fastrpc_test \


### PR DESCRIPTION
Upgrade fastrpc from version 1.0.6 to 1.0.7, bringing new utilities, performance improvements, bug fixes, and security hardening.

  ### **Changelog**

  **New Features**
  - Add DSP check utility and documentation
  - Add poll mode support for improved fastrpc performance
  - Add man pages for fastrpc and daemons

  **Bug Fixes**
  - Fix memory leaks in rpcmem_alloc_internal and handle-list
  - Fix ARM32 userspace pointer sign-extension on ARM64 kernel
  - Fix daemon restart behavior for SIGTERM and ENOMEM

  **Security**
  - Add missing input validation in remote API entry points

  **Full Changelog**
  https://github.com/qualcomm/fastrpc/compare/v1.0.6...v1.0.7