### PR TITLE
ci: fix remaining zizmor warnings / issues

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -147,12 +147,13 @@ runs:
         KERNEL_DIRNAME="${INPUTS_KERNEL_DIRNAME}"
         BUILDNAME="${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${KERNEL_DIRNAME}"
         FILENAME="build-url_${BUILDNAME}"
-        echo "${{ steps.upload_s3_artifacts.outputs.url }}" > "${FILENAME}"
+        echo "${UPLOAD_URL}" > "${FILENAME}"
         echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
       env:
         INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
         INPUTS_MACHINE: ${{ inputs.machine }}
         INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+        UPLOAD_URL: ${{ steps.upload_s3_artifacts.outputs.url }}
     - name: Upload build URL
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,10 @@
 name: Backport merged pull request
 on:
-  pull_request_target:
+  # pull_request_target is required here: the workflow must run with a write
+  # token after the pull request is closed. It only acts on merged pull
+  # requests (see the job condition) and checks out the base repository, so
+  # no pull-request-controlled code is ever executed.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [closed]
 permissions:
   contents: write # so it can comment

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -99,11 +99,15 @@ jobs:
           lookup-only: true
 
       - name: Report github-cache-check decision
+        env:
+          SKIP_IF_CACHED: ${{ inputs.skip_if_github_cached }}
+          CACHE_HIT: ${{ steps.restore.outputs.cache-hit }}
+          RUN_HASH: ${{ steps.hash.outputs.run_hash }}
         run: |
-          if [ "${{ inputs.skip_if_github_cached }}" != "true" ]; then
+          if [ "${SKIP_IF_CACHED}" != "true" ]; then
             echo "skip_if_github_cached not set; build will run"
-          elif [ "${{ steps.restore.outputs.cache-hit }}" = "true" ]; then
-            echo "Run cache hit on key build-success, hash ${{ steps.hash.outputs.run_hash }}: skipping build matrix"
+          elif [ "${CACHE_HIT}" = "true" ]; then
+            echo "Run cache hit on key build-success, hash ${RUN_HASH}: skipping build matrix"
           else
             echo "No previous successful build run recorded in github cache for this hash: build will run"
           fi

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -222,12 +222,13 @@ jobs:
           KERNEL_DIRNAME="${INPUTS_KERNEL_DIRNAME}"
           BUILDNAME="${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${KERNEL_DIRNAME}"
           FILENAME="build-url_${BUILDNAME}"
-          echo "${{ steps.upload_s3_artifacts.outputs.url }}" > "${FILENAME}"
+          echo "${UPLOAD_URL}" > "${FILENAME}"
           echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
         env:
           INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
           INPUTS_MACHINE: ${{ inputs.machine }}
           INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+          UPLOAD_URL: ${{ steps.upload_s3_artifacts.outputs.url }}
       - name: Upload build URL
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,19 +10,25 @@ on:
   - cron: "22 0 * * *"
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
 
 jobs:
   build-nightly:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/build-yocto.yml
     with:
       skip_if_github_cached: true
     secrets: inherit
   test-nightly:
     if: needs.build-nightly.outputs.build_skipped != 'true'
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test.yml
     needs: build-nightly
     secrets: inherit
@@ -30,6 +36,12 @@ jobs:
       build_id: ${{ github.run_id }}
   publish-test-results:
     if: needs.build-nightly.outputs.build_skipped != 'true'
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     needs: [build-nightly, test-nightly]
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,11 +10,7 @@ on:
       - '.github/.markdownlint.yaml'
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
-  actions: read
 
 jobs:
   event-file:
@@ -26,16 +22,24 @@ jobs:
       with:
         name: Event File
         path: ${{ github.event_path }}
-        
+
   pr-to-workflow-dependency:
     name: "PR To Workflow Dependency"
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: qualcomm/qcom-reusable-workflows/.github/workflows/qswat-reusable-pr-to-workflow-dependency.yml@qswat-release-v1
     with:
       workflow_id: ${{ github.run_id }}
       run_attempt: ${{ github.run_attempt }}
       pr_number: ${{ github.event.pull_request.number }}
-      
+
   build-pr:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/build-yocto.yml
     with:
       profile: pr

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           client-id: 2291458
           private-key: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
+          # Scope the token to what publish-unit-test-result-action uses
+          # instead of inheriting every permission of the app installation
+          permission-checks: write
+          permission-pull-requests: write
+          permission-contents: read
+          permission-issues: read
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,21 +6,33 @@ on:
       - master
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/build-yocto.yml
   test:
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test.yml
     needs: [build]
     secrets: inherit
     with:
       build_id: ${{ github.run_id }}
   publish-test-results:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     needs: test
     secrets: inherit

