### PR TITLE
ci/performance.yml: skip GPT auto-discovery for non-SOTA builds

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -3,4 +3,4 @@ header:
 
 local_conf_header:
   cmdline-perf: |
-    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"
+    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux ${@bb.utils.contains('DISTRO_FEATURES', 'sota', '', 'systemd.gpt_auto=no', d)}"


### PR DESCRIPTION
systemd-gpt-auto-generator probes the partition table during early boot even when the root device is explicitly specified. Skip this probing in performance builds to reduce generator time.

SOTA relies on the generator to create boot.mount and boot.automount for OSTree services that access /boot. Retain GPT discovery for SOTA builds.