### PR TITLE
ci: publish-results: drop unsatisfiable app token scopes

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -57,12 +57,12 @@ jobs:
         with:
           client-id: 2291458
           private-key: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
-          # Scope the token to what publish-unit-test-result-action uses
-          # instead of inheriting every permission of the app installation
+          # Scope the token to what publish-unit-test-result-action uses on a
+          # public repository instead of inheriting every permission of the app
+          # installation. contents and issues are only needed on private repos,
+          # and the app is not granted issues at all.
           permission-checks: write
           permission-pull-requests: write
-          permission-contents: read
-          permission-issues: read
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0


### PR DESCRIPTION
Commit 4852ced7 ("ci: publish-results: scope test-reporting app token") scopes the token minted for the test-reporting app to checks and pull-requests write plus contents and issues read. The app is not granted the issues permission at all, and an installation token can only ever request a subset of what the installation holds, so create-github-app-token now fails with "The permissions requested are not granted to this installation" (HTTP 422). No token is minted, and the publish step that follows aborts with "GitHub token must be provided", which hides the real error. As a result the "Test Results" check is no longer published for pushes, nightly builds or the pull request test chain.

The scoping could not be exercised before merging, because the workflow that runs for a pull request is the one on the target branch.

publish-unit-test-result-action documents contents and issues read as needed on private repositories only. Request just checks and pull-requests write, which the app is granted and which cover the check run and the result comment on this public repository. The zizmor github-app finding that the scoping addresses stays clear, as the token remains scoped.

Assisted-by: Claude Code:claude-opus-5 [zizmor]