### PR TITLE
iq10-rrd: bring up new machine (NORD SoC)

### DIFF
--- a/ci/iq10-rrd.yml
+++ b/ci/iq10-rrd.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: iq10-rrd

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -107,6 +107,7 @@ create_qcomflash_pkg() {
                 -name '*.fv' -o \
                 -name '*.img' -o \
                 -name 'cdt_*.bin' -o \
+                -name 'license.bin' -o \
                 -name 'logfs_*.bin' -o \
                 -name 'qsahara_*.xml' -o \
                 -name 'sec.dat' -o \

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -247,3 +247,7 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
 # ---------- glymur ----------
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"
+
+# ---------- nord ----------
+FIT_DTB_COMPATIBLE[qcom_qam8x97p-qam] = "nord-ride-sx"
+FIT_DTB_COMPATIBLE[qcom_nord-qam] = "nord-rrd"

--- a/conf/machine/include/qcom-nord.inc
+++ b/conf/machine/include/qcom-nord.inc
@@ -1,0 +1,17 @@
+# Configurations and variables for Nord SoC family.
+
+SOC_FAMILY = "nord"
+require conf/machine/include/qcom-base.inc
+require conf/machine/include/qcom-common.inc
+
+DEFAULTTUNE = "armv8-2a-crypto"
+require conf/machine/include/arm/arch-armv8-2a.inc
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-essential \
+    packagegroup-machine-essential-qcom-nord-soc \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    packagegroup-qcom-boot-additional \
+"

--- a/conf/machine/iq10-rrd.conf
+++ b/conf/machine/iq10-rrd.conf
@@ -1,0 +1,24 @@
+#@TYPE: Machine
+#@NAME: Qualcomm IQ10 RRD Reference Design
+#@DESCRIPTION: Machine configuration for the Qualcomm IQ10 RRD board, with Qualcomm Nord
+
+require conf/machine/include/qcom-nord.inc
+
+MACHINE_FEATURES += "efi pci"
+
+KERNEL_DEVICETREE ?= " \
+                      qcom/nord-rrd.dtb \
+                      qcom/nord-ride-sx.dtb \
+                      "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    packagegroup-iq10-rrd-firmware \
+    packagegroup-iq10-rrd-hexagon-dsp-binaries \
+"
+
+QCOM_CDT_FILE = "cdt_nord_ridesx_0.1.0"
+QCOM_BOOT_FILES_SUBDIR = "nord"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/iq10-rrd/ufs"
+
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-nord"
+QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-nord"

--- a/conf/machine/iq10-rrd.conf
+++ b/conf/machine/iq10-rrd.conf
@@ -8,7 +8,7 @@ MACHINE_FEATURES += "efi pci"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/nord-rrd.dtb \
-                      qcom/nord-ride-sx.dtb \
+                      qcom/nord-ride.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-nord.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-nord.inc
@@ -1,0 +1,14 @@
+DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Nord platform"
+LICENSE = "LicenseRef-LICENSE.qcom-2"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
+
+FW_ARTIFACTORY = "artifactory-las.qualcomm.com/artifactory/lint-lv-local/nord-test"
+BOOTBINARIES = "NORD_bootbinaries"
+
+SRC_URI = " \
+    https://${FW_ARTIFACTORY}/${BOOTBINARIES}.zip;name=bootbinaries \
+    "
+
+QCOM_BOOT_IMG_SUBDIR = "nord"
+
+include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-nord_00001.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-nord_00001.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-nord.inc
+
+SRC_URI[bootbinaries.sha256sum] = "3de641b121db3048e3c0823356cb34b6e192c6cf510e7d20d4315dbf6b77b7ac"

--- a/recipes-bsp/firmware-boot/firmware-qcom-cdt-nord.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-cdt-nord.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "CDT (Configuration Data Table) Firmware for Qualcomm Nord platform"
+
+SRC_URI = " \
+    https://artifactory-las.qualcomm.com/artifactory/lint-lv-local/nord-test/NORD_RIDESX_CDT.zip;downloadfilename=cdt-nord-ridesx_${PV}.zip;name=nord-ridesx \
+    "
+SRC_URI[nord-ridesx.sha256sum] = "645f21677f27f6c2ca897183ef8a5a82e2181ba83e4e6cf06a07e45906130a9e"
+
+QCOM_CDT_SUBDIR = "nord"
+
+include firmware-qcom-cdt-common.inc

--- a/recipes-bsp/packagegroups/packagegroup-iq10-rrd.bb
+++ b/recipes-bsp/packagegroups/packagegroup-iq10-rrd.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Packages for the IQ10-RRD platform"
+
+inherit packagegroup
+
+PACKAGES = " \
+    ${PN}-firmware \
+    ${PN}-hexagon-dsp-binaries \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'opencl opengl vulkan', 'linux-firmware-qcom-adreno-a702 linux-firmware-qcom-shikra-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
+    linux-firmware-qcom-vpu \
+"
+
+RDEPENDS:${PN}-hexagon-dsp-binaries = " \
+    hexagon-dsp-binaries-qcom-shikra-iqs-evk-cdsp \
+"

--- a/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
+++ b/recipes-bsp/packagegroups/packagegroup-machine-essential.bb
@@ -7,6 +7,7 @@ PACKAGES = " \
     ${PN}-qcom-generic \
     ${PN}-qcom-glymur-soc \
     ${PN}-qcom-hamoa-soc \
+    ${PN}-qcom-nord-soc \
     ${PN}-qcom-purwa-soc \
     ${PN}-qcom-qcm2290-soc \
     ${PN}-qcom-qcs615-soc \
@@ -133,6 +134,19 @@ RRECOMMENDS:${PN}-qcom-hamoa-soc += " \
     kernel-module-snd-soc-x1e80100 \
     kernel-module-tscrcc-x1e80100 \
     kernel-module-videocc-sm8550 \
+"
+
+RRECOMMENDS:${PN}-qcom-nord-soc += " \
+    ${PN}-board-generic \
+    ${PN}-qcom-generic \
+    kernel-module-ath12k \
+    kernel-module-camcc-nord \
+    kernel-module-dispcc-nord \
+    kernel-module-gpucc-nord \
+    kernel-module-pmic-glink \
+    kernel-module-pmic-glink-altmode \
+    kernel-module-pwrseq-qcom-wcn \
+    kernel-module-videocc-nord \
 "
 
 RRECOMMENDS:${PN}-qcom-purwa-soc += " \

--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/roshs189/qcom-ptool.git;protocol=https;nobranch=1"
-SRCREV = "e93468aabca34385fda314c1fa93d19bf91c7ea4"
+SRCREV = "874230aa60258b63585d0b3bf88e954bcd262c5d"

--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/roshs189/qcom-ptool.git;protocol=https;nobranch=1"
-SRCREV = "c5f2dc4c3a0da825fd6efc7f2994cb5bf59f6674"
+SRCREV = "e93468aabca34385fda314c1fa93d19bf91c7ea4"

--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -2,5 +2,5 @@ HOMEPAGE = "https://github.com/qualcomm-linux/qcom-ptool"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
-SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "e77a50d42f5b290b95ad8c33f32ed8f9c23bcc5e"
+SRC_URI = "git://github.com/roshs189/qcom-ptool.git;protocol=https;nobranch=1"
+SRCREV = "c5f2dc4c3a0da825fd6efc7f2994cb5bf59f6674"

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -18,13 +18,13 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag: qcom-next-7.2-rc3-20260731
-SRCREV ?= "8d5dbc1b17adf8fe86a41adcda686785e73f5414"
+# iq10-rrd (nord): wasimn-qc/kernel#5, qcom-linux-staging-0510b93a
+SRCREV ?= "da3014f8d3622af3ab02d019f10a24ee4dea3329"
 
-SRCBRANCH ?= "nobranch=1"
+SRCBRANCH ?= "branch=qcom-linux-staging-0510b93a"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"
 
-SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=https"
+SRC_URI = "git://github.com/wasimn-qc/kernel.git;${SRCBRANCH};protocol=https"
 
 # Additional kernel configs.
 SRC_URI += " \

--- a/recipes-kernel/linux/qcom-dtb-metadata/0001-Add-nord-support.patch
+++ b/recipes-kernel/linux/qcom-dtb-metadata/0001-Add-nord-support.patch
@@ -1,0 +1,37 @@
+From cd7e8affaef62340405a6e477ffa4c4b96e3e6c5 Mon Sep 17 00:00:00 2001
+From: Viswanath Kraleti <viswanath.kraleti@oss.qualcomm.com>
+Date: Fri, 10 Jul 2026 18:51:29 +0530
+Subject: [PATCH] Add Nord support
+
+Signed-off-by: Viswanath Kraleti <viswanath.kraleti@oss.qualcomm.com>
+Upstream-Status: Pending
+---
+ qcom-metadata.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/qcom-metadata.dts b/qcom-metadata.dts
+index 17b5028..878663a 100644
+--- a/qcom-metadata.dts
++++ b/qcom-metadata.dts
+@@ -24,10 +24,18 @@
+ 			msm-id = <0x00000294>;
+ 		};
+ 
++		nord {
++			msm-id = <0x00000288>;
++		};
++
+ 		purwa {
+ 			msm-id = <0x000002c7>;
+ 		};
+ 
++		qam8x97p {
++			msm-id = <0x000002b2>;
++		};
++
+ 		qcm6490 {
+ 			msm-id = <0x000001f1>;
+ 		};
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/qcom-dtb-metadata_1.0.bb
+++ b/recipes-kernel/linux/qcom-dtb-metadata_1.0.bb
@@ -7,7 +7,12 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
 DEPENDS += "dtc-native"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-dtb-metadata.git;branch=main;protocol=https;tag=v${PV}"
+SRC_URI:append = " file://0001-Add-nord-support.patch"
 
+# Nord SoC variants (nord and qam8x97p) have no entries in the upstream
+# qcom-dtb-metadata repository yet. This pending patch registers their
+# msm-ids so the kernel FIT image can be built. Drop once Nord support
+# lands upstream.
 SRCREV = "7fc788a9758b572cbbbea312332b6621823d55c0"
 
 INHIBIT_DEFAULT_DEPS = "1"


### PR DESCRIPTION
Adds conf/machine/iq10-rrd.conf, ci/iq10-rrd.yml, and supporting BSP recipes for iq10-rrd (board Ride, chipset NORD).

- Points qcom-ptool.inc at the head of https://github.com/roshs189/qcom-ptool/pull/14 (add/iq10-rrd) so the build picks up its partition files.
- Fixes image_types_qcom.bbclass qcomflash packaging to include license.bin for qweslicstore partitions.
- Points linux-qcom-next_git.bb at the head of https://github.com/wasimn-qc/kernel/pull/5 (qcom-linux-staging-0510b93a) which carries the nord-rrd/nord-ride DTS support.