### PR TITLE
firmware-qcom-boot-shikra: upgrade 00053 -> 00065

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00053.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00053.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-shikra.inc
-
-SRC_URI[bootbinaries.sha256sum] = "f3f9508288c7d9b10119dae3e423fee3edfc74f720394b0204e3cbafa0fc9542"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00065.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00065.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-shikra.inc
+
+SRC_URI[bootbinaries.sha256sum] = "536415482ad869f65b727b5244dc82e3579d24e62cd9273ebbbed904159c3665"


### PR DESCRIPTION
The new firmware includes updates for Ethernet-related GPIO138 AC policy
handling as well as TZ access-control changes affecting TLMM XPU, eSE
SGPIO, TUI interrupt, and ARGC handling.

Signed-off-by: Arun Sahu <arunsahu@qti.qualcomm.com>