### PR TITLE
camx: revision update for Lemans, Talos,Kodiak

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.28.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.28.bb
@@ -1,9 +1,0 @@
-PLATFORM = "hamoa"
-PBT_BUILD_DATE = "260708"
-
-require common.inc
-
-SRC_URI[camxlib.sha256sum] = "911d809c27af900656936bfeb8513004e5971f0aaab45e1acccf1dfa69a07e94"
-SRC_URI[camx.sha256sum] = "20f3b57499e2192bbda194d178c403a120b8416877ecb9e829d4235e992eddbd"
-SRC_URI[chicdk.sha256sum] = "a2caf9c07acd7033d51d82eb7b8b2938d409582e094508a89399c70d6a14d14c"
-SRC_URI[camxcommon.sha256sum] = "f76c61c54b4a349d86aaf8611839ea0f29be19be2606f6142a6c5f8cc56db529"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.41.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-hamoa_1.0.41.bb
@@ -1,0 +1,29 @@
+PLATFORM = "hamoa"
+PBT_BUILD_DATE = "260826"
+
+require common.inc
+
+SRC_URI[camxlib.sha256sum] = "70208241d530536878c202ac512f4e39019827b9feb2ba9177d904416dbab198"
+SRC_URI[camx.sha256sum] = "7d2d59c06788a57487b43a0c6792b62822c8992718c15ab5811cdd03b169fc79"
+SRC_URI[chicdk.sha256sum] = "5896081c3200da9c497079e217cae2c616cfd610ea2f2c80a6c5a636052de6bf"
+SRC_URI[camxcommon.sha256sum] = "76b94b2af3ad33cf6ffcb768dfe42e85352adf231488e42b99de5575d191100e"
+SRC_URI[camxtest.sha256sum] = "ccf1b6430bb494b34a0db616c7f1f7940fed925531c76f1a8ed2a7211381609c"
+
+do_install:append() {
+    # copy skel file
+    install -d ${D}${datadir}/qcom
+    cp -r ${S}/usr/share/qcom/x1e80100 ${D}${datadir}/qcom/
+}
+PACKAGE_BEFORE_PN += "${PN}-skel"
+RDEPENDS:${PN} += "${PN}-skel"
+FILES:${PN}-skel = "${datadir}/qcom"
+# Algo librarires are pre-compiled, pre-stripped.
+# Skipping QA checks: 'already-stripped', 'arch', 'libdir' because:
+# - Library files are Pre-stripped  (already-stripped)
+# - skel binaries/library are not AArch64 (arch mismatch)      (arch)
+# - Files are installed under /usr/share (non-libdir path) (libdir)
+# - .so symlink is used for runtime DSP usage, not a dev artifact (dev-so)
+INSANE_SKIP:${PN}-skel += " arch libdir already-stripped dev-so"
+
+# Preserve ${PN}-skel naming to avoid ambiguity in package identification.
+DEBIAN_NOAUTONAME:${PN}-skel = "1"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.35.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-kodiak_1.0.35.bb
@@ -8,16 +8,18 @@ LICENSE = "LicenseRef-LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0 \
                     file://usr/share/doc/${BPN}/NOTICE;md5=04facc2e07e3d41171a931477be0c690"
 
-PBT_BUILD_DATE = "260708"
+PBT_BUILD_DATE = "260825"
 PBT_BRANCH = "master"
 SRC_URI = " \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/${BPN}_${PV}_armv8-2a.tar.gz;name=camxlib \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camx-kodiak_${PV}_armv8-2a.tar.gz;name=camx \
    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/chicdk-kodiak_${PV}_armv8-2a.tar.gz;name=chicdk \
+   https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxtest-kodiak_${PV}_armv8-2a.tar.gz;name=camxtest \
    "
-SRC_URI[camxlib.sha256sum] = "c8bc1baab12d2002a3a614b28c045868693a3a59a003b25b8a9236a0df7e941e"
-SRC_URI[camx.sha256sum] = "46a1d3d0682beb931e44cccdd47834b59a54004908441e4597ad11ced4f5d0c8"
-SRC_URI[chicdk.sha256sum] = "386f7cb21feffeb9ede8430e58c837f47ed988bc3980b3a7f2430dfbc67ae785"
+SRC_URI[camxlib.sha256sum] = "694c66493b5459bde8734ba416673ec93e5abdbabef5cbd9f86a60a52e09eb1b"
+SRC_URI[camx.sha256sum] = "7ab9838704139cbb52bc9c9c0277edaa2eabadf6dfd6719cf8aa93a4e7d9f29b"
+SRC_URI[chicdk.sha256sum] = "b0800ae386afa8f3ddac704d5e67a6f71d9a270acb3e2bc793a5b56a6d829417"
+SRC_URI[camxtest.sha256sum] = "26653dcaa7974c6b44fa5f3dc8560cd8d7f8b33c8ceae337ed0e43fb49d3e2a1"
 
 S = "${UNPACKDIR}"
 
