### PR TITLE
ci: base: patch oe-core for the revert python3-pycairo 7aa548771b

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -21,6 +21,9 @@ repos:
       scons-variables-revert:
         repo: meta-qcom
         path: patches/oe-core/0002-python3-scons-backport-revert-of-the-4.11.0-Variables.patch
+      revert-python3-pycairo:
+        repo: meta-qcom
+        path: patches/oe-core/0001-Revert-python3-pycairo-inherit-python3-dir-not-pytho.patch
     layers:
       meta:
 

--- a/patches/oe-core/0001-Revert-python3-pycairo-inherit-python3-dir-not-pytho.patch
+++ b/patches/oe-core/0001-Revert-python3-pycairo-inherit-python3-dir-not-pytho.patch
@@ -1,0 +1,52 @@
+From dfcae61676e608b7e3186cf63cd4196668900217 Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <jose.quaresma@oss.qualcomm.com>
+Date: Mon, 31 Aug 2026 15:04:27 +0100
+Subject: [PATCH] Revert "python3-pycairo: inherit python3-dir not
+ python3targetconfig"
+
+This reverts commit 7aa548771b7d405e215219360bd60c1b6efe9069.
+
+Without this the arch on the library name changes from "aarch64"
+to "x86_64" when we build for arm64 target.
+
+Analysis of buildhistory shows that the content is the same,
+only the name changes:
+
+# --- a/packages/armv8a-oe-linux/python3-pycairo/sysroot
+# +++ b/packages/armv8a-oe-linux/python3-pycairo/sysroot
+# @@ -9,8 +9,8 @@
+#  drwxr-xr-x -          -                  22 ./usr/lib/pkgconfig
+#  -rw-r--r-- -          -                 162 ./usr/lib/pkgconfig/py3cairo.pc
+#  drwxr-xr-x -          -                  26 ./usr/lib/python3.14
+#  drwxr-xr-x -          -                  58 ./usr/lib/python3.14/site-packages
+# -drwxr-xr-x -          -                 174 ./usr/lib/python3.14/site-packages/cairo
+# --rwxr-xr-x -          -              303544 ./usr/lib/python3.14/site-packages/cairo/_cairo.cpython-314-x86_64-linux-gnu.so
+# +drwxr-xr-x -          -                 176 ./usr/lib/python3.14/site-packages/cairo
+# +-rwxr-xr-x -          -              303544 ./usr/lib/python3.14/site-packages/cairo/_cairo.cpython-314-aarch64-linux-gnu.so
+#  drwxr-xr-x -          -                  20 ./usr/lib/python3.14/site-packages/cairo/include
+#  -rw-r--r-- -          -                8778 ./usr/lib/python3.14/site-packages/cairo/include/py3cairo.h
+#  -rw-r--r-- -          -                 660 ./usr/lib/python3.14/site-packages/cairo/__init__.py
+
+Upstream-Status: Submitted [https://lists.openembedded.org/g/openembedded-core/message/244813]
+
+Signed-off-by: Jose Quaresma <jose.quaresma@oss.qualcomm.com>
+---
+ meta/recipes-devtools/python/python3-pycairo_1.29.1.bb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meta/recipes-devtools/python/python3-pycairo_1.29.1.bb b/meta/recipes-devtools/python/python3-pycairo_1.29.1.bb
+index 19e41baac4..b70d1f177d 100644
+--- a/meta/recipes-devtools/python/python3-pycairo_1.29.1.bb
++++ b/meta/recipes-devtools/python/python3-pycairo_1.29.1.bb
+@@ -17,7 +17,7 @@ SRC_URI[sha256sum] = "4fbd26b4af24c9787d84cf5448e34eb8dca064b732479aaecd03109520
+ 
+ S = "${UNPACKDIR}/pycairo-${PV}"
+ 
+-inherit meson pkgconfig python3-dir github-releases
++inherit meson pkgconfig python3targetconfig github-releases
+ 
+ CFLAGS += "-fPIC"
+ 
+-- 
+2.55.0
+


### PR DESCRIPTION
```
 # 7aa548771b python3-pycairo: inherit python3-dir not python3targetconfig
 #
 # Now that meson.bbclass tells meson where to install Python files this
 # recipe just needs to know the value of PYTHON_SITEPACKAGES_DIR for
 # FILES, so just inherit python3-dir to remove a dependency on the target
 # python recipe.
```

This is not fully true and targetconfig is still needed.
With this patch 7aa54877 the arch on the library name changes from
"aarch64" to "x86_64" when we build for arm64 target.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/2981