### PR TITLE
qcom-dtb-metadata: update to build version V1.1

### DIFF
--- a/recipes-kernel/linux/qcom-dtb-metadata_1.1.bb
+++ b/recipes-kernel/linux/qcom-dtb-metadata_1.1.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-dtb-metadata.git;branch=main;protocol=https;tag=v${PV}"
 
-SRCREV = "7fc788a9758b572cbbbea312332b6621823d55c0"
+SRCREV = "f1596a6b726c232743f968786de375a91d954eca"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Update SRCREV to pick up V1.1 tag

Changes since V1.0:

v1.1:
- Update qcom-next-fitimage.its: Add EL2KVM overlay support for Kodiak
- scripts: add --soc and --board filtering to build-dtb-image.sh
- scripts: fix --prune to handle mixed indentation in ITS blocks
- qcom-next-fitimage.its: fix indentation
- Update Stale Issues Workflow
- Add Nord support
- Revert "Merge pull request #124 from shashim-quic/nord"
- ci: trigger Build DTB Image workflow on pull_request events
- qcom-next-fitimage.its: Add Kodiak camx EL2/KVM configurations
- Update qcom-next-fitimage.its for Glymur Staging
- Update qcom-next-fitimage.its for kodiak camx overlay
- Add FIT support for Mahua CRD board
- fitimage: rename rb3gen2 industrial mezzanine UART BT overlay
- Update qcom-next-fitimage.its to add staging dtbo for Purwa