### PR TITLE
packagegroup-iq-615-evk: add qcc2072 WLAN/BT firmware

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq-615-evk.bb
@@ -10,8 +10,8 @@ PACKAGES = " \
 
 RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a612 linux-firmware-qcom-qcs615-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-qca6698aq linux-firmware-ath12k-qcc2072', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca6698 linux-firmware-qca-qcc2072', '', d)} \
     camxfirmware-talos \
     linux-firmware-qcom-qcs615-audio \
     linux-firmware-qcom-qcs615-compute \


### PR DESCRIPTION
Talos Lyra EVK has QCC2072 chip in addition to QCA6698. Add linux-firmware-ath12k-qcc2072 and linux-firmware-qca-qcc2072 so that WLAN/BT firmware bin files get packaged into the image.