### PR TITLE
image_types_qcom: cut the cost of building the qcomflash tarball

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -201,7 +201,7 @@ create_qcomflash_pkg() {
     ln -rsf ${QCOMFLASH_DIR} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash
 
     # Create qcomflash tarball
-    ${IMAGE_CMD_TAR} --numeric-owner --transform="s,^\./,${IMAGE_BASENAME}-${MACHINE}/," -cf- . | pigz -p ${BB_NUMBER_THREADS} -9 -n --rsyncable > ${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash.tar.gz
+    ${IMAGE_CMD_TAR} --numeric-owner --transform="s,^\./,${IMAGE_BASENAME}-${MACHINE}/," -cf- . | pigz -p ${BB_NUMBER_THREADS} -6 -n --rsyncable > ${IMGDEPLOYDIR}/${IMAGE_NAME}.qcomflash.tar.gz
     ln -sf ${IMAGE_NAME}.qcomflash.tar.gz ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.qcomflash.tar.gz
 }
 

--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -85,7 +85,7 @@ create_qcomflash_pkg() {
         install -m 0644 "${DEPLOY_DIR_IMAGE}/boot-${MACHINE}.img" boot.img
 
     # rootfs image
-    install -m 0644 ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} rootfs.img
+    cp -l -L ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_QCOMFLASH_FS_TYPE} rootfs.img
 
     # partition bins/xml files
     if [ -n "${QCOM_PARTITION_FILES_SUBDIR}" ]; then


### PR DESCRIPTION
create_qcomflash_pkg assembles the flashable package in a staging
directory that exists only so it can be tarred. It installs the rootfs
image into that directory, copying 4-9 GB that nothing ever modifies,
and then compresses the tarball at pigz -9, which spends about three
times the CPU of -6 to produce a tarball half a percent smaller. Both
costs are paid once per image, so a qcom-distro-catchall build pays them
three times.

Hard link the rootfs image instead of copying it, and lower the
compression level to -6.

Measured on a qcs9100-ride-sx qcom-distro-catchall build over sixteen
threads, do_image_qcomflash drops from 1,701 to 707 CPU seconds and from
21.9 to 7.1 GB of writes, while the tarballs grow from 5,226 to 5,251
MiB in total. 