### PR TITLE
ci: update qcom-linux-testkit to testkit-2026.09.02

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "6070e41a1472e3fd595ea7ac849f7c30f86a2282"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.08.14"
+  TESTKIT_REF: "testkit-2026.09.02"
 
 jobs:
   prepare-env:


### PR DESCRIPTION
Update TESTKIT_REF from testkit-2026.08.14 to testkit-2026.09.02.

New test coverage:
- baseport: add device-tree hardware capability validation
- baseport: add SMP2P and remoteproc health validation
- baseport: add interconnect and memory integrity tests
- connectivity: add Ethernet inventory, traffic, throughput and suspend/resume validation
- kernel: add MinkIPC PKCS11 validation (single and multi-client)
- storage: add functional RMTFS validation coverage
- add KVM tests to testplan
- add random number generator (rngtest) tests
- audio: add Shikra audio playback and record validation

Enhancements and fixes:
- camera: restore QTI camera server around NHX; add CAMX overlay preparation for desktop
- audio: add Ubuntu control plane support for playback
- graphics: add Ubuntu Wayland session and package profiles; harden weston-simple-egl against wall-clock steps
- bluetooth: harden interactive controller power handling; stabilize scan/pairing tests; improve first-boot firmware recovery
- gstreamer: improve test timeout handling, codec fault classification and probe cache isolation
- sensors: add apt recovery dependencies; derive validation targets from runtime inventory
- connectivity: wifi: ignore recoverable QMI DMA allocation fallback on Hamoa
- utils: add clock step detection, EFI text variable, Bluetooth runtime recovery and device-tree capability helpers

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>