### PR TITLE
[Backport Wrynose] Update LAVA test plans, bring in Shikra testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "62f75dda7cc3c62305abaa5b6ace6c06a080bb7f"
+  LAVA_TEST_PLANS_REF: "ed4ac266438d0d9be521a6bd5498c6816ba718c5"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.06.21"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "ed4ac266438d0d9be521a6bd5498c6816ba718c5"
+  LAVA_TEST_PLANS_REF: "1d5707eec220248e0b4e7a039c545aba4d3e3deb"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.06.21"
+  TESTKIT_REF: "testkit-2026.07.12"
 
 jobs:
   prepare-env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "1d5707eec220248e0b4e7a039c545aba4d3e3deb"
+  LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.07.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
 env:
   # git sha, tag or branch in lava-test-plans repository
-  LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
+  LAVA_TEST_PLANS_REF: "6070e41a1472e3fd595ea7ac849f7c30f86a2282"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
   TESTKIT_REF: "testkit-2026.07.19"
 
@@ -48,7 +48,7 @@ jobs:
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk,sm8750-mtp"
-      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,sm8750-mtp"
+      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk,sm8750-mtp"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
       distro_suffix: "_linux-qcom-next"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,8 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk"
-      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk,sm8750-mtp"
+      devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,sm8750-mtp"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"
       distro_suffix: "_linux-qcom-next"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
   # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
-  TESTKIT_REF: "testkit-2026.07.12"
+  TESTKIT_REF: "testkit-2026.07.19"
 
 jobs:
   prepare-env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       build_id: "${{ inputs.build_id }}"
-      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      devices: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit,shikra-evk"
       devices_premerge: "glymur-crd,iq-8275-evk,iq-9075-evk,iq-x7181-evk,kaanapali-mtp,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
       project_name: "meta-qcom"
       distro_name: "qcom-distro"


### PR DESCRIPTION
Backport #2912 and its dependencies (#2708, #2503, #2768).