### PR TITLE
workflows/compile: skip the OTA images already in the qcomflash tarball

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -169,7 +169,7 @@ jobs:
             # ESP (efi.bin) and vmlinux, so skip their standalone copies when
             # the tarball is published (uncompress or extract them if needed)
             if compgen -G "$images_dir/*.qcomflash.tar.gz" > /dev/null; then
-              exclude+=( ! -name '*.rootfs.ext4' ! -name 'esp-qcom-image-*.vfat' ! -name 'vmlinux' )
+              exclude+=( ! -name '*.rootfs.ext4' ! -name '*.rootfs.ota-ext4' ! -name '*.rootfs.ota-esp' ! -name 'esp-qcom-image-*.vfat' ! -name 'vmlinux' )
             fi
             # The world build deploys the same initramfs images for every
             # machine, so publish them only from the generic machines


### PR DESCRIPTION
On a sota distro the tarball takes rootfs.img from the ota-ext4 image and efi.bin from the ota-esp one, and neither name matches the existing filters, so both are staged and uploaded in full next to the tarball that contains them. For qcom-distro-catchall that is 22.3 GiB of the 35.9 GiB each job publishes, and no test plan fetches either file.

Assisted-by: Claude Code:claude-fable-5