--- a/.github/workflows/test-pr-wrynose.yml
+++ b/.github/workflows/test-pr-wrynose.yml
@@ -3,7 +3,11 @@ name: Test PR build
 run-name: "Tests triggered by PR: ${{ github.event.workflow_run.display_title }}"
 
 on:
-  workflow_run:
+  # workflow_run is the intended privilege separation: the build runs
+  # unprivileged on pull_request (fork token is read-only) and this chain
+  # runs in the base context to submit LAVA jobs and publish results,
+  # consuming the build's artifacts as data, never executing its code.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Build on PR"]
     types:
       - completed

--- a/.github/workflows/test-pr-wrynose.yml
+++ b/.github/workflows/test-pr-wrynose.yml
@@ -9,15 +9,14 @@ on:
       - completed
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
-  actions: read
 
 jobs:
   determine-target-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       branch: ${{ steps.branch.outputs.value }}
     steps:
@@ -41,6 +40,11 @@ jobs:
   test-wrynose:
     needs: determine-target-branch
     if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'wrynose'
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: qualcomm-linux/meta-qcom/.github/workflows/test.yml@wrynose
     secrets: inherit
     with:
@@ -51,6 +55,10 @@ jobs:
     needs: [test-wrynose]
     if: always() && (needs.test-wrynose.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     steps:
 
       - name: Download Result Summary
@@ -96,6 +104,12 @@ jobs:
           pr-number: ${{ steps.pr_comment_prep.outputs.pr_number }}
 
   publish-test-results:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     secrets: inherit
     needs: [test-wrynose]

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,7 +3,11 @@ name: Test PR build
 run-name: "Tests triggered by PR: ${{ github.event.workflow_run.display_title }}"
 
 on:
-  workflow_run:
+  # workflow_run is the intended privilege separation: the build runs
+  # unprivileged on pull_request (fork token is read-only) and this chain
+  # runs in the base context to submit LAVA jobs and publish results,
+  # consuming the build's artifacts as data, never executing its code.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Build on PR"]
     types:
       - completed

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,15 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
-  actions: read
 
 jobs:
   determine-target-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       branch: ${{ steps.branch.outputs.value }}
       pr_number: ${{ steps.branch.outputs.pr_number }}
@@ -60,6 +59,11 @@ jobs:
   test:
     needs: determine-target-branch
     if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'master'
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
@@ -71,6 +75,10 @@ jobs:
     name: "Comment on PR"
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     steps:
 
       - name: Download Result Summary
@@ -120,6 +128,12 @@ jobs:
           comment-tag: test-results
 
   publish-test-results:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     secrets: inherit
     needs: [test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,5 +98,9 @@ jobs:
     steps:
       - name: Summary IDs
         id: generate-summary
+        env:
+          NODISTRO_SUMMARY_ID: ${{ needs.test-nodistro.outputs.summary_id }}
+          QCOM_DISTRO_SUMMARY_ID: ${{ needs.test-qcom-distro.outputs.summary_id }}
+          QCOM_DISTRO_6_18_SUMMARY_ID: ${{ needs.test-qcom-distro_linux-qcom-6-18.outputs.summary_id }}
         run: |
-          echo "artifact_ids=${{ needs.test-nodistro.outputs.summary_id }},${{ needs.test-qcom-distro.outputs.summary_id }},${{ needs.test-qcom-distro_linux-qcom-6-18.outputs.summary_id }}" >> $GITHUB_OUTPUT
+          echo "artifact_ids=${NODISTRO_SUMMARY_ID},${QCOM_DISTRO_SUMMARY_ID},${QCOM_DISTRO_6_18_SUMMARY_ID}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The org-required "GitHub Actions Security Scan (zizmor)" check currently fails on every pull request due to pre-existing high-severity findings in .github/ (#2901 fixed the github-env set; this series clears the rest).

- template-injection: expand step/job outputs via step env: blocks instead of interpolating ${{ }} into run scripts (actions/compile, build-yocto.yml, compile.yml, test.yml). The build-url artifact consumed by LAVA is unchanged.
- excessive-permissions: drop workflow-level checks/pull-requests: write in pr.yml, push.yml, nightly-build.yml, test-pr*.yml; each job now gets only what its steps and called reusable workflows declare.
- github-app: scope the test-reporting app token in publish-results.yml with permission-* inputs instead of inheriting the full installation.
- dangerous-triggers: annotate the by-design pull_request_target (backport) and workflow_run (test chain) triggers with the reviewed inline ignore the enterprise policy documents, with justification comments.

The unused actions/compile is fixed in place rather than dropped (#2455): the fixed action will first be copied to meta-qcom-distro (update to meta-qcom-distro#417), and then removed from this repository.