### PR TITLE
ci: introduce weekly builds

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -201,6 +201,7 @@ jobs:
       kernel_yaml: ${{matrix.kernel.yamlfile}}
       kernel_dirname: ${{matrix.kernel.dirname}}
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+      profile: ${{ inputs.profile }}
 
   compile_sdk:
     needs: [github-cache-check, compile_warm_up, compile-env]
@@ -219,6 +220,7 @@ jobs:
       kernel_yaml: ''
       kernel_dirname: ''
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+      profile: ${{ inputs.profile }}
 
   compile:
     needs: [github-cache-check, compile_warm_up, compile-env]
@@ -486,6 +488,7 @@ jobs:
       kernel_yaml: ${{matrix.kernel.yamlfile}}
       kernel_dirname: ${{matrix.kernel.dirname}}
       cache_dir: ${{ needs.compile-env.outputs.CACHE_DIR }}
+      profile: ${{ inputs.profile }}
 
   publish_summary:
     needs: [github-cache-check, compile, compile_sdk]

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -6,7 +6,7 @@ on:
       profile:
         required: false
         type: string
-        default: "full" # values: pr | full
+        default: "full" # values: pr | full | weekly
       skip_if_github_cached:
         required: false
         type: boolean
@@ -254,8 +254,10 @@ jobs:
             yamlfile: ':ci/qcom-distro-catchall.yml'
           - name: debug
             yamlfile: ':ci/qcom-distro-catchall.yml:ci/debug.yml'
+            profile: full
           - name: performance
             yamlfile: ':ci/qcom-distro-catchall.yml:ci/performance.yml'
+            profile: full
         kernel:
           - type: default
             dirname: ""
@@ -464,7 +466,12 @@ jobs:
     uses: ./.github/workflows/compile.yml
     with:
       name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
-      enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
+      # Which profiles build this entry. Entries without distro.profile are
+      # built by every profile; an entry marked with distro.profile is built by
+      # that profile and by the wider ones above it, ordered pr < full (push
+      # and nightly) < weekly. Add "profile: weekly" to the distro entry of a
+      # target that is too expensive to build every night.
+      enabled: ${{ (matrix.distro.profile || 'any') == 'any' || (matrix.distro.profile == 'full' && inputs.profile != 'pr') || (matrix.distro.profile == 'weekly' && inputs.profile == 'weekly') }}
       # One world build per machine and distro family is enough for compile
       # coverage: nodistro (including the nogl variant) covers the plain OE
       # configuration and qcom-distro-catchall enables a superset of the

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -5,6 +5,10 @@ on:
         required: false
         type: boolean
         default: true
+      profile:
+        required: false
+        type: string
+        default: "full" # values: pr | full | weekly
       sdk:
         required: false
         type: boolean
@@ -199,6 +203,9 @@ jobs:
           elif [[ "$GITHUB_EVENT_NAME" = "push" ]]; then
             echo "OBJECT_TAG=retention=15d" >> $GITHUB_ENV
             echo "BUILD_TYPE=buildType=PUSH" >> $GITHUB_ENV
+          elif [[ "${INPUTS_PROFILE}" = "weekly" ]]; then
+            echo "OBJECT_TAG=retention=15d" >> $GITHUB_ENV
+            echo "BUILD_TYPE=buildType=WEEKLY" >> $GITHUB_ENV
           elif [[ "$GITHUB_WORKFLOW" == *"Nightly Build"* ]]; then
             echo "OBJECT_TAG=retention=15d" >> $GITHUB_ENV
             echo "BUILD_TYPE=buildType=NIGHTLY" >> $GITHUB_ENV
@@ -206,6 +213,8 @@ jobs:
             echo "OBJECT_TAG=retention=15d" >> $GITHUB_ENV
             echo "BUILD_TYPE=buildType=OTHER" >> $GITHUB_ENV
           fi
+        env:
+          INPUTS_PROFILE: ${{ inputs.profile }}
       
       - name: Upload artifacts to S3 bucket
         uses: qualcomm-linux/upload-private-artifact-action@aws-v5

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,7 +21,6 @@ jobs:
     uses: ./.github/workflows/build-yocto.yml
     with:
       skip_if_github_cached: true
-    secrets: inherit
   test-nightly:
     if: needs.build-nightly.outputs.build_skipped != 'true'
     permissions:
@@ -31,7 +30,8 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/test.yml
     needs: build-nightly
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: ${{ github.run_id }}
   publish-test-results:
