### PR TITLE
linux-qcom-next: update to tag qcom-next-7.2-rc7-20260820.2

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -10,7 +10,7 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "7.1+7.2-rc3"
+LINUX_VERSION ?= "7.1+7.2-rc7"
 
 PV = "${LINUX_VERSION}+git"
 
@@ -18,8 +18,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag: qcom-next-7.2-rc3-20260731
-SRCREV ?= "8d5dbc1b17adf8fe86a41adcda686785e73f5414"
+# tag: qcom-next-7.2-rc7-20260820.2
+SRCREV ?= "64d13ac76b4fac6f5c8dab3c7a4f5c7818d7a983"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.2-rc7-20260820.2, which corresponds to kernel version v7.2-rc7

Changelog:

| Name | SHA | Commits |
|------|-----|----------|
| tech/bsp/clk | `24b9b5e45f09d6d747e025eedd9a296f0b5bd1e9` | 32 |
| tech/bsp/devfreq | `480953456f9e3ec33a295dcca3ae1ad3fc55ac6e` | 7 |
| tech/security/firmware-smc | `de7413c5885e6106c7da9650d992ff2c0293525c` | 6 |
| tech/bsp/soc-infra | `ff6ff7b65a2f4ba4822a6a5343f949b43cd6e87f` | 22 |
| tech/bsp/pinctrl | `79149ef6a826d6237346aa74eca65ccbe19d761f` | 1 |
| tech/bsp/remoteproc | `39a86aa1e9c03be4b388d65a70fac68e69476be0` | 13 |
| tech/bus/peripherals | `e6f67411cde0905ca6034286f47f993cebed386e` | 8 |
| tech/bus/pci/all | `99d5cf2f33770c1850038f2fcfac7f98ce375ac5` | 45 |
| tech/bus/pci/phy | `66e44c2741ecc5bc40d8e66ee62ea5c5c179cbc7` | 14 |
| tech/bus/usb/dwc | `9dd47ad7e5c1dea9cfbcdd3f5e84af8d647af95f` | 3 |
| tech/bus/usb/phy | `c3aa7d5c9b171a9fb9ae9d1a9adf4dab251508f9` | 35 |
| tech/debug/hwtracing | `27d6059813d700717fdaf6c144693ab6a236d6e4` | 23 |
| tech/pmic/misc | `8d60b5132ccc7e3505569fd1c476f3b3ada16286` | 22 |
| tech/mem/iommu | `cdc9e8034c64ae939077d3780be625bea6b923e9` | 9 |
| tech/mm/audio/all | `88b8f29570c5211e654cec357e6a1282f92737b7` | 8 |
| tech/mm/camss | `dffc6e97f95f9c17ef21a558a29f96e54944017c` | 49 |
| tech/mm/drm | `209715ecd929604269ce01cd21239e1ae8d13fea` | 75 |
| tech/mm/fastrpc | `bff2f473e68a1a70c6998cf6648d75cd4a9a6bde` | 12 |
| tech/mm/video | `bdcc5c43477bf32b98214de3963e2ffdba31fa1e` | 127 |
| tech/mm/gpu | `0b8d9f42795065bb8e25714b5a169b59ae7e23a2` | 7 |
| tech/mproc/rpmsg | `55dc46433784180276e93105b359bdce601d492e` | 1 |
| tech/net/ath | `149122bebfa60c5f393153f5215fb77eab077698` | 20 |
| tech/net/bluetooth | `450dc5efa2636baf7a6ebb4c7b784d8529141245` | 7 |
| tech/pm/power | `f712532bb684387c2681cc912859b9d03e81457b` | 16 |
| tech/pm/thermal | `d525ff96debf4348da73f19056038b06864095b3` | 8 |
| tech/security/crypto | `1f60c0a2ca909753004854053ebac4cd45719e92` | 23 |
| tech/security/ice | `beabac03036a596434bb02c3f91b7c9672ea7c15` | 9 |
| tech/storage/all | `cef1b3c7fc3078e27ca66dd58e8f9fe86b0e077a` | 5 |
| tech/all/dt/qcs6490 | `740676bbcc99769adabe7b3037019b06167777c8` | 27 |
| tech/all/dt/qcs9100 | `0a48d61247aa4306f7ff83ceb8fdcbb7c06e55cc` | 92 |
| tech/all/dt/qcs8300 | `a02cf612f13f5efe97b10e2e228a8d727297632c` | 31 |
| tech/all/dt/qcs615 | `5cec04d74f3d04ab1dd2078a929752246d059d62` | 10 |
| tech/all/dt/agatti | `c828f10cd2c53b7ff2cc061e73b239973ee17bc6` | 1 |
| tech/all/dt/eliza | `5338032c5f8d1b9ad79a33cc6fb24e62b13d2668` | 25 |
| tech/all/dt/hamoa | `106f486e8dedb5371b83fdb0001f5e8ba70c8606` | 49 |
| tech/all/dt/glymur | `c5bf216cf0bb7c05d02a57021492d3d5452b09c0` | 60 |
| tech/all/dt/kaanapali | `d21ef73d814a2cf34e6c0850a8dfb9f796ba8ae9` | 26 |
| tech/all/dt/pakala | `33ecf6f10af6a446cb234b92f5579e23d7d0b8e8` | 14 |
| tech/all/config | `0e19c8689cccb93d91806b975dfc8ed2cf10a82c` | 76 |
| tech/overlay/dt | `b895d0e7537337daeeb814cea5cf764664b1bc36` | 78 |
| tech/all/workaround | `219d869a96c8fb79ab6c6604eaf61b0656c135ec` | 12 |
| tech/mproc/all | `104969c5b070fdc7bf93c7109c625b8b655a93ee` | 2 |
| tech/noup/debug/all | `e47307681abe61565162d394afd788b86d460ed4` | 29 |
| tech/hwe/unoq | `a2d85fe547167dbd8fc59618907c20a6f17d2e5a` | 4 |
| early/hwe/shikra/drivers | `b19d2ec290c8ae6fa2d3e8c1955413c4f20d4c3e` | 184 |
| early/hwe/shikra/dt | `dd90d88cfaad62aec33e4278bdd69b95aff0480d` | 130 |
| early/hwe/lyra | `d92faf9ccfd1376910986c5e7fa0e343c2eb1349` | 3 |

Fixes : 
https://github.com/qualcomm-linux/kernel/issues/982
