### PR TITLE
ci: update lava-test-plans reference to 72813c68

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ on:
         description: "Token used to submit jobs to the LAVA lab"
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "6070e41a1472e3fd595ea7ac849f7c30f86a2282"
+  LAVA_TEST_PLANS_REF: "72813c68eb386a8491c6b20c70c0324f3228a51c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.08.14"
 


### PR DESCRIPTION
Update LAVA_TEST_PLANS_REF from 6070e41a to 72813c68.

New features:
- Add GitHub Action to render test plans with configurable revision
- projects: add meta-qcom-3rdparty project support
- test: enable FastRPC validation in pre-merge basic tests
- glymur-crd: enable additional testplans and testcases

Fixes/adjustments:
- rb1-core-kit: disable audio tests and testplan
- disable fastrpc_test due to kernel regression

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>