### PR TITLE
iris-video-dlkm: kaanapali, sm8750: prioritize blacklisting iris_vpu to load qcom-iris

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
@@ -43,6 +43,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:qcs615 = "150"
 # On shikra, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:shikra = "150"
 
+# On kaanapali, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:kaanapali = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"

--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
@@ -46,6 +46,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:shikra = "150"
 # On kaanapali, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:kaanapali = "150"
 
+# On sm8750, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:sm8750 = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"


### PR DESCRIPTION
On kaanapali and sm8750, the iris_vpu out-of-tree driver does not
support the hardware. 

When iris-video-dlkm is installed (for example, in qcom-multimedia-proprietary-image),
the default update-alternatives priority activates `blacklist-video.conf.venus`,
which results in qcom_iris being blacklisted and prevents the in-kernel driver
from loading and functioning correctly.

Raise the update-alternatives priority of the `bl-vidc sub-package` to 150 ,
ensuring it takes precedence over bl-venus and becomes the active alternative.
This activates `blacklist-video.conf.vidc` , effectively blacklisting iris_vpu while
allowing qcom_iris to load and operate as expected.

Signed-off-by: Gourav Kumar [gouravk@qti.qualcomm.com](mailto:gouravk@qti.qualcomm.com)