@@ -61,9 +63,9 @@ do_install:append() {
     cp -r ${S}/usr/share/qcom ${D}${datadir}
 
     # Install bin files only if /usr/bin exists in ${S}
-    if [ -d "${S}${bindir}" ]; then
-        install -d ${D}${bindir}
-        cp -r ${S}/usr/bin/* ${D}${bindir}
+    if [ -d "${S}${libexecdir}" ]; then
+        install -d ${D}${libexecdir}
+        cp -r ${S}/usr/libexec/* ${D}${libexecdir}
     fi
 
     # Remove unnecessary development symlinks (.so) from the staged image
@@ -107,6 +109,7 @@ FILES:camx-kodiak = "\
     "
 FILES:chicdk-kodiak = "\
     ${libdir}/camx/kodiak/com.qti.feature2*${SOLIBS} \
+    ${libdir}/libcamxchiofflinepostproclib_kodiak*${SOLIBS} \
     ${libdir}/camx/kodiak/libchimldw*${SOLIBS} \
     ${libdir}/camx/kodiak/com.qualcomm*${SOLIBS} \
     ${libdir}/camx/kodiak/chiofflinepostproclib*${SOLIBS} \
@@ -121,7 +124,7 @@ FILES:chicdk-kodiak = "\
     ${libdir}/camx/kodiak/camera/*.bin \
     ${libdir}/camx/kodiak/camera/com.qti.sensor*${SOLIBS} \
     ${libdir}/camx/kodiak/hw/com.qti.chi.*${SOLIBS} \
-    ${bindir}/ \
+    ${libexecdir}/ \
     "
 FILES:${PN}-skel = "\
     ${datadir}/camx \
@@ -132,7 +135,6 @@ FILES:${PN} = "\
     ${libdir}/camx/kodiak/*${SOLIBS} \
     ${libdir}/camx/kodiak/hw/*${SOLIBS} \
     ${libdir}/camx/kodiak/camera/components/*${SOLIBS} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opencl', '${libdir}/camx/kodiak/*.cl', '', d)} \
     "
 FILES:${PN}-dev = "\
     ${libdir}/*${SOLIBSDEV} \

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.38.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-lemans_1.0.38.bb
@@ -1,12 +1,13 @@
 PLATFORM = "lemans"
-PBT_BUILD_DATE = "260708"
+PBT_BUILD_DATE = "260825"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum] = "b0ccf732368795b585f31779cdcf468e322a8480c763a209c8dc6566a60877a3"
-SRC_URI[camx.sha256sum] = "60a949a85590f6281fcae365bc30af0efc03c88716afae62e465add98b17ca8a"
-SRC_URI[chicdk.sha256sum] = "260b8522eeca0a1de4f658e424c343a35bc6855d0450d29c21252f5b29242f13"
-SRC_URI[camxcommon.sha256sum] = "1603dcb36647e9cd34d8c1c92cb653e7fb2de1b71744b4530054f2c9d690940d"
+SRC_URI[camxlib.sha256sum] = "d786afdae167643ad5feaad745ed14b741001060cf41e6174fe4f37cee8077f5"
+SRC_URI[camx.sha256sum] = "fd57a206aa1ae4dd6ac95f71ceb2812f995b5ebbf32322fe693186c7359b9770"
+SRC_URI[chicdk.sha256sum] = "31b7582c5c8f2f8a3412e9b99f3b689afda6b53efd1504d8864097ab73fd9c31"
+SRC_URI[camxcommon.sha256sum] = "e2a8645a8ae22182cd62e612ecbb1d098b7fcee4e75e42778b79a88b2587bcfb"
+SRC_URI[camxtest.sha256sum] = "628a94a198b5269812169e3bfbedf285b68cd3190e7102d9f076654fef3b9915"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual/libopencl1', '', d)}"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virtual/libgles2', '', d)}"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.38.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/camxlib-talos_1.0.38.bb
@@ -1,12 +1,13 @@
 PLATFORM = "talos"
-PBT_BUILD_DATE = "260708"
+PBT_BUILD_DATE = "260825"
 
 require common.inc
 
-SRC_URI[camxlib.sha256sum] = "eb95b7b3f733e189cd08df674d63604f7a1961c3985d537b7ec74eda48fcaa57"
-SRC_URI[camx.sha256sum] = "391d247d2350b48febe598cbf0cf63e4b70fe30c9a6a827def3eedf2ddaa2fdb"
-SRC_URI[chicdk.sha256sum] = "094e78c486d5c199590a7b74b264d5d2363f1c7383b14aba031294b3bc18db2e"
-SRC_URI[camxcommon.sha256sum] = "50771e2bc3c68c861b631001d9d2bcbc2b6af997fdd16b9ae84226232bd40982"
+SRC_URI[camxlib.sha256sum] = "bad5bb9ca3a99dda9665d0ddbe2f5ade10fb291ef7b954f279b378da9c56c63d"
+SRC_URI[camx.sha256sum] = "f2e356e96b84bf77a764b16fcb1d947854ea6feec8f04682bb3202b165aaa76d"
+SRC_URI[chicdk.sha256sum] = "4e6942bd426bb0dd9d5719674740c97f77e8ba4a17255e48a5ae9b554118082a"
+SRC_URI[camxcommon.sha256sum] = "3400a71accf286d0539d05f7b55e9f7269a77c31c833e83742163d613be45ed3"
+SRC_URI[camxtest.sha256sum] = "af51977b0cbd79e7d50088ac64ae643b98e1d7c11b0a419bd3319c88e185d258"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opencl', 'virtual/libopencl1', '', d)}"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virtual/libgles2', '', d)}"

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/common.inc
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/common.inc
@@ -22,6 +22,7 @@ SRC_URI = " \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camx-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camx \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/chicdk-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=chicdk \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxcommon-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camxcommon \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxtest-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camxtest \
 "
 
 S = "${UNPACKDIR}"
@@ -44,6 +45,11 @@ do_install:append() {
     if [ -d "${S}${bindir}" ]; then
         install -d ${D}${bindir}
         cp -r ${S}/usr/bin/* ${D}${bindir}
+    fi
+    # Install camera-nhx files only if /usr/libexec exists in ${S}
+    if [ -d "${S}${libexecdir}" ]; then
+        install -d ${D}${libexecdir}
+        cp -r ${S}/usr/libexec/* ${D}${libexecdir}
     fi
     # Remove unnecessary development symlinks (.so) from the staged image
     rm -f ${D}${libdir}/camx/${PLATFORM}/*${SOLIBSDEV}
@@ -100,7 +106,7 @@ FILES:chicdk-${PLATFORM} = "\
     ${libdir}/camx/${PLATFORM}/camera/*.bin \
     ${libdir}/camx/${PLATFORM}/camera/com.qti.sensor*${SOLIBS} \
     ${libdir}/camx/${PLATFORM}/hw/com.qti.chi.*${SOLIBS} \
-    ${bindir}/camx \
+    ${libexecdir}/ \
 "
 
 FILES:${PN} = "\

--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camx/common.inc
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camx/common.inc
@@ -22,7 +22,7 @@ SRC_URI = " \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camx-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camx \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/chicdk-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=chicdk \
     https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxcommon-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camxcommon \
-    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxtest-${PLATFORM}_${PV}_armv8-2a.tar.gz;name=camxtest \
+    https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/camxtest-${PLATFORM}_1.0.38_armv8-2a.tar.gz;name=camxtest \
 "
 
 S = "${UNPACKDIR}"

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Add-SELinux-policy-for-nhx.sh.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Add-SELinux-policy-for-nhx.sh.patch
@@ -1,6 +1,6 @@
-From 44c57cd405bda4974f7e10450ab8c74ab4cedf48 Mon Sep 17 00:00:00 2001
+From 205fb1f91d9055c315ff3fcd57579b36f57b2897 Mon Sep 17 00:00:00 2001
 From: Rohit Biradar <rohibira@qti.qualcomm.com>
-Date: Wed, 10 Jun 2026 00:05:54 +0530
+Date: Fri, 21 Aug 2026 01:17:34 +0530
 Subject: [PATCH] Add SELinux policy for nhx.sh
 
 The proprietary camera testing script 'nhx.sh' currently executes in the
@@ -15,9 +15,11 @@ their own confined domains:
 - qcom_nhx_t: For 'nativehaltest', granting access to the CamX framework,
   DMA, FastRPC, V4L video nodes, and camera cache directories.
 
-These tools are installed to /usr/bin/ and depends
-on the closed-source CamX framework. As such, this policy is inappropriate
-for upstream submission.
+'nhx.sh' is installed to /usr/bin/. 'nativehaltest' is installed to
+/usr/libexec/camx-<platform>/ rather than /usr/bin, since /usr/bin
+should hold only flat, directly user-invocable executables, not
+per-SoC subdirectories. Both depend on the closed-source CamX
+framework, so this policy is inappropriate for upstream submission.
 
 Upstream-Status: Inappropriate [Qualcomm specific change]
 
@@ -47,7 +49,7 @@ index 0000000..f2dda81
 +qcom_nhx = module
 diff --git a/policy/modules/services/qcom_nhx.fc b/policy/modules/services/qcom_nhx.fc
 new file mode 100644
-index 0000000..3562ddf
+index 0000000..439993f
 --- /dev/null
 +++ b/policy/modules/services/qcom_nhx.fc
 @@ -0,0 +1,10 @@
@@ -57,7 +59,7 @@ index 0000000..3562ddf
 +/usr/bin/nhx\.sh    --    gen_context(system_u:object_r:qcom_nhx_launcher_exec_t,s0)
 +
 +# Label nativehaltest binaries for different SoC families
-+/usr/bin/camx/.*/nativehaltest    --    gen_context(system_u:object_r:qcom_nhx_exec_t,s0)
++/usr/libexec/camx-[^/]*/nativehaltest    --    gen_context(system_u:object_r:qcom_nhx_exec_t,s0)
 +
 +# Label camera cache files
 +/var/cache/camera(/.*)?    gen_context(system_u:object_r:qcom_camera_cache_t,s0)

--- a/recipes-multimedia/camx/camxcommon-headers_1.0.38.bb
+++ b/recipes-multimedia/camx/camxcommon-headers_1.0.38.bb
@@ -5,10 +5,10 @@ DESCRIPTION = "This recipe provides headers for all Qualcomm CamX stacks"
 LICENSE = "LicenseRef-LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${BPN}/LICENSE.QCOM-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-PBT_BUILD_DATE = "260708"
+PBT_BUILD_DATE = "260825"
 PBT_BRANCH = "master"
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/camx.qclinux.0.0/${PBT_BUILD_DATE}/prebuilt_yocto_${PBT_BRANCH}/${BPN}_${PV}_armv8-2a.tar.gz"
-SRC_URI[sha256sum] = "3e4d94d6e15a1134a8302d0388683eefe62115b7d40fee06e564895c3176e48a"
+SRC_URI[sha256sum] = "f3e66fbea6c554d4e0d515a8810759719fce5753fa75ac1c5caa21a338c5dc31"
 
 S = "${UNPACKDIR}"
 


### PR DESCRIPTION
camxcommon-headers: Update to the 1.0.13 revision.

- Source/header mismatch causes CamX compilation failure.
- Update the headers tar to align with the sources.

camxlib-kodiak: Update to the 1.0.27 revision

- Correct defaultmctf type from INT to BYTE.
- Updated runtime feature library checks for EIS and LDC static capability publishing.
- Enabled dual VC mode support for BayerFusionStaticSHDR.
- Replaced static OpenCL linkage with dynamic loading in BayerFusionStaticSHDR and YUVFusionSHDR.
- Updated iwarp feature to dynamically load OpenCL/OpenGL libraries at runtime.
- Stop filtering OpenCL/OpenGL-related binaries based on DISTRO_FEATURES. These components are now loaded dynamically via dlopen(), allowing optional runtime availability without build-time dependency requirements.

camxlib-lemans: Update to the 1.0.30 revision

- Stop filtering OpenCL/OpenGL-related binaries based on DISTRO_FEATURES. These components are now loaded dynamically via dlopen(), allowing optional runtime availability without build-time dependency requirements.

camxlib-talos: Update to the 1.0.30 revision

- Fixed stride handling issues in the HIDRX library.
- Replaced static OpenCL linkage with dynamic library loading in the HIDRX library.
- Added static capability publishing support for EIS and LDC features.
- Enabled OX03F10 GMSL RAW10 linear mode on IQ615EVK Talos (1920x1536 @ 30fps, 2-lane, 512 Mbps), including sensor pipeline updates, output resolution fixes, embedded/stats data removal, and mirror mode disablement for the MAX96717/MAX96724 GMSL setup.
- Updated iwarp feature to dynamically load OpenCL/OpenGL libraries at runtime.
- Stop filtering OpenCL/OpenGL-related binaries based on DISTRO_FEATURES. These components are now loaded dynamically via dlopen(), allowing optional runtime availability without build-time dependency requirements.
