### PR TITLE
[Backport wrynose] ci: build-yocto: drop duplicate rt-6.18-distro-kvm matrix rows

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -260,6 +260,15 @@ jobs:
             dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
         exclude:
+          # 6.18 RT selects qcom-distro by default, remove others
+          - distro:
+                name: nodistro
+            kernel:
+                type: rt-6.18-distro-kvm
+          - distro:
+                name: qcom-distro-catchall
+            kernel:
+                type: rt-6.18-distro-kvm
           # Exclude jobs from compile_warm_up
           - machine: glymur-crd
             distro:


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2993 to wrynose.