### PR TITLE
linux-qcom-next: update to tag qcom-next-7.2-20260826

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -10,7 +10,7 @@ COMPATIBLE_MACHINE = "(qcom)"
 
 LINUX_QCOM_FIT_DTB_COMPATIBLE = "conf/machine/include/fit-dtb-compatible-linux-qcom.inc"
 
-LINUX_VERSION ?= "7.1+7.2-rc7"
+LINUX_VERSION ?= "7.2"
 
 PV = "${LINUX_VERSION}+git"
 
@@ -18,8 +18,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag: qcom-next-7.2-rc7-20260820.2
-SRCREV ?= "64d13ac76b4fac6f5c8dab3c7a4f5c7818d7a983"
+# tag: qcom-next-7.2-20260826
+SRCREV ?= "d49c33864d06e9672dce57738be8851384578fcf"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-next"


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.2-20260826, which corresponds to kernel version v7.2

Changelog:

| Name | SHA | Commits |
|------|-----|----------|
| tech/bsp/clk | `24b9b5e45f09d6d747e025eedd9a296f0b5bd1e9` | 32 |
| tech/bsp/devfreq | `480953456f9e3ec33a295dcca3ae1ad3fc55ac6e` | 7 |
| tech/security/firmware-smc | `de7413c5885e6106c7da9650d992ff2c0293525c` | 6 |
| tech/bsp/soc-infra | `ff6ff7b65a2f4ba4822a6a5343f949b43cd6e87f` | 22 |
| tech/bsp/pinctrl | `79149ef6a826d6237346aa74eca65ccbe19d761f` | 1 |
| tech/bsp/remoteproc | `39a86aa1e9c03be4b388d65a70fac68e69476be0` | 13 |
| tech/bus/peripherals | `e6f67411cde0905ca6034286f47f993cebed386e` | 8 |
| tech/bus/pci/all | `99d5cf2f33770c1850038f2fcfac7f98ce375ac5` | 45 |
| tech/bus/pci/phy | `66e44c2741ecc5bc40d8e66ee62ea5c5c179cbc7` | 14 |
| tech/bus/usb/dwc | `d90fb648965d84287c830a389cc7c0981d3ecc3a` | 4 |
| tech/bus/usb/phy | `c3aa7d5c9b171a9fb9ae9d1a9adf4dab251508f9` | 35 |
| tech/debug/hwtracing | `a3f730f4921cc857f8c3e526eb70c64004f26a87` | 24 |
| tech/pmic/misc | `8d60b5132ccc7e3505569fd1c476f3b3ada16286` | 22 |
| tech/mem/iommu | `cdc9e8034c64ae939077d3780be625bea6b923e9` | 9 |
| tech/mm/audio/all | `88b8f29570c5211e654cec357e6a1282f92737b7` | 8 |
| tech/mm/camss | `dffc6e97f95f9c17ef21a558a29f96e54944017c` | 49 |
| tech/mm/drm | `83f65e13cce094e96a295b5bfeb95f6bcfe54b04` | 76 |
| tech/mm/fastrpc | `bff2f473e68a1a70c6998cf6648d75cd4a9a6bde` | 12 |
| tech/mm/video | `bdcc5c43477bf32b98214de3963e2ffdba31fa1e` | 127 |
| tech/mm/gpu | `b9f22911e1899caf7a0cc4f839ebf99ae43155b4` | 12 |
| tech/mproc/rpmsg | `55dc46433784180276e93105b359bdce601d492e` | 1 |
| tech/net/ath | `2ac1acc14b5be97729e955555f17ac7dfde6a66f` | 21 |
| tech/net/bluetooth | `450dc5efa2636baf7a6ebb4c7b784d8529141245` | 7 |
| tech/pm/power | `f712532bb684387c2681cc912859b9d03e81457b` | 16 |
| tech/pm/thermal | `d525ff96debf4348da73f19056038b06864095b3` | 8 |
| tech/security/crypto | `1f60c0a2ca909753004854053ebac4cd45719e92` | 23 |
| tech/security/ice | `beabac03036a596434bb02c3f91b7c9672ea7c15` | 9 |
| tech/storage/all | `cef1b3c7fc3078e27ca66dd58e8f9fe86b0e077a` | 5 |
| tech/all/dt/qcs6490 | `2e92fd16906e29681d37d6d13a9afdf21aff3328` | 28 |
| tech/all/dt/qcs9100 | `754b8081f957618f2c863d4b3bb4a96d37e12c6b` | 24 |
| tech/all/dt/qcs8300 | `a02cf612f13f5efe97b10e2e228a8d727297632c` | 31 |
| tech/all/dt/qcs615 | `66b7e2fc2a222bb469279379e415162f55b6d8c5` | 11 |
| tech/all/dt/agatti | `2ca1b63b35a7e70a4a80398286211dee17729739` | 2 |
| tech/all/dt/eliza | `5338032c5f8d1b9ad79a33cc6fb24e62b13d2668` | 25 |
| tech/all/dt/hamoa | `106f486e8dedb5371b83fdb0001f5e8ba70c8606` | 49 |
| tech/all/dt/glymur | `c5bf216cf0bb7c05d02a57021492d3d5452b09c0` | 60 |
| tech/all/dt/kaanapali | `d21ef73d814a2cf34e6c0850a8dfb9f796ba8ae9` | 26 |
| tech/all/dt/pakala | `450d786a8ce19b7c382be99125b1af6236a556a6` | 9 |
| tech/all/config | `7b48e6e7d5f40c890bd8afc75c1dc7a0596e5ee7` | 78 |
| tech/overlay/dt | `b895d0e7537337daeeb814cea5cf764664b1bc36` | 78 |
| tech/all/workaround | `219d869a96c8fb79ab6c6604eaf61b0656c135ec` | 12 |
| tech/mproc/all | `104969c5b070fdc7bf93c7109c625b8b655a93ee` | 2 |
| tech/noup/debug/all | `e47307681abe61565162d394afd788b86d460ed4` | 29 |
| tech/hwe/unoq | `a2d85fe547167dbd8fc59618907c20a6f17d2e5a` | 4 |
| early/hwe/shikra/drivers | `b19d2ec290c8ae6fa2d3e8c1955413c4f20d4c3e` | 184 |
| early/hwe/shikra/dt | `dd90d88cfaad62aec33e4278bdd69b95aff0480d` | 130 |
| early/hwe/lyra | `8c9d598ff2b40c84187732b94e15aaff262c59e5` | 6 |