### PR TITLE
qcom-base: enable the qcomflash image type by default

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -51,9 +51,6 @@ local_conf_header:
     "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
-  qcomflash: |
-    IMAGE_CLASSES += "image_types_qcom"
-    IMAGE_FSTYPES += "qcomflash"
   extra: |
     DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"

--- a/ci/qcom-armv7a.yml
+++ b/ci/qcom-armv7a.yml
@@ -5,7 +5,4 @@ header:
   includes:
   - ci/base.yml
 
-local_conf_header:
-  qcomflash: |
-
 machine: qcom-armv7a

--- a/ci/qcom-armv8a.yml
+++ b/ci/qcom-armv8a.yml
@@ -5,7 +5,4 @@ header:
   includes:
   - ci/base.yml
 
-local_conf_header:
-  qcomflash: |
-
 machine: qcom-armv8a

--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -16,6 +16,11 @@ IMAGE_FSTYPES += "ext4"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
 
+# Ship the flashable package (boot firmware, partition tables and rootfs)
+# by default, it is the expected way of installing an image on these boards.
+IMAGE_CLASSES += "image_types_qcom"
+IMAGE_FSTYPES += "qcomflash"
+
 SERIAL_CONSOLES ?= "115200;ttyMSM0"
 
 QCOM_BOOTIMG_ROOTFS ?= "PARTLABEL=rootfs"


### PR DESCRIPTION
The configuration to enable qcomflash was only on the kas env which could lead to misconfiguration when users were not using kas.

Move the config to the inc file included as base machine configuration.

The 2 exception (armv7a and armv8a) only cleaned the qcomflash default, but they also don't include qcom-base.inc, so they will behave the same.

tested by building `core-image-minimal`  with machine `rb3gen2-core-kit`.

Fixes #2816 