### PR TITLE
[Backport wrynose] ci: switch sstate cache from EFS to fsxOpenZFS

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
+  CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
   KAS_CONTAINER: ${{ github.workspace }}/kas-container
   KAS_CONTAINER_IMAGE: ghcr.io/siemens/kas/kas:5.5


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom/pull/3054 to wrynose.