### PR TITLE
gst-plugins-imsdk-common: migrate source repository to qimsdk

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk-common.inc
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk-common.inc
@@ -9,9 +9,9 @@ inherit cmake features_check pkgconfig gobject-introspection
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-SRC_URI = "git://github.com/qualcomm/gst-plugins-imsdk;protocol=https;nobranch=1;tag=${PV}"
+SRC_URI = "git://github.com/qualcomm/qimsdk;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "806ad865287c418d2aac380506b7ad44b5a11319"
+SRCREV = "fa161fea87cd827a39fb4a428ffab3d34bff1339"
 
 DEPENDS += "\
     gstreamer1.0 \


### PR DESCRIPTION
## Summary

The IMSDK source tree has been consolidated into the `qimsdk`
repository and is no longer actively maintained in the legacy
`gst-plugins-imsdk` repository.

Update the `gst-plugins-imsdk-common` recipe to fetch sources from
`qimsdk` and update `SRCREV` accordingly.