### PR TITLE
ci: update qcom-linux-testkit to testkit-2026.08.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.07.19"
+  TESTKIT_REF: "testkit-2026.08.14"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
Update TESTKIT_REF from testkit-2026.07.19 to testkit-2026.08.14

## Included updates

### qcom-linux-testkit
- Distro-aware audio, display, and sensor validation.
- New X11 graphics validation suites.
- Extended Weston validation across supported distributions.
- Ubuntu Bluetooth stack preparation.
- Support for dynamically instantiated M.2 Bluetooth controllers during firmware and KMD validation.
- New meta-qcom nightly test plans.
- Improved package installation handling.
- Audio timeout and result-reporting fixes.
- Workflow security and hardening fixes.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>