### PR TITLE
image-adbd: install the USB gadget modules adbd needs

### DIFF
--- a/classes-recipe/image-adbd.bbclass
+++ b/classes-recipe/image-adbd.bbclass
@@ -12,6 +12,8 @@ IMAGE_FEATURES[validitems] += "enable-adbd"
 
 PACKAGE_INSTALL:append = " ${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "android-tools-adbd android-tools-adbd-cmdline", "", d)}"
 
+PACKAGE_INSTALL_ATTEMPTONLY:append = " ${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "kernel-module-libcomposite kernel-module-usb-f-fs", "", d)}"
+
 enable_adbd_at_boot () {
     touch ${IMAGE_ROOTFS}/etc/usb-debugging-enabled
 }


### PR DESCRIPTION
When trying to install adbd to get serial console on Uno Q we faced a missing module on the target image.

With this it will work when the kernel has the modules built-in or when it's enabled as a module. But it still requires that the kernel enables it somehow (otherwise adbd will not work on the board).