@@ -44,7 +44,8 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     needs: [build-nightly, test-nightly]
-    secrets: inherit
+    secrets:
+      TEST_REPORTING_APP_TOKEN: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
     with:
       workflow_id: ${{ github.run_id }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -15,6 +15,10 @@ on:
       commit:
         required: true
         type: string
+    secrets:
+      TEST_REPORTING_APP_TOKEN:
+        required: true
+        description: "Private key of the GitHub App used to report test results"
 
 permissions:
   checks: write

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -48,6 +48,10 @@ on:
       summary_id:
         description: "ID of the test summary artifact"
         value: ${{ jobs.publish-test-summary.outputs.summary_id }}
+    secrets:
+      LAVATOKEN:
+        required: true
+        description: "Token used to submit jobs to the LAVA lab"
 
 jobs:
   prepare-boot-jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ on:
       summary_ids:
         description: "IDs of the test summary artifact"
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
+    secrets:
+      LAVATOKEN:
+        required: true
+        description: "Token used to submit jobs to the LAVA lab"
 env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
@@ -40,7 +44,8 @@ jobs:
     needs: [prepare-env]
     name: "Test nodistro"
     uses: ./.github/workflows/test-distro.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,dragonboard-410c,dragonboard-820c,rb1-core-kit"
@@ -54,7 +59,8 @@ jobs:
     needs: [prepare-env]
     name: "Test qcom-distro"
     uses: ./.github/workflows/test-distro.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk,sm8750-mtp"
@@ -69,7 +75,8 @@ jobs:
     needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-6.18"
     uses: ./.github/workflows/test-distro.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,43 +1,43 @@
-name: Nightly Build
-run-name: "Nightly Build (${{ github.ref_name }})"
+name: Weekly Build
+run-name: "Weekly Build (${{ github.ref_name }})"
 
 on:
   workflow_dispatch:
   schedule:
-  # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
-  # so that build notification emails will be sent out properly.
-  # At 0:22 UTC from Sunday to Friday - picked a random "minute" as top of hour
-  # can be busy in github. Saturday is covered by the weekly build, which builds
-  # a superset of this matrix.
-  - cron: "22 0 * * 0-5"
+  # At 0:22 UTC on Saturday - picked a random "minute" as top of hour can be
+  # busy in github. The weekly build repeats the whole nightly matrix and adds
+  # the entries that are too expensive to build every night, so it takes over
+  # Saturday's nightly slot and its results are published well before Monday.
+  - cron: "22 0 * * 6"
 
 permissions:
   contents: read
 
 jobs:
-  build-nightly:
+  build-weekly:
     permissions:
       contents: read
       packages: read
       actions: read
     uses: ./.github/workflows/build-yocto.yml
     with:
+      profile: weekly
       skip_if_github_cached: true
-  test-nightly:
-    if: needs.build-nightly.outputs.build_skipped != 'true'
+  test-weekly:
+    if: needs.build-weekly.outputs.build_skipped != 'true'
     permissions:
       contents: read
       actions: read
       checks: write
       pull-requests: write
     uses: ./.github/workflows/test.yml
-    needs: build-nightly
+    needs: build-weekly
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: ${{ github.run_id }}
   publish-test-results:
-    if: needs.build-nightly.outputs.build_skipped != 'true'
+    if: needs.build-weekly.outputs.build_skipped != 'true'
     permissions:
       contents: read
       packages: read
@@ -45,7 +45,7 @@ jobs:
       checks: write
       pull-requests: write
     uses: ./.github/workflows/publish-results.yml
-    needs: [build-nightly, test-nightly]
+    needs: [build-weekly, test-weekly]
     secrets:
       TEST_REPORTING_APP_TOKEN: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
     with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build on push (master)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?label=Build%20on%20push%20(master))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml)
 [![Nightly Build (master)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?label=Nightly%20Build%20(master))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml)
+[![Weekly Build (master)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/weekly-build.yml?label=Weekly%20Build%20(master))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/weekly-build.yml)
 
 [![Build on push (wrynose)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/push.yml?branch=wrynose&label=Build%20on%20push%20(wrynose))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/push.yml?query=branch%3Awrynose)
 [![Nightly Build (wrynose)](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/meta-qcom/nightly-build.yml?branch=wrynose&label=Nightly%20Build%20(wrynose))](https://github.com/qualcomm-linux/meta-qcom/actions/workflows/nightly-build.yml?query=branch%3Awrynose)


### PR DESCRIPTION
Created out of necessity from qualcomm-linux/meta-qcom-distro#307: the
browser-enabled multimedia image is too expensive to build every night, and
there is no cadence slower than the nightly build to put such targets in.

This adds a weekly build that reuses the compile matrix through a new build
profile ladder (`pr` < `full` < `weekly`), running the same test stage and
publishing results the same way as the nightly build. It takes over Saturday's
nightly slot, and its artifacts are tagged `buildType=WEEKLY`. Restricting a
target to the weekly cadence is now a one-line `profile: weekly` addition to
its matrix entry; the `pr` and `full` coverage is unchanged.