### PR TITLE
ci: base.lock: update layers to latest

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,23 +3,23 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: ace4d721578b8bbb217d760ee86171009d2efc7c
+            commit: 09df3e534c4f38a033c514d7567006ed35cc34df
         bitbake:
-            commit: c6a1288cb15171297c5607a8f6f6c01595ba8b8e
+            commit: 75c85c54d9bcc5b732459bef183bab79db00c843
         meta-arm:
-            commit: 86b180b091c0bd595a31fe11fb5e2677a5bfd790
+            commit: b0ff16aba48a197070daff28ef7ad67067fd3d88
         meta-openembedded:
-            commit: 7af0bdb0fec638be67d8fe4e655f026e0d08a312
+            commit: f191557494e09df5a47bedcccdb6181cb8b6dbd4
         meta-virtualization:
             commit: f45cc3787c11d040dbef8e7f956a4da420375829
         meta-audioreach:
-            commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
+            commit: 066142f374d074a0908afc14eb2c0bc6e1485611
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: c6266761a5a62eba1695fe9bf7bdfa4a414c00c2
+            commit: 3f79539a8e1250c46d824b3af2415b9add945161
         meta-security:
-            commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
+            commit: 0339b65f63877ed36fcffa44953e57c3bb969ca9
         meta-dpdk:
             commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
@@ -1,4 +1,4 @@
-From dd51eaf49bb5732fb603af29a518d0d6c46118dd Mon Sep 17 00:00:00 2001
+From cf0d6c681b20b8c75a79766264f084e2dc70c150 Mon Sep 17 00:00:00 2001
 From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
 Date: Tue, 13 Jan 2026 17:58:26 +0530
 Subject: [PATCH] v4l2: Add support for V4L2_PIX_FMT_QC08C format
@@ -10,32 +10,18 @@ Upstream-Status: Denied [Adding NV12_Q08C format is denied by upstream, for comp
 
 Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
 ---
- sys/v4l2/gstv4l2object.c | 6 ++++++
- 1 file changed, 6 insertions(+)
+ sys/v4l2/gstv4l2object.c | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
-index 99ed48b..ab37526 100644
+index 53f4e08..257fa75 100644
 --- a/sys/v4l2/gstv4l2object.c
 +++ b/sys/v4l2/gstv4l2object.c
-@@ -182,6 +182,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
-   {MAP_FMT (NV12_16L16, UNKNOWN),               MAP_DRM (NV12, SAMSUNG_16_16_TILE), GST_V4L2_RAW},
-   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
-   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
+@@ -224,6 +224,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_FMT (NV12_16L16, UNKNOWN),               MAP_DRM (NV12, SAMSUNG_16_16_TILE), GST_V4L2_RAW | GST_V4L2_MPLANE},
+   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW | GST_V4L2_MPLANE},
+   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW | GST_V4L2_MPLANE},
 +  {MAP_FMT (QC08C, NV12_Q08C),                  MAP_DRM (NV12, QCOM_COMPRESSED),    GST_V4L2_RAW},
-   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW | GST_V4L2_MPLANE},
    {MAP_FMT (NV21, NV21),                        KNOWN_DRM_MAP,                      GST_V4L2_RAW},
-   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
-@@ -2003,6 +2004,11 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
-       fourcc_nc = desc->v4l2_format;
-     if (fallback_desc)
-       fourcc = fallback_desc->v4l2_format;
-+
-+    if (fourcc_nc == V4L2_PIX_FMT_QC08C) {
-+      fourcc_nc = 0;
-+      fourcc = V4L2_PIX_FMT_QC08C;
-+    }
-   } else if (g_str_equal (mimetype, "video/mpegts")) {
-     fourcc = V4L2_PIX_FMT_MPEG;
-   } else if (g_str_equal (mimetype, "video/x-dv")) {
---
-2.34.1
+   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW | GST_V4L2_MPLANE},

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch
@@ -1,4 +1,4 @@
-From e816852afe4bc190154f091f6cad017a0661eb1b Mon Sep 17 00:00:00 2001
+From bf33b3d095153f8bada9354deb56323ac904b674 Mon Sep 17 00:00:00 2001
 From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
 Date: Mon, 19 Jan 2026 14:55:27 +0530
 Subject: [PATCH] v4l2: Add support for V4L2_PIX_FMT_QC10C format
