### PR TITLE
firmware-qcom-boot-iq-x7181: upgrade v00015 -> v00019

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00015.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00015.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6b12777ac79ec40665bc9aa5772d6f63a85306d4ecbdc66bcbb9ae2ec3797374"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00019.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00019.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "b26be9d7254fecae3732f20f98e519f3efc154efcb7e2e12888b321cfeb25a33"


### PR DESCRIPTION
firmware-qcom-boot-iq-x7181: upgrade v00015 -> v00019
Changelog:

feat: add PCIe USB hub enumeration and COM Express arch changes
feat: add FIT-based DT overlay support and update DDR size bits
feat: enable WWAN driver, new platform variant, and hypervisor DT fixup
feat: modularize UEFI firmware APIs into standard and enhanced variants
feat: add multi-stage device identity provisioning and secure enclave TA
feat: enable strongbox service, extend DRM support, add trusted UI
feat: introduce HDCP 2.2 RX session TA replacing legacy MEL-based impl
feat: add NIST SP800-108 counter-mode key derivation support

fix: resolve recovery and trial-boot ramdump path fallback handling
fix: correct external display detection on USB-C with sibling port off
fix: resolve UEFI compliance and protocol test failures for base boot
fix: address capsule crash, RPMB magic mismatch, file-close on Windows
fix: correct I2C init failure, SPI stall, and RTC alarm misconfiguration
fix: restore MPU global init and fix type-conversion in verified-boot
fix: resolve kernel panic from wireless subsystem restart under stress
fix: correct PCIe link-width negotiation to full x4 instead of x2
fix: resolve null-ptr deref in media session and OOB in key mgmt TA
fix: fix memory leak in provisioning and error propagation in DRM TA
fix: correct passcode retry throttle bypass allowing unlock after reboot
fix: resolve PKCS#11 object lookup failure after storage token init
fix: correct compiler warnings and KW-reported issues across TA modules

security: apply EDK2 patches for https://github.com/advisories/GHSA-fxqf-p2p3-gxvr and https://github.com/advisories/GHSA-w8rg-pqpr-83hp
security: fix OOB write in UEFI firmware update and key management TA
security: fix uncontrolled alloc in font manager and OOB read in key mgmt
security: restrict re-provisioning to enforce device identity hardening

chore: refresh TEE firmware to latest release
chore: update access-control policy, SDK tooling, and JTAG config