### PR TITLE
Add eDP display overlays for hamoa and purwa IoT EVKs

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -21,10 +21,12 @@ require conf/machine/include/fit-dtb-compatible.inc
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx] = "hamoa-iot-evk hamoa-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-staging] = "hamoa-iot-evk hamoa-evk-camx hamoa-staging"
 FIT_DTB_COMPATIBLE[qcom_hamoa-evk-camx-el2kvm] = "hamoa-iot-evk hamoa-evk-camx x1-el2 hamoa-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_hamoa-evk-edp] = "hamoa-iot-evk hamoa-iot-evk-edp"
 
 # ---------- purwa -----------
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx] = "purwa-iot-evk purwa-evk-camx"
 FIT_DTB_COMPATIBLE[qcom_purwa-evk-camx-el2kvm] = "purwa-iot-evk purwa-evk-camx x1-el2 purwa-camx-el2"
+FIT_DTB_COMPATIBLE[qcom_purwa-evk-edp] = "purwa-iot-evk purwa-iot-evk-edp"
 
 # ---------- lemans ----------
 

--- a/conf/machine/iq-x5121-evk.conf
+++ b/conf/machine/iq-x5121-evk.conf
@@ -13,6 +13,7 @@ KERNEL_DEVICETREE ?= " \
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/purwa-iot-evk-edp.dtbo \
     qcom/purwa-evk-camx.dtbo \
     qcom/purwa-camx-el2.dtbo \
 "

--- a/conf/machine/iq-x7181-evk.conf
+++ b/conf/machine/iq-x7181-evk.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE ?= " \
 
 # These DTs are not upstreamed and currently exist only in linux-qcom kernels
 LINUX_QCOM_KERNEL_DEVICETREE ?= " \
+    qcom/hamoa-iot-evk-edp.dtbo \
     qcom/hamoa-evk-camx.dtbo \
     qcom/hamoa-staging.dtbo \
     qcom/hamoa-camx-el2.dtbo \


### PR DESCRIPTION
Both Hamoa and Purwa IoT EVKs are available in headed and headless
variants. The headed variants use an eDP display panel connected via
the DP3 controller, while the headless variants do not include a
display.

The existing DT is causing the eDP-panel driver to probe an unavailable
panel, resulting in AUX probe timeouts and missing display modes.
Userspace then attempts display commits through the eDP connector,
causing repeated DPU vblank, frame-done, and IRQ timeout errors.

Move the eDP-specific nodes out of the base DTS files into separate
DTBO overlays for each board. This allows the base DTBs to be used
as-is for headless variants, while the composite DTBs enable eDP
support on headed variants.

CRs-Fixed: 4543794, 4543797