### PR TITLE
ci/performance: skip console DSR terminal-size probing

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -3,4 +3,4 @@ header:
 
 local_conf_header:
   cmdline-perf: |
-    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux initramfs.udev-root-only=1"
+    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=dumb initramfs.udev-root-only=1"


### PR DESCRIPTION
Set systemd.tty.term.console=dumb to skip systemd's early ANSI DSR-based terminal-size probing on the console. This avoids the cursor-position query and response wait in terminal_get_size_by_dsr(), reducing PID 1 early initialization time on slow serial consoles. 

The setting only affects systemd's console terminal handling. It does not change the TERM value of the ttyMSM0 serial login session, which continues to use its default terminal type.

Three measurements of this window on `rb3gen2-core-kit` with the `QLI.2.0 wrynose-260627.1` catchall build show:
- Default: `1.259 s`, `1.222 s`, `1.202 s` (average `1.228 s`)
- With this change: `0.850 s`, `0.876 s`, `0.805 s` (average `0.844 s`)

This saves `384 ms (31.3%)` on average, letting PID 1 proceed to manager startup and unit loading sooner so userspace services can start earlier.