### PR TITLE
mesa: change SRC_URI indentation size

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,7 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI:append:qcom = " file://0001-freedreno-Add-support-for-A704.patch \
-                        file://0001-freedreno-Add-chip-id-support-for-A830v1.patch \
+SRC_URI:append:qcom = " \ 
+    file://0001-freedreno-Add-support-for-A704.patch \
+    file://0001-freedreno-Add-chip-id-support-for-A830v1.patch \
 "
 
 # Enable freedreno driver


### PR DESCRIPTION
The indentation used is different from that used in wrynose. Maintaining the same pattern in both branches facilitates interpretation when resolving conflicts in the backport process.