### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260828 v6.18.37

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -20,8 +20,8 @@ KERNEL_PAHOLE ?= '${@oe.utils.vartrue("DEBUG_BUILD", bb.utils.contains("BBFILE_C
 do_configure[depends] += '${@oe.utils.vartrue("KERNEL_PAHOLE", "pahole-native:do_populate_sysroot", "", d)}'
 EXTRA_OEMAKE += '${@oe.utils.vartrue("KERNEL_PAHOLE", "", "PAHOLE=false", d)}'
 
-# tag:qcom-6.18.y-20260812
-SRCREV ?= "bfeb0e5567c0987f05faeec78664719b718133e5"
+# tag:qcom-6.18.y-20260828
+SRCREV ?= "dc0f4d4280a7ecfcf8bc2d6bff1f42b1b8d33b08"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260828

Changelog:
FROMLIST: phy: qcom: qmp-pcie: Add vdda-refgen supplies for Glymur
FROMLIST: dt-bindings: phy: sc8280xp-qmp-pcie: Add vdda-refgen supply for Glymur
FROMLIST: arm64: dts: qcom: hamoa/purwa: Add QREF regulator supplies
FROMLIST: arm64: dts: qcom: glymur: Add QREF regulator supplies to TCSR
FROMLIST: arm64: dts: qcom: glymur-crd: Add refgen supplies for PCIe PHY on Glymur
FROMLIST: dt-bindings: clock: qcom,glymur-tcsr: Add mahua support
FROMLIST: arm64: dts: qcom: monaco: Add PSCI SYSTEM_RESET2 types
FROMLIST: arm64: dts: qcom: lemans: Add PSCI SYSTEM_RESET2 types
FROMLIST: wifi: ath12k: fix MLO 4-way handshake timeout on QCC2072
QCLINUX: qcom.config: Enable FUNCTION_TRACER
FROMLIST: arm64: defconfig: Enable LT9611C bridge driver
FROMLIST: arm64: dts: qcom: shikra-iqs-evk: Add LT9611UXD HDMI bridge support
FROMLIST: drm/bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver
FROMLIST: dt-bindings: bridge: Add Lontium LT9611C(EX/UXD) MIPI DSI to HDMI driver
BACKPORT: drm/bridge: add of_drm_get_bridge_by_endpoint()
BACKPORT: drm/bridge: add of_drm_find_and_get_bridge()
BACKPORT: drm/atomic-state-helper: Add drm_atomic_helper_bridge_create_state()
BACKPORT: drm/bridge: Add new atomic_create_state callback
BACKPORT: drm/bridge: Switch private_obj initialization to atomic_create_state
BACKPORT: drm/atomic-helper: Add private_obj atomic_create_state helper
BACKPORT: drm/atomic: Add new atomic_create_state callback to drm_private_obj
BACKPORT: drm/atomic: Make drm_atomic_private_obj_init fallible
BACKPORT: drm/atomic: Add dev pointer to drm_private_obj
BACKPORT: drm: Rename struct drm_atomic_state to drm_atomic_commit
BACKPORT: drm/display: bridge_connector: move audio_infoframe checks to OP_HDMI
BACKPORT: drm/bridge: refactor HDMI InfoFrame callbacks
BACKPORT: drm/bridge: add next_bridge pointer to struct drm_bridge
UPSTREAM: clk: qcom: Fix test_ctl_hi field for DEFAULT_EVO PLLs
UPSTREAM: clk: qcom: gcc-shikra: Add additional frequencies for EMAC RGMII clocks
FROMLIST: soc: qcom: rpmh-rsc: Output debug information from RSC
UPSTREAM: arm64: dts: qcom: talos: Fix cpu6 1094.4MHz OPP frequency typo
FROMLIST: soc: qcom: cmd-db: add reverse address-to-name lookup
FROMLIST: soc: qcom: cmd-db: export RPMh accelerator type string helper
QCLINUX: arm64: configs: qcom: reduce SWIOTLB size to 2 MiB
FROMLIST: media: iris: Fix frame interval enumeration for non-divisor framerates
FROMLIST: arm64: dts: qcom: sc7280: Add dma-coherent property into venus node
FROMLIST: dt-bindings: media: qcom,sc7280-venus: Add dma-coherent property
QCLINUX: kernel: configs: debug: Disable KASLR for debug builds
FROMLIST: hamoa: Add ICE node for UFS inline encryption
FROMLIST: qcom,inline-crypto-engine: Add x1e80100 support
BACKPORT: Revert "drm/msm: dsi: fix PLL init in bonded mode"
BACKPORT: arm64: dts: qcom: rb3gen2: add Industrial BT UART overlay
BACKPORT: arm64: dts: qcom: sc7280: mark PCIe root port as bridge
BACKPORT: arm64: dts: qcom: qcs6490-rb3gen2: label BT PMU node
BACKPORT: Bluetooth: qca: update QCC2072 NVM handling
FROMLIST: media: qcom: camss: validate local/remote endpoint bus-type
FROMLIST: media: qcom: camss: Dynamic data-rate specific C-PHY register settings
FROMLIST: media: qcom: camss: Add sa8300 C-PHY 3ph lane config
FROMLIST: media: qcom: camss: Add sa8775p C-PHY 3ph lane config
FROMLIST: media: qcom: camss: Prepare CSID for C-PHY support in gen3
FROMLIST: media: qcom: camss: Program CSIPHY common control registers
FROMLIST: media: qcom: camss: Enable C-PHY where available
FROMLIST: media: qcom: camss: Account for C-PHY when calculating link frequency
FROMLIST: media: qcom: camss: csiphy-3ph: Update Gen2 v1.1 MIPI CSI-2 C-PHY init
FROMLIST: media: qcom: camss: csiphy-3ph: Add Gen2 v1.1 MIPI CSI-2 C-PHY init
FROMLIST: media: qcom: camss: Initialize lanes after lane configuration is available
FROMLIST: media: qcom: camss: Prepare CSID for C-PHY support
FROMLIST: media: qcom: camss: csiphy-3ph: Use odd bits for configuring C-PHY lanes
FROMLIST: media: qcom: camss: csiphy: Introduce PHY configuration
FROMLIST: media: qcom: camss: csiphy-3ph: Fix lane mask calculation
FROMLIST: gpio: Add fwnode_gpiod_get() helper
FROMLIST: dt-bindings: clock: qcom: Move glymur TCSR to own binding
FROMLIST: clk: qcom: tcsrcc-x1e80100: Migrate to clk_ref helper
FROMLIST: dt-bindings: clock: qcom: Move x1e80100 TCSR to own binding
FROMLIST: clk: qcom: tcsrcc-glymur: Add Mahua QREF regulator support
FROMLIST: clk: qcom: tcsrcc-glymur: Add regulator supplies and migrate to clk_ref helper
FROMLIST: clk: qcom: Add generic clkref_en support
Revert "WORKAROUND: phy: qcom: qmp-pcie: add x1e80100 qref supplies"
FROMLIST: arm64: dts: qcom: shikra: Add coresight nodes
FROMLIST: dt-bindings: arm: qcom,coresight-ctcu: Add Shikra
FROMLIST: media: qcom: iris: Add request key frame support for encoder
FROMLIST: media: qcom: iris: improve gop size support for gen1 encoder
QCLINUX: arm64: configs: qcom: Enable XDP sockets (AF_XDP)
FROMLIST: PCI: Add support for PCIe WAKE# interrupt
FROMLIST: gpio: Add fwnode_gpiod_get() helper
FROMLIST: arm64: dts: qcom: msm8996: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: kodiak: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8650: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: talos: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8550: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8450: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8350: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8250: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sm8150: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sdm845: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sc8280xp: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sc8180x: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sar2130p: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: sa8540p: Move PCIe GPIOs to root port node
FROMLIST: arm64: dts: qcom: sa8295p: Move PCIe GPIOs to root port node
FROMLIST: arm64: dts: qcom: qcs8550: Move PCIe GPIOs to root port node
FROMLIST: arm64: dts: qcom: qcs404: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: msm8998: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: lemans: Move PCIe phy and GPIOs to root port node
FROMLIST: arm64: dts: qcom: talos: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: kodiak: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sa8540p-ride: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: lemans: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: monaco: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sar2130p: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8750: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8650: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8550: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8450: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8350: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8250: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sm8150: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sc8180x: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: sdm845: Fix PCIe wake GPIO polarity
FROMLIST: arm64: dts: qcom: msm8996: Fix PCIe wake GPIO polarity
FROMLIST: ARM: dts: qcom: sdx55: Fix PCIe wake GPIO polarity
FROMLIST: wifi: ath11k: add purwa-iot-evk and qcs6490-rb3gen2 to usecase firmware table
FROMLIST: drm/msm: Fix task_struct reference leak in recover_worker
FROMLIST: drm/msm/a6xx: Fix IRQ storm during msm_recovery test
FROMLIST: drm/msm/a6xx: Fix A621 GPUCC register list for state capture
FROMLIST: drm/msm/a6xx: Fix A663 GPUCC register list for state capture
FROMLIST: drm/msm: Recover HW before retire hung submit
FROMLIST: media: iris: disable time-delta-based rate control for VBR
FROMLIST: media: iris: avoid bit depth validation for capture formats
FROMLIST: media: iris: add hierarchical coding support for ar50lt encoder
FROMLIST: media: iris: add Long-Term Reference control support for ar50lt encoder
BACKPORT: media: qcom: iris: vdec: allow GEN2 decoding into 10bit format
BACKPORT: media: qcom: iris: vdec: update find_format to handle 8bit and 10bit formats
BACKPORT: media: qcom: iris: vdec: update size and stride calculations for 10bit formats
BACKPORT: media: qcom: iris: gen2: add support for 10bit decoding
BACKPORT: media: qcom: iris: add QC10C & P010 buffer size calculations
BACKPORT: media: qcom: iris: add helpers for 8bit and 10bit formats
BACKPORT: media: qcom: iris: Fix FPS calculation and VPP FW overhead
BACKPORT: media: iris: drop struct iris_fmt
BACKPORT: media: qcom: iris: Simplify COMV size calculation
BACKPORT: media: qcom: iris: Optimize iris_hfi_gen1_packet_session_set_property
BACKPORT: media: qcom: iris: Add hierarchical coding support for encoder
BACKPORT: media: qcom: iris: Add B frames support for encoder
BACKPORT: media: qcom: iris: Add Long-Term Reference support for encoder
BACKPORT: media: qcom: iris: Add intra refresh support for gen1 encoder
BACKPORT: media: iris: Fix use IRQF_NO_AUTOEN when requesting the IRQ
FROMLIST: arm64: dts: qcom: lemans: Add OPP-table for ICE UFS device node