### PR TITLE
Revert "ci: publish-results: drop unsatisfiable app token scopes"

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -57,12 +57,12 @@ jobs:
         with:
           client-id: 2291458
           private-key: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
-          # Scope the token to what publish-unit-test-result-action uses on a
-          # public repository instead of inheriting every permission of the app
-          # installation. contents and issues are only needed on private repos,
-          # and the app is not granted issues at all.
+          # Scope the token to what publish-unit-test-result-action uses
+          # instead of inheriting every permission of the app installation
           permission-checks: write
           permission-pull-requests: write
+          permission-contents: read
+          permission-issues: read
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0


### PR DESCRIPTION
Lately the test reporting workflow started to fail pointing out the token errors ('RuntimeError: GitHub token must be provided via action input or environment variable GITHUB_TOKEN'). Since the test reports publishing has worked beforehand, revert the seemingly offennding commit b7dac7b2c07a ("ci: publish-results: drop unsatisfiable app token scopes").
