### PR TITLE
[Backport Wrynose] firmware-qcom-boot-kaanapali: upgrade 0009.1 -> 00036

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali.inc
@@ -1,15 +1,13 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Kaanapali-MTP platform"
 LICENSE = "LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
-FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.0.0/qualcomm_linux.spf.0.0-test-device-public"
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Kaanapali_bootbinaries.1.0/kaanapali_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "kaanapali_bootbinaries"
 
 SRC_URI = " \
-    https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/common/build/ufs/bin/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r0.0_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/r0.0_${PV}/KAANAPALI.LE.0.0/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
     "
-SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "kaanapali"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali_00009.1.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali_00009.1.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-kaanapali.inc
-
-SRC_URI[bootbinaries.sha256sum] = "87b72830fd06ffd08ebc211301a254f4ef46325fde75bb6ff82ac558a5c26b12"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali_00036.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-kaanapali_00036.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-kaanapali.inc
+
+SRC_URI[bootbinaries.sha256sum] = "3efc9cbe88726a20f2bfedd7f59b508546f0ba66fddd397b50007ddbeef4af92"


### PR DESCRIPTION
Backport of #2950.

Tech pack based release path and versioning is for SPF agnostic paths across QLI targets. This enabled SP build label versioning of boot bins instead of release tag based versioning and explains the version bump to 00036.

Known fixes:
feat: Capsule update and Runtime services were enabled
