### PR TITLE
ci: switch sstate cache from EFS to fsxOpenZFS

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
+  CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
   KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5

--- a/.github/workflows/sstate-cleanup.yml
+++ b/.github/workflows/sstate-cleanup.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+env:
+  CACHE_DIR: /efsx/qli/meta-qcom
+
 jobs:
   sstate-cache-cleanup:
     if: github.repository_owner == 'qualcomm-linux'
@@ -17,5 +20,5 @@ jobs:
         run: |
           # bitbake refreshes the mtime of every sstate file a build uses, so
           # a file older than 15 days was not used by any build in 15 days
-          find /efs/qli/meta-qcom/sstate-cache -type f -mtime +15 -delete
-          find /efs/qli/meta-qcom/sstate-cache -mindepth 1 -type d -empty -delete
+          find "${CACHE_DIR}/sstate-cache" -type f -mtime +15 -delete
+          find "${CACHE_DIR}/sstate-cache" -mindepth 1 -type d -empty -delete


### PR DESCRIPTION
This change will reduce sstate cache costs. As AWS EFS costs increase with throughput and data transfer growth, IT evaluated FSx OpenZFS as an alternative and expects 70–80% savings compared to EFS.