### PR TITLE
[wrynose] ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,17 +3,17 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: f09a0f28aeb54ddd90415dd458338e1565bb5a49
+            commit: ef022bf82d79015802309d14c28b13373ebe53f5
         meta-lts-mixins:
-            commit: 6ad95d00531b32ec01792ab496718943dc95277b
+            commit: 8bfc4ae8cf7fc835a23d7a27830f866617d9808f
         bitbake:
-            commit: fae9db3168dbff1b8c76fe9c6726a9687ff97514
+            commit: 0ad6c1c34a5e07a5f8dd66ab248c1e7b37b69fa9
         meta-arm:
             commit: 0979b80429099f1a42dc0026c8c466cee780bc74
         meta-openembedded:
-            commit: 6bf0d8ad57b33950bab4c7f6c037e1ccb6f6e2eb
+            commit: 14282a02be9c74a1276a7cda7d6c89e054699a11
         meta-virtualization:
-            commit: ff03b1e118c4788f17d7ae45b820b00e3194634a
+            commit: aab9c1a0dd6b48776c9f372a32c32486c560b9c9
         meta-audioreach:
             commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:

--- a/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260810.bb
+++ b/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_20260810.bb
@@ -13,7 +13,7 @@ LICENSE = " \
 LIC_FILES_CHKSUM = "\
     file://LICENSE.qcom;md5=56e86b6c508490dadc343f39468b5f5e \
     file://LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0 \
-    file://WHENCE;md5=ba0674c526f9fdc6f687dc13cb432f31 \
+    file://WHENCE;md5=eee256607278e4eebd2eba4193d0bd9c \
     file://conf.d/hexagon-dsp-binaries-qualcomm-iq9075-evk.yaml;endline=2;md5=077232564320a8fce4ea446daad3d726 \
 "
 NO_GENERIC_LICENSE[dspso-qcom] = "LICENSE.qcom"
@@ -24,7 +24,7 @@ SRC_URI = " \
     git://github.com/linux-msm/dsp-binaries;protocol=https;branch=trunk;tag=${PV} \
 "
 
-SRCREV = "2ba83638b373c0a6bbb7ecb32f5e2b9dfca2c4ce"
+SRCREV = "7780697e3de9d7afbecc3f0a4dbad30fe449d73a"
 
 inherit allarch
 

