### PR TITLE
iq-615-evk: declare TPM2 machine feature

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs615.inc
 
-MACHINE_FEATURES += "efi kvm pci"
+MACHINE_FEATURES += "efi kvm pci tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \


### PR DESCRIPTION
This is a forward-port of #2938

Declare TPM2 as a supported machine feature for iq-615-evk. The platform provides dTPM support using ST33HTPH2X32AHE4.

This allows TPM-related packages to be conditionally included by the distro without affecting platforms that do not have TPM hardware support.