### PR TITLE
kgsl-dlkm: Update v1.0.11 ->  v1.0.12

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.12.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.12.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "72383caaef29830f77c5314945cddcd293d817f2"
+SRCREV = "a183ffbab70cc9fc2f29092bce45fcbe9111b410"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.12 brings below fixes:

- gen8: Enable aqe in gen8_1_0.
- gen8: Enable hwsched on gen8_1_0.
- Clear OPP ICC bandwidth votes during power off.
- Replace qcom_scm PAS wrappers with qcom_pas API.

Signed-off-by: Sumant Gupta <sumagupt@qti.qualcomm.com>
