### PR TITLE
[Backport Wrynose] firmware-qcom-boot-sm8750: upgrade 00043 -> 00045

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm SM8750-MTP platform"
 LICENSE = "LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE.${BPN};md5=6e1bae7ef13289c332a27b917fb49764"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/SM8750_bootbinaries.1.0/sm8750_bootbinaries.1.0-test-device-public"
 
@@ -8,9 +8,7 @@ BOOTBINARIES = "pakala_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
-    https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     "
-SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"
 
 QCOM_BOOT_IMG_SUBDIR = "sm8750"
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00043.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00043.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-sm8750.inc
-
-SRC_URI[bootbinaries.sha256sum] = "e56b8cb82fd2566b9de9ca771e342dd7559bbfb51c94587a65c4ae395f605805"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00045.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-sm8750_00045.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-sm8750.inc
+
+SRC_URI[bootbinaries.sha256sum] = "376818f0c41e2356cbd2225ba467671ddb81a75e9c87ce040721a29b30b308cc"


### PR DESCRIPTION
Backport of #2973

Known fixes:
feat: Capsule update
feat: Runtime services were enabled