@@ -10,37 +10,25 @@ Upstream-Status: Denied [Same reason as 8-bit compressed format, denied by upstr
 
 Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
 ---
- sys/v4l2/gstv4l2object.c | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ sys/v4l2/gstv4l2object.c | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
-index 692f152..58ecd59 100644
+index 4f526f3..a265094 100644
 --- a/sys/v4l2/gstv4l2object.c
 +++ b/sys/v4l2/gstv4l2object.c
-@@ -183,6 +183,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
-   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
-   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW},
+@@ -225,6 +225,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_FMT (NV12M_8L128, NV12_8L128),           MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW | GST_V4L2_MPLANE},
+   {MAP_FMT (NV12M_10BE_8L128, NV12_10BE_8L128), MAP_DRM (INVALID, INVALID),         GST_V4L2_RAW | GST_V4L2_MPLANE},
    {MAP_FMT (QC08C, NV12_Q08C),                  MAP_DRM (NV12, QCOM_COMPRESSED),    GST_V4L2_RAW},
 +  {MAP_FMT (QC10C, NV12_Q10LE32C),              KNOWN_DRM_MAP,                      GST_V4L2_RAW},
-   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV21M, NV21),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW | GST_V4L2_MPLANE},
    {MAP_FMT (NV21, NV21),                        KNOWN_DRM_MAP,                      GST_V4L2_RAW},
