### PR TITLE
userspace-resource-manager: Update to v0.4.9

### DIFF
--- a/recipes-support/userspace-resource-manager/userspace-resource-manager_0.4.9.bb
+++ b/recipes-support/userspace-resource-manager/userspace-resource-manager_0.4.9.bb
@@ -4,11 +4,11 @@ DESCRIPTION = "Userspace Resource Manager(URM) is a lightweight userspace \
 daemon that monitors system resources and enforces policies using \
 Linux kernel interfaces such as cgroups and sysfs."
 
-LICENSE = "BSD-3-Clause-Clear"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9701d0ef17353f1d05d7b74c8712ebbd"
 
 SRC_URI = "git://github.com/qualcomm/userspace-resource-manager.git;protocol=https;branch=main;tag=v${PV}"
-SRCREV = "58375d896a828e47504b2770131a8357e1341dd1"
+SRCREV = "21380f4c0150d2df2eef2e1e45338fbe9438a1a4"
 
 inherit cmake pkgconfig systemd
 
@@ -16,20 +16,18 @@ DEPENDS += "libyaml"
 
 PACKAGECONFIG ??= "\
     classifier \
-    extensions \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'state-detector systemd', '', d)} \
     tests \
 "
 
 PACKAGECONFIG[classifier] = "-DBUILD_CLASSIFIER=ON,-DBUILD_CLASSIFIER=OFF"
-PACKAGECONFIG[extensions] = "-DBUILD_EXTENSIONS=ON,-DBUILD_EXTENSIONS=OFF"
 PACKAGECONFIG[state-detector] = "-DBUILD_STATE_DETECTOR=ON,-DBUILD_STATE_DETECTOR=OFF"
 PACKAGECONFIG[systemd] = ",,systemd"
 PACKAGECONFIG[tests] = "-DBUILD_TESTS=ON,-DBUILD_TESTS=OFF"
 
 SYSTEMD_SERVICE:${PN} = "urm.service"
 FILES:${PN}-dev += " \
-    ${libdir}/urm/libUrmTestPlugin.so \    
+    ${libdir}/urm/libUrmTestPlugin.so \
     ${libdir}/urm/libUrmPlugin.so \
 "
 
@@ -38,13 +36,14 @@ FILES:${PN} += "${sysconfdir}/urm/*"
 PACKAGE_BEFORE_PN += "${PN}-extensions"
 FILES:${PN}-extensions += " \
     ${sysconfdir}/urm/target/* \
-    ${sysconfdir}/urm/initscripts/post_boot/* \
+    ${libexecdir}/urm/initscripts/post_boot/* \
     ${libdir}/urm/libUrmPlugin.so* \
 "
 
 PACKAGE_BEFORE_PN += "${PN}-tests"
 FILES:${PN}-tests += " \
-    ${sysconfdir}/urm/tests/* \
+    ${datadir}/urm/tests/configs/* \
+    ${datadir}/urm/tests/nodes/* \
     ${bindir}/UrmComponentTests \
     ${bindir}/UrmIntegrationTests \
     ${libdir}/libRestuneTestUtils.so* \


### PR DESCRIPTION
userspace-resource-manager: Update to v0.4.9

CHANGES in v0.4.9
- URM Executable moved to /usr/sbin
- post-boot configs moved from /etc/urm/initscripts to /usr/libexec/initscripts
- Test configs moved to /usr/share/urm/tests, instead of /etc/urm/tests
- Additional Configs for Seraph
- Added the retuneSignal API, to extend duration of existing signal configurations
- Removed the BUILD_EXTENSIONS CMake flag, to ensure the extensions
  package is always generated alongside URM, users retain the flexibility
  to install / remove the extensions package according to their requirements.
- Update project licensing from BSD-3-Clause-Clear to BSD-3-Clause
- Updated URM test framework, so that the test nodes are correctly placed in
  a rw directory prior to testing. This is achieved by using the mktemp system
  call in the test runner and passing the path returned by the system call to
  the URM test binaries UrmIntegrationTests and UrmComponentTests, appropriate
  CLI handling options have been added to the above binaries.