### PR TITLE
ci: build-yocto: drop duplicate rt-6.18-distro-kvm matrix rows

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -267,6 +267,15 @@ jobs:
             dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
         exclude:
+          # 6.18 RT selects qcom-distro by default, remove others
+          - distro:
+                name: nodistro
+            kernel:
+                type: rt-6.18-distro-kvm
+          - distro:
+                name: qcom-distro-catchall
+            kernel:
+                type: rt-6.18-distro-kvm
           # Exclude jobs from compile_warm_up
           - machine: glymur-crd
             distro:


### PR DESCRIPTION
The rt-6.18-distro-kvm kernel axis appends ci/qcom-distro-kvm.yml after the distro fragment, and its include of ci/qcom-distro.yml overrides the distro and target list selected by the distro axis: the nodistro and qcom-distro-catchall rows build the exact same qcom-distro-kvm image as the qcom-distro row, wasting 32 jobs per run on duplicates.

Exclude the nodistro and qcom-distro-catchall rows for the rt-6.18-distro-kvm kernel type, keeping qcom-distro as the single qcom-distro-kvm build per machine and dropping the matrix to 221 configurations. The debug and performance rows are kept: their local.conf fragments still apply, so those builds are not duplicates.

Assisted-by: Claude Code:claude-fable-5