### PR TITLE
u-boot-qcom: update SRCREV to latest qcom-next commit

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.07+2026.10-rc1+git"
 
-SRCREV = "7588f73ca1883188e422eadc0f8620da446cecb1"
+SRCREV = "be2aa51173238a0b6fe3f4dcf02f333e1a27ffbe"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Bump SRCREV from 7588f73ca188 to be2aa5117323 to pick up the latest fixes and updates from the Qualcomm u-boot tree.

Changelog:
- Add EFI capsule multi-payload support in mkeficapsule
- Extend Qualcomm capsule update support to update multiple firmware partitions instead of just the u-boot partition
- Add Shikra QMP USB3 PHY driver
- Add SC7280 interconnect driver; add SC7280 SDCC2 apps clock; enable shared RPMH clock driver on SC7280
- Keep PHY-sourced gate / PCIe pipe clocks unpolled (sa8775p, sc7280, qcs615, shikra)
- arm: dts: qcs6490-rb3gen2: drop pil_reserved_mem reservation