### PR TITLE
[Backport wrynose] packagegroup-purwa-iot-evk: add Purwa-specific DSP…

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-purwa-iot-evk.bb
@@ -19,6 +19,6 @@ RRECOMMENDS:${PN}-firmware = " \
 
 # Purwa IoT EVK and Hamoa IoT EVK share the same Hexagon DSP binaries.
 RDEPENDS:${PN}-hexagon-dsp-binaries = " \
-    hexagon-dsp-binaries-qcom-hamoa-iot-evk-adsp \
-    hexagon-dsp-binaries-qcom-hamoa-iot-evk-cdsp \
+    hexagon-dsp-binaries-qcom-purwa-iot-evk-adsp \
+    hexagon-dsp-binaries-qcom-purwa-iot-evk-cdsp \
 "


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/2314 to wrynose.