### PR TITLE
Upgrade camera-service to 1.0.5

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.5.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.5.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/qualcomm/camera-service"
 
 SRC_URI = "git://github.com/qualcomm/camera-service;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "9f50e49824ed112593e6643a9197e03922cbc807"
+SRCREV = "1c3bc85b8cd35502b29895cc875c51bbcb2cb68f"
 
 # Limit this recipe to ARMv8 (aarch64) only, because it depends
 # on camxcommon-headers which is explicitly restricted to ARMv8 (aarch64).
@@ -23,7 +23,7 @@ DEPENDS += "\
     protobuf-native \
 "
 
-SYSTEMD_SERVICE:${PN} = "cam-server.service"
+SYSTEMD_SERVICE:${PN} = "qti-cam-server.service"
 
 # Split the recipe output into logical subpackages.
 PACKAGE_BEFORE_PN = " \


### PR DESCRIPTION
Upgrade camera-service recipes tag from 1.0.4 to 1.0.5

Highlights:
- Preserve client-set SWSHDRType Parameter.
- Fix build warnings and logging category.
- Expose camera feature capabilities via API for binder path.
- Port compatible codes related to GBM format from qmmf-server.
- Add missing Documentation key in service.
- Fix typos in log messages.
- Move check-camx-overlay.sh to libexec.
- Debian rules removed from source repo.
- Support P010 heif snapshot.
- Rename cam-server to qti-cam-server.
- Enable offlineIPE feature.