-   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW},
-@@ -2017,6 +2018,11 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
-       fourcc_nc = 0;
-       fourcc = V4L2_PIX_FMT_QC08C;
-     }
-+
-+    if (fourcc_nc == V4L2_PIX_FMT_QC10C) {
-+      fourcc_nc = 0;
-+      fourcc = V4L2_PIX_FMT_QC10C;
-+    }
-   } else if (g_str_equal (mimetype, "video/mpegts")) {
-     fourcc = V4L2_PIX_FMT_MPEG;
-   } else if (g_str_equal (mimetype, "video/x-dv")) {
-@@ -3632,6 +3638,10 @@ gst_v4l2_object_save_format (GstV4l2Object * v4l2object,
+   {MAP_FMT (NV16M, NV16),                       KNOWN_DRM_MAP,                      GST_V4L2_RAW | GST_V4L2_MPLANE},
+@@ -3664,6 +3665,10 @@ gst_v4l2_object_save_format (GstV4l2Object * v4l2object,
      padded_width = format->fmt.pix.width;
    }
-
+ 
 +  /* For Q10C format, padded width should be represented in pixels */
 +  if (GST_VIDEO_INFO_FORMAT (&info->vinfo) == GST_VIDEO_FORMAT_NV12_Q10LE32C)
 +    padded_width = (padded_width * 3) / 4;
@@ -48,6 +36,3 @@ index 692f152..58ecd59 100644
    if (padded_width < format->fmt.pix.width)
      GST_WARNING_OBJECT (v4l2object->dbg_obj,
          "Driver bug detected, stride (%d) is too small for the width (%d)",
---
-2.34.1
-


### PR DESCRIPTION
Relevant changes for oe-core:
- 09df3e534 Revert "files/ext-sdk-prepare: Ensure all dependencies extract correctly"
- 8d6b930f4 sbom-cve-check-update-nvd-native,sbom-cve-check-update-cvelist-native: upgrade 2026.08.03-000011 -> 2026.08.25-000009
- 62176a7e8 patch: correct CVE_PRODUCT mapping
- bc30a3436 u-boot: share CVE_PRODUCT with u-boot-tools
- 89ffb1fec vim-tiny: add CVE_PRODUCT mapping
- ef202e90a vim: correct CVE_PRODUCT mapping
- 90be80693 kernel-devsrc: normalize Clang compiler entry in auto.conf.cmd
- e5e9c6c1d devtool: handle symlinks in source tree cleanup
- df3cc9f85 meta/conf/fragments/yocto/monitor-disk-space.conf: add fragment
- 1ffcc8f38 lib/bbconfigbuild/configfragments.py: match Available and Enabled built-in fragment lists
- a0be18de2 meta/conf/fragments: harmonize fragment summaries and descriptions
- 3e5939faa ptest-perl: fix overly greedy SKIP detection in run-ptest
- dffdd6bd9 gst-examples: Show warnings in gtk-play
- d23086790 documentation.conf: Remove the documentation of GROUPMEMS_PARAM
- 9bdfa26c3 package.bbclass: Remove GROUPMEMS_PARAM from PACKAGEVARS
- a4c63bddc useradd-staticids.bbclass: Remove references to GROUPMEMS_PARAM
- 4cc68882c useradd_base.bbclass: Remove perform_groupmems()
- 09a18ce9e useradd.bbclass: Remove support for the GROUPMEMS_PARAM variable
- 51e5d5602 rpm-sequoia-crypto-policy: upgrade to latest revision
- 2c80b400f rust: Upgrade 1.97.1 -> 1.98.0
- 5a86378f7 cargo-c: upgrade 0.10.24 -> 0.10.25
- a0b0d4c27 gstreamer1.0: upgrade 1.28.5 -> 1.28.6
- 235fdf9f3 gstreamer1.0-rtsp-server: upgrade 1.28.5 -> 1.28.6
- 714d14599 gstreamer1.0-python: upgrade 1.28.5 -> 1.28.6
- 022185166 gstreamer1.0-plugins-ugly: upgrade 1.28.5 -> 1.28.6
- 171b0ae01 gstreamer1.0-plugins-good: upgrade 1.28.5 -> 1.28.6
- b5514235d gstreamer1.0-plugins-base: upgrade 1.28.5 -> 1.28.6
- 7012ec6a0 gstreamer1.0-plugins-bad: upgrade 1.28.5 -> 1.28.6
- 678e4426d gstreamer1.0-libav: upgrade 1.28.5 -> 1.28.6
- 1343f8868 gst-examples: upgrade 1.28.5 -> 1.28.6
- 057c446d8 gst-devtools: upgrade 1.28.5 -> 1.28.6
- d10dc8812 man-pages: upgrade 6.18 -> 6.19
- c011e0900 python3-uv-build: upgrade 0.12.5 -> 0.12.6
- 62f93b20b python3-git: upgrade 3.1.59 -> 3.1.60
- 4b018106c python3-cryptography: upgrade 50.0.0 -> 50.0.1
- 11fae4761 cmake,cmake-native: upgrade 4.4.2 -> 4.4.3
- 2c7260580 libslirp: upgrade 4.9.3 -> 4.9.4
- 9b7607cb2 python3-imagesize: upgrade 2.0.0 -> 2.0.1
- febc047d3 python3-maturin: upgrade 1.14.1 -> 1.15.0
- 919bc8b3d netbase: upgrade 6.5 -> 6.6
- f8336d39d files/ext-sdk-prepare: Ensure all dependencies extract correctly

Relevant changes for bitbake:
- 75c85c5 bin/toaster: Remove accidentally added version string
- 3be1f19 cookerdata: cleanup imports
- e0ce2f2 __init__.py: add missing import bb.event
- 042c003 build: localize import of bb.progress
- 786044d runqueue: use set 'discard' method instead of 'in' followed by 'remove'
- cc882b3 runqueue: fix init of RunQueueScheduler.prio_map; add test for 'basic' scheduler
- 27efe75 data_smart: use Pattern.search instead of findall, to match comment

Relevant changes for meta-arm:
- b0ff16ab arm/uefi-secureboot: fix race with secureboot keys
- c6f7492f meta-arm: fix trailing whitespace

Relevant changes for meta-openembedded:
- f19155749 vboxguestdrivers: Upgrade to 7.2.16
- 7a393253e python3-ujson: add CVE_PRODUCT mapping
- 46ca829b6 python3-twitter: correct Tweepy CVE_PRODUCT mapping
- 3874342e0 python3-flask-user: correct CVE_PRODUCT mapping
- 6cbb85db1 python3-flask: correct CVE_PRODUCT mapping
- 33d7be431 python3-aiohttp: correct CVE_PRODUCT mapping
- ae093476e python3-waitress: correct CVE_PRODUCT mapping
- fd0b8a36e python3-werkzeug: correct CVE_PRODUCT mapping
- fa89b2d67 swagger-ui: upgrade 5.32.13 -> 5.32.14
- 54d51c2c2 libfaketime: extend to nativesdk

Relevant changes for meta-audioreach:
- 9fc1164 CI: Improve LAVA artifact handling and refresh S3 build URLs
- 6299922 CI: Reuse meta-qcom CI configuration in base setup

Relevant changes for meta-updater:
- 3f79539 classes/sota: compress the OSTree tarballs with zstd
- ec5c4fb classes/sota: only push to the update server when credentials are set

Assisted-by: Claude Code:claude-fable-5