--- a/recipes-kernel/linux-firmware/linux-firmware/0001-qcom-sa8775p-update-signature-on-cdsp1-firmware.patch
+++ b/recipes-kernel/linux-firmware/linux-firmware/0001-qcom-sa8775p-update-signature-on-cdsp1-firmware.patch
@@ -1,0 +1,66 @@
+From 9e3ce788d41254ed7b2936a94f95177ffdebd0a0 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Tue, 25 Aug 2026 23:34:47 +0300
+Subject: [PATCH] qcom/sa8775p: update signature on cdsp1 firmware
+
+The CDSP1 firmwre from the commit 0b1b0d6f1623 ("qcom: Update DSP
+firmware for sa8775p platform") didn't contain the correct test
+signature, which made TZ reject it. Change it to the file with the
+correct signature.
+
+Fixes: 0b1b0d6f1623 ("qcom: Update DSP firmware for sa8775p platform")
+Upstream-Status: Backport [https://gitlab.com/kernel-firmware/linux-firmware/-/commit/9e3ce788d41254ed7b2936a94f95177ffdebd0a0]
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ qcom/sa8775p/cdsp1.mbn | Bin 3170304 -> 3174400 bytes
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+diff --git a/qcom/sa8775p/cdsp1.mbn b/qcom/sa8775p/cdsp1.mbn
+index a92dca82e68de3a4b829cec8d7fa00408db91b3c..a2ea2424e985beaa620f2286132e522d4832ac4b 100644
+GIT binary patch
+delta 2684
+zcmchZ3se==8pmhm%sFs)odbtA!ugc9pzHx5C47Y>##;{QLVTbNFNr~30cHc|dbh4s
+zC!rHkMm~bN*fKK|Q7{#e%3MK)3gQFqqARYX0x>f!Z6ClDwCLV-t<|jA-|TPCp1tRr
+z@Auz(N=`P@CB4mb*>kp(6-A8{iee}wMbX5iP<gSMK2W|x%}`8vlM6$!<(FM(W%)fd
+zjr5MRnpWzAi3NS)NWGZYHToUI?$$RFdqCe!Z0x~%w5^5hRx&6hF^o!4X`>ek%=I2h
+zEeiYoszqybP>q6@D&;T#&^3JNVw-uZTf|S{r^Tg$=UEj$P}~&7tF~^so81>!sL=nr
+z0v$BA+|7uHXAq;V7;JxHaK2~kV4+m*JhP>_|BPbGHbu|0!`JJJ%uFlJ<<F?!^WEaQ
+zr1_U))m<J8M}4$1I(%h(BhROnz1x`U+p;ar-KG1T<!w_VUO&D0eH)$AvEqlFC(j?B
+zy*|n4@{ezYP)N%hA|-gYgrOORrjd!vcsdRj+vc(o2`a7QOp#nBNnm9vCLx~lMbizA
+zMCBSE7OIJfiHrwQi4B-NYbghz2}_?115H@G2A0OeXb@+Gl!o3$DtUZz7A#8VQw7cv
+zDGY5UD&x3>g^{5#QBj;DvNtrDsw_hnMJ)skzb-9H6f%X>bUv5!M`-k>_hLSa&q>aN
+zgj}BV$<2cZz6cO_r3g8YNBs1xR1mT<i@cGGow<Jyn(ZIxj{;DDf1;iFEQ5>2T$C~~
+zC>63aOku1t2~EySC&Oi>CySgDaxk<?R95l)I*lM?=8n!vrq3A{#iN^(1&a#E2QVUE
+zvu!Rz%cMS~EHzECmSU^635~aVJRMc96im&hl{hK%to!m$=nGBjoz8W=q_5oKxKEVF
+z4BeF`&ak-iA3>$KX;Yq9**dfT_R+pz{*8N8|J)mRA??|9!|pPhm`J|TgQ`egzIwPB
+zj@BNE9$q%(LA8LMM{4r=&aSLIvMsURPTzUqe#0A!qWo*63-Xq?zp0JfF_Kqj70VzB
+znHu^kSXROql^_*yL}z!_%)o+=jFw7`2nx=IE*7jUYi)e`$#2=$7QLC*|LxG>klO`U
+zZWKk0VKYLFB#k2Ua#Rb`y0vZXg_Z~Vo_wKwmz&Lt8|!D>IrY=|(!N=a&##y|)Z=53
+zbN`pP#N?f4+&)f@yUCy&;e1uwElt2%N5s0JjNUx^d(kgK$u9#-!cMj)(Z{oz=dRB=
+z;5paBtNzZ*8ENYiP7!hkNy+~my<_lxI5E#Y$eYAKGCJ*l!z)gf&v9x0ukb!%7onMk
+z2~Aa=ld?NGxm*xImJ|KCKyngv1BlNBjk$lDAjQ!aAE(GiK|PKj|3C*?jnke@XQv#r
+zUgF-gXJ3qd#kugiKX+tf=OayG>B_wqSV(Eucx#DYsOzmcsSCc@a5bV(JKriJ?3JpH
+zBKw88W#_BX8a%hU`8w9ue{ac#n`HC%cit%a&MLde;%sc7^}7z$YtX6*IuKM_HZ*vC
+zcG`^2y(z!A%Vyq&6Kltj{hLh0aXK+9SVSkrNJi5S8G5{0XxRkt(<zifz%M(cRj+2l
+zm31G?aR}+&bi4hU{EO=9#;)#;wc6l<-s=6#DrwN+uYE$!t)LzbGeP8$TPb-rT5cR#
+zR=lp@LF@5<xQSN=E`H=Sr&V5Ww&0SBn01W){Ny$7l+D%iUUzs}*Hbr(Q2!Yz(SJGl
+zqu`5=w`@Ox<WG=4LOLf-B%ez}rGG-r|G${U-?pO1kLeGv4``|>eEX$N^H09o+iTQ(
+z#jmqwW95UM*rLXav^AGIpIF^7Q1hx-d-F)fs`Bm#PI$-dQl=)=Y~?}S=UsbrE861Y
+zwrvOkOTVvU6F)5bxK<d@1Yi5t5%+Y9tK7Uzb(?#)uc;0}!Q-f&6ne8!sHI3kpdPpW
+zj}a{zHZAf8FuInb{C!?E4xw|7<-dJ>f4|1dV|!9<WQZ<rzuk4|r%x5w>H2!koOrMB
+z8Ewavl3d%Mgo}jeAH(~O`<12HxXu<lJWO6y{A^lreV+4TY4R4Gbf-qPyHn@g+VAVu
+zp#JL1Wj~zIl{}nqR0_N3p~~!C^x!1sXl0qJld?gnb{#a=0tOlbgF%9U#URBX!(fEL
+z7=s*x2?kRPW*E#dSYS|KP-3veV1+@2!5V`N23rhv80;}PU~t6XgkcH>XACYF)ELP4
+oQ!z}#;EKTwgF6Nf44xRgFnD8_j==|mFNPTyW@7Mr572^N0k|thZU6uP
+
+delta 337
+zcmW;Ey)Q#i00r=SUt3zLUR8^hzSc(-EoU}JCl-SUB4YFhNK6_-V>s4ccW9KMX+%nh
+zNPPqY4}S%V(b%~buTFA)Inyb8+p_R#%i>m~<`SY+Cx$SEkgb(ac}rGQ*)keZJ;#lP
+zOMS(qP)$oFbW~bW=vhZoZ~X7P<B~2r7WI>3MSnWx>P;C5ctq>GbaRpkshnG9%sr?%
+z^M2*_XW?<pzB>+uSI-aKRp0JM?Z8TJUngGzmy6ZZg{YstzisXu{brX-_LW548>|=)
+z=6r13zYjtZ2H_&ygokJ&+6gb=BRYsq!cTM&0iv5Qi6GHKgos`uOhkx2qMsNbqC|`s
+oB!-AMVG#);NemMs#3(UFq=<1MO-vAz#1xSsvcxnoa|Y!80OZtU2><{9
+
+-- 
+2.43.0
+

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -7,6 +7,12 @@ DEFAULT_PREFERENCE:layer-lts-linux-firmware-mixin:qcom = "1"
 ALTERNATIVES_CLASS = ""
 ALTERNATIVES_CLASS:qcom = "update-alternatives"
 
+PATCHTOOL:qcom = "git"
+
+SRC_URI:append:qcom = " \
+    file://0001-qcom-sa8775p-update-signature-on-cdsp1-firmware.patch \
+"
+
 inherit_defer ${ALTERNATIVES_CLASS}
 
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo


### PR DESCRIPTION
Refresh base.lock.yml pins to the latest available SHAs on each REPO's branch.

Changes in oe-core:
  - ef022bf82d build-appliance-image: Update to wrynose head revisions
  - 3b859a1f3e oe-selftest: fitimage: Add tests for KERNEL_DTBVENDORED
  - d78d6a1e3d kernel-fit-image: Add KERNEL_DTBVENDORED support for FIT_CONF_DEFAULT_DTB
  - 2f47b623ea kernel-fit-image.bbclass: Fix operation with KERNEL_DTBVENDORED = "1"
  - d2f89f7348 kernel-fit-image.bbclass: Do not include kernel property in DTBO config subnodes
  - 144e5cfa56 oe-selftest: fitimage: Do not expect kernel property in DTBO config subnodes
  - d2ff23667c python3-pip: set CVE_PRODUCT
  - f4d42e7aa4 gstreamer1.0: set status for CVE-2026-5056
  - dc0e9d0444 cpan_build: disable .packlist and html doc
  - 1ea67ed48e python3-idna: set CVE_PRODUCT
  - 7ac5762dd6 python3-certifi: set CVE_PRODUCT
  - e61f182707 python3-xmltodict: set CVE_PRODUCT
  - 3a6b58e394 python3-pyyaml: set CVE_PRODUCT
  - f228ddb095 python3-pyopenssl: set CVE_PRODUCT
  - e9c66d46cb bind: upgrade 9.20.23 -> 9.20.26
  - 19e2414c7e selftest: uboot: remove duplicated KVM presence test

Changes in meta-lts-mixins:
  - 8bfc4ae8cf README: ajust formating and add note about fixing license syntax
  - a234646ffc linux-firmware: fix license syntax
  - 71ff2b1b1f linux-firmware: upgrade 20260622 -> 20260810
  - 5edcd300e5 linux-firmware: fix typo Firwmare/Firmware in one of the LICENSEs
  - 9cf8b6a0e5 linux-firmware: Convert to SPDX license strings

Changes in bitbake:
  - 0ad6c1c34a doc: bitbake-user-manual-environment-setup: use pip to install bitbake-setup

Changes in meta-openembedded:
  - 14282a02be libhtml-tree-perl, libmodule-build-tiny-perl: Drop obsolete TMPDIR scrubbing
  - 4ddd1e3945 python3-httplib2: correct CVE_PRODUCT mapping
  - ecbab436e2 python3-web3: add CVE_PRODUCT mapping
  - a02e847fa2 swagger-ui: upgrade 5.32.13 -> 5.32.14
  - f136fe167f samba: upgrade 4.23.8 -> 4.23.11
  - 56fc67a07e swagger-ui: upgrade 5.32.12 -> 5.32.13
  - 2af3c02179 swagger-ui: upgrade 5.32.11 -> 5.32.12
  - 8990cb5a3c cjose: upgrade 0.6.2.7 -> 0.6.2.8
  - 8eaa3ca840 python3-psycopg: upgrade 3.3.3 -> 3.3.4
  - edca03fca9 python3-filelock: set CVE_PRODUCT
  - 206b109aae gvfs: upgrade 1.60.1 -> 1.60.2
  - 46133d7aed gvfs: upgrade 1.60.0 -> 1.60.1
  - 628008e12b gdm: upgrade 50.1 -> 50.2
  - 56e5e164b0 gnome-software: upgrade 50.0 -> 50.3
  - 411e417600 file-roller: upgrade 44.5 -> 44.7
  - 0d7e0d0dbf firewalld: upgrade 2.2.1 -> 2.2.3
  - 6b815fe901 postfix: upgrade 3.10.12 -> 3.10.13
  - aa6d643ec8 libsdl3: upgrade 3.4.4 -> 3.4.8
  - c6650604cf libsdl3-image: upgrade 3.4.2 -> 3.4.4
  - fe0503d236 hiredis: upgrade 1.3.0 -> 1.3.1
  - 56f07f3e89 thin-provisioning-tools: upgrade 1.3.1 -> 1.3.3
  - e4ed510b63 redis: avoid LTO for clang builds
  - fb2bca0962 libssh: upgrade 0.11.4 -> 0.11.5
  - 039e0dea33 python3-web3: Fix CVE-2026-40072
  - 34800488de python3-ujson: Fix CVE-2026-54911
  - b9fb63c09a python3-httplib2: upgrade 0.31.2 -> 0.32.0
  - 2fb2b9fb1d python3-twisted: Fix CVE-2026-42304
  - 8519105eec python3-pyjwt: Fix CVE-2026-48526
  - 5fd7815f34 python3-pyjwt: Fix CVE-2026-48525
  - 8a6759f036 python3-pyjwt: Fix CVE-2026-48524
  - 79accf77d2 python3-pyjwt: Fix CVE-2026-48523
  - 242530c3e4 python3-pyjwt: Fix CVE-2026-48522
  - d070b08b56 python3-aiohttp: fix CVE-2026-54280
  - bf97296869 python3-aiohttp: fix CVE-2026-54279
  - 813105c96d python3-aiohttp: fix CVE-2026-54278
  - 45e39122a3 python3-aiohttp: fix CVE-2026-54277
  - 4061d30051 python3-aiohttp: fix CVE-2026-54276
  - 22f7bc5b39 python3-aiohttp: fix CVE-2026-54275
  - 81b7b1e1c7 python3-aiohttp: fix CVE-2026-54274
  - 6de7cbdd5b python3-aiohttp: fix CVE-2026-50269
  - 1936909624 python3-aiohttp: fix CVE-2026-47265
  - e389fd34bc python3-aiohttp: fix CVE-2026-34993
  - 8aff5f4d15 giflib: Fix CVE-2026-26740
  - b3470f0633 openvpn: fix CVE-2026-13117
  - df411c8098 poppler: fix CVE-2026-10118
  - 3463973c5e libfastjson: fix rsyslogd segfault crash at load
  - 6a8a0b46d6 mpd: fix build error with libupnp v1.14.30 onwards
  - 5fe702bec3 jq: fix CVE-2026-39956
  - 6afddbfda3 vboxguestdrivers: Provide target kernel version

Changes in meta-virtualization:
  - aab9c1a0dd container-bundle: select the target arch when fetching multiarch containers
  - dad91fe74c vruntime: assert 'virtualization' on the vdkr/vpdmn rootfs images
  - eb7bb50008 vruntime: declare 'virtualization' so the distro is self-contained
  - ccc8f8c7b1 vruntime: stop masking cgroup-lite (docker hard-depends on it)
  - 30f1a9d7e5 python3-webob: update to 1.8.10