### PR TITLE
mesa: Backport A830v1 support patch

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI:append:qcom = " file://0001-freedreno-Add-support-for-A704.patch"
+SRC_URI:append:qcom = " file://0001-freedreno-Add-support-for-A704.patch \
+                        file://0001-freedreno-Add-chip-id-support-for-A830v1.patch \
+"
 
 # Enable freedreno driver
 PACKAGECONFIG_FREEDRENO = "\

--- a/recipes-graphics/mesa/mesa/0001-freedreno-Add-chip-id-support-for-A830v1.patch
+++ b/recipes-graphics/mesa/mesa/0001-freedreno-Add-chip-id-support-for-A830v1.patch
@@ -1,0 +1,29 @@
+From 68cfa0ffe069f5b06264d0b2e89df60e50c58932 Mon Sep 17 00:00:00 2001
+From: Lakshman Chandu Kondreddy <lkondred@qti.qualcomm.com>
+Date: Thu, 13 Aug 2026 20:14:20 +0530
+Subject: [PATCH] freedreno: Add chip-id support for A830v1
+
+Add initial support for A830v1 device in freedreno.
+Verified weston,glmark2-es2-wayland.
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/2061a5ee6184e465eafb87cf465aed92c04f1a41]
+Signed-off-by: Lakshman Chandu Kondreddy <lkondred@qti.qualcomm.com>
+---
+ src/freedreno/common/freedreno_devices.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/freedreno/common/freedreno_devices.py b/src/freedreno/common/freedreno_devices.py
+index 87b41904132..53a9ad4a6db 100644
+--- a/src/freedreno/common/freedreno_devices.py
++++ b/src/freedreno/common/freedreno_devices.py
+@@ -1382,6 +1382,7 @@ add_gpus([
+ 
+ add_gpus([
+         GPUId(chip_id=0xffff44050000, name="Adreno (TM) 830"),
++        GPUId(chip_id=0xffff44050001, name="Adreno (TM) 830v1"),
+         GPUId(chip_id=0x44050001, name="Adreno (TM) 830"), # KGSL
+     ], A6xxGPUInfo(
+         CHIP.A8XX,
+-- 
+2.34.1
+


### PR DESCRIPTION
The freedreno driver in the mesa version currently shipped via oe-core does not recognize the Adreno (TM) 830v1 GPU, so platforms with this GPU fall back to software rendering / fail to bring up GL.

Pull in the upstream Mesa fix as a temporary backport so A830v1 platforms get hardware acceleration in meta-qcom builds until oe-core advances to a mesa version that already contains it.