### PR TITLE
iq-615-evk: Enable m2connector MACHINE_FEATURE

### DIFF
--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs615.inc
 
-MACHINE_FEATURES += "efi kvm pci tpm2"
+MACHINE_FEATURES += "efi m2connector kvm pci tpm2"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/talos-evk.dtb \


### PR DESCRIPTION
Declare external M.2 connector capability for iq-615-evk.

This feature flag is used by image recipes to decide whether to pull optional M.2 wireless firmware packagegroups. Machines without this hardware should not install those add-on firmware packages.