### PR TITLE
refpolicy-targeted: Update qcom_nhx file contexts for new paths

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Add-SELinux-policy-for-camera-nhx.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-Add-SELinux-policy-for-camera-nhx.patch
@@ -1,23 +1,23 @@
-From 44c57cd405bda4974f7e10450ab8c74ab4cedf48 Mon Sep 17 00:00:00 2001
+From 16d3443363f3d9af299879f6cad588604f55dfdf Mon Sep 17 00:00:00 2001
 From: Rohit Biradar <rohibira@qti.qualcomm.com>
-Date: Wed, 10 Jun 2026 00:05:54 +0530
-Subject: [PATCH] Add SELinux policy for nhx.sh
+Date: Fri, 21 Aug 2026 01:17:34 +0530
+Subject: [PATCH] Add SELinux policy for camera-nhx
 
-The proprietary camera testing script 'nhx.sh' currently executes in the
+The proprietary camera testing script 'camera-nhx' currently executes in the
 generic 'initrc_t' domain. This configuration lacks proper process
 isolation and fails to define the specific permissions required
 by the 'nativehaltest' application it launches.
 
 Define a new policy module 'qcom_nhx' to transition these tools into
 their own confined domains:
-- qcom_nhx_launcher_t: For 'nhx.sh', allowing it to read
+- qcom_nhx_launcher_t: For 'camera-nhx', allowing it to read
   /sys/devices/soc0/soc_id for SoC detection.
 - qcom_nhx_t: For 'nativehaltest', granting access to the CamX framework,
   DMA, FastRPC, V4L video nodes, and camera cache directories.
 
-These tools are installed to /usr/bin/ and depends
-on the closed-source CamX framework. As such, this policy is inappropriate
-for upstream submission.
+'camera-nhx' is installed to /usr/bin/. 'nativehaltest' is installed to
+/usr/libexec/camx-<platform>/ and depends on the closed-source CamX
+framework. As such, this policy is inappropriate for upstream submission.
 
 Upstream-Status: Inappropriate [Qualcomm specific change]
 
@@ -47,17 +47,17 @@ index 0000000..f2dda81
 +qcom_nhx = module
 diff --git a/policy/modules/services/qcom_nhx.fc b/policy/modules/services/qcom_nhx.fc
 new file mode 100644
-index 0000000..3562ddf
+index 0000000..73c0a5a
 --- /dev/null
 +++ b/policy/modules/services/qcom_nhx.fc
 @@ -0,0 +1,10 @@
 +# File contexts for Qualcomm NHX camera test launcher
 +
-+# Label the nhx.sh launcher script
-+/usr/bin/nhx\.sh    --    gen_context(system_u:object_r:qcom_nhx_launcher_exec_t,s0)
++# Label the camera-nhx launcher script
++/usr/bin/camera-nhx    --    gen_context(system_u:object_r:qcom_nhx_launcher_exec_t,s0)
 +
 +# Label nativehaltest binaries for different SoC families
-+/usr/bin/camx/.*/nativehaltest    --    gen_context(system_u:object_r:qcom_nhx_exec_t,s0)
++/usr/libexec/camx-[^/]*/nativehaltest    --    gen_context(system_u:object_r:qcom_nhx_exec_t,s0)
 +
 +# Label camera cache files
 +/var/cache/camera(/.*)?    gen_context(system_u:object_r:qcom_camera_cache_t,s0)
@@ -158,7 +158,7 @@ index 0000000..2f73e8f
 +')
 diff --git a/policy/modules/services/qcom_nhx.te b/policy/modules/services/qcom_nhx.te
 new file mode 100644
-index 0000000..9ad9303
+index 0000000..2815ce2
 --- /dev/null
 +++ b/policy/modules/services/qcom_nhx.te
 @@ -0,0 +1,91 @@
@@ -182,7 +182,7 @@ index 0000000..9ad9303
 +
 +########################################
 +#
-+# qcom_nhx_launcher local policy (nhx.sh)
++# qcom_nhx_launcher local policy (camera-nhx)
 +#
 +
 +gen_require(`

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom = " \
-    file://0001-Add-SELinux-policy-for-nhx.sh.patch \
+    file://0001-Add-SELinux-policy-for-camera-nhx.patch \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', '', 'file://0002-Enable-the-tunable-flag-tee_supplicant_qtee.patch', d)} \
     file://0003-seatd-allow-self-fifo_file-read-write-for-signal-han.patch \
 "


### PR DESCRIPTION
'nhx.sh' was renamed to 'camera-nhx' and 'nativehaltest' moved from
`/usr/bin/camx/<soc>/` to `/usr/libexec/camx-<soc>/`, leaving the qcom_nhx
file contexts pointing at paths that no longer exist.

'nativehaltest' therefore matched the generic `/usr/libexec(/.*)?` rule and
was labeled `bin_t`, which `qcom_nhx_launcher_t` is already allowed to
`execute_no_trans` via `corecmd_exec_bin()`. The exec succeeded with no
domain transition and no AVC, leaving nativehaltest running in the launcher
domain and denying on permissions already granted to `qcom_nhx_t`.

Update the file contexts to track the new paths:

```
/usr/bin/nhx\.sh                ->  /usr/bin/camera-nhx
/usr/bin/camx/.*/nativehaltest  ->  /usr/libexec/camx-[^/]*/nativehaltest
```

No policy rules are changed.