### PR TITLE
Fix OP-TEE coexistence

### DIFF
--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom-kodiak_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom-kodiak_git.bb
@@ -4,3 +4,5 @@ OPTEEMACHINE = "qcom-kodiak"
 
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(qcom)"
+
+OPTEE_DEPLOY = "optee-kodiak"

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom-lemans_git.bb
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom-lemans_git.bb
@@ -4,3 +4,5 @@ OPTEEMACHINE = "qcom-lemans"
 
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(qcom)"
+
+OPTEE_DEPLOY = "optee-lemans"

--- a/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom.inc
+++ b/dynamic-layers/meta-arm/recipes-security/optee/optee-os-qcom.inc
@@ -5,3 +5,13 @@ PV = "4.10.0-qcom-20260721+git"
 SRC_TAG = "tag=qcom-next-4.10-20260721"
 SRC_URI = "git://github.com/qualcomm-linux/optee_os.git;protocol=https;name=optee;nobranch=1;${SRC_TAG}"
 SRCREV_optee = "690842e042dc470bf0625eb77a8cab926c372a8f"
+
+# Copy of do_deploy from meta-arm until we get it fixed to support configurable deploy dir
+OPTEE_DEPLOY ?= "optee"
+do_deploy() {
+    install -d ${DEPLOYDIR}/${MLPREFIX}${OPTEE_DEPLOY}
+    install -m 644 ${D}${nonarch_base_libdir}/firmware/* ${DEPLOYDIR}/${MLPREFIX}${OPTEE_DEPLOY}
+
+    install -d ${DEPLOYDIR}/${MLPREFIX}${OPTEE_DEPLOY}/ta
+    install -m 644 ${B}/ta/*/*.elf ${DEPLOYDIR}/${MLPREFIX}${OPTEE_DEPLOY}/ta
+}


### PR DESCRIPTION
`build world` in meta-qcom-distro pointed out that `optee-os-qcom-kodiak` and `optee-os-qcom-lemans` recipes conflict because both of them try deploying files to the same deploy dir. Enhance optee-os-qcom.inc to let each of the recipes to specify its own deploy dir. This doesn't affect TF-A building as it picks up BL32 from the staging sysroot rather than the deploy directory.

The `do_deploy()` override is local, it will be submitted to meta-arm after obtaining the permission.