### PR TITLE
iris-video-dlkm: upgrade v1.0.26 -> v1.0.27

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "5fb3b4746a53244147c3e5ef0484e03bbf1ae564"
+SRCREV  = "ba6d8523b39600f2dae231dca1024fb282cd9348"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.27 brings the following update for Qcom Iris:

- Fix monaco context-bank probe failure by splitting the non-secure context bank into bitstream/pixel entries and explicitly attaching each to its own IOMMU domain

