### PR TITLE
kgsl-dlkm: Update v1.0.12 ->  v1.0.13

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.13.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.13.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Qualcomm KGSL driver for managing Adreno GPU"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://adreno.c;beginline=1;endline=1;md5=fcab174c20ea2e2bc0be64b493708266"
 
-SRCREV = "a183ffbab70cc9fc2f29092bce45fcbe9111b410"
+SRCREV = "5dc2bb00d6357e2c180d3955b51dc4c8dbfbe071"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \


### PR DESCRIPTION
This tag v1.0.13 brings below fixes:

- Add support for Gen8_2_1 GPU with standard DT bindings.
- Add support for Gen8_0_1 GPU with standard DT bindings.

Signed-off-by: Sumant Gupta <sumagupt@qti.qualcomm.com>