### PR TITLE
ci/qcom-distro.yml: Enable meta-ai layer (cherry-picked commits from master branch)

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -24,3 +24,5 @@ overrides:
             commit: c0d1d6200e7a84c39fb940cb1f22aad4b0b3d808
         meta-dpdk:
             commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
+        meta-ai:
+            commit: 23558d82906f6babdcf8e4575e51575e2dcac0bf

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -25,4 +25,4 @@ overrides:
         meta-dpdk:
             commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:
-            commit: 23558d82906f6babdcf8e4575e51575e2dcac0bf
+            commit: 60e38e2015f19058b467febd044f49bf70c4528f

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -24,6 +24,10 @@ repos:
       meta-python:
       meta-xfce:
 
+  meta-ai:
+    url: https://github.com/qualcomm-linux/meta-ai
+    branch: main
+
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization
 


### PR DESCRIPTION
Currently there is no support for building AI/ML inference runtimes in the CI configuration.
Add meta-ai, which is a standalone layer that hosts AI/ML recipes like onnx, onnxruntime, llama and tflite, to the CI configuration and pin it to a specific commit in base.lock.yml for reproducible builds.
