### PR TITLE
firmware-boot: update boot binaries and split archives

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-common.inc
@@ -1,6 +1,13 @@
 # Install NHLOS boot binaries in DEPLOY_DIR
 
 S = "${UNPACKDIR}/${BOOTBINARIES}"
+BOOTBINARIES_IMMUTABLE ?= "${BOOTBINARIES}_immutable"
+
+# Some firmware releases split boot files across the main archive and an
+# immutable companion archive. Deploy the recipe's source directory first, so
+# recipes that override S to a subdirectory keep their existing layout, then
+# deploy the optional immutable archive when it exists.
+QCOM_BOOT_BINARY_DIRS ?= "${S} ${UNPACKDIR}/${BOOTBINARIES_IMMUTABLE}"
 
 QCOM_BOOT_IMG_SUBDIR ?= ""
 
@@ -13,17 +20,20 @@ inherit deploy
 
 do_deploy() {
     install -d ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR}
-    find "${S}" -maxdepth 1 -name 'gpt_*.bin' -delete
-    find "${S}" -maxdepth 1 -name 'zeros_*.bin' -delete
-    find "${S}" -maxdepth 1 -name '*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.elf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.fv' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.lzma' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name 'qsahara_*.xml' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
-    find "${S}" -maxdepth 1 -name '*.xz' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    for bootdir in ${QCOM_BOOT_BINARY_DIRS}; do
+        [ -d "${bootdir}" ] || continue
 
+        find "${bootdir}" -maxdepth 1 -name 'gpt_*.bin' -delete
+        find "${bootdir}" -maxdepth 1 -name 'zeros_*.bin' -delete
+        find "${bootdir}" -maxdepth 1 -name '*.bin' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.elf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.fv' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.lzma' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name 'qsahara_*.xml' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+        find "${bootdir}" -maxdepth 1 -name '*.xz' -exec install -m 0644 {} ${DEPLOYDIR}/${QCOM_BOOT_IMG_SUBDIR} \;
+    done
 }
 addtask deploy before do_build after do_install
 

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181.inc
@@ -7,10 +7,9 @@ include firmware-qcom-boot-common.inc
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Hamoa_bootbinaries.1.0/hamoa_bootbinaries.1.0-test-device-public/"
 BOOTBINARIES = "HAMOA_bootbinaries"
 
-S = "${UNPACKDIR}/${BOOTBINARIES}/spinor"
-
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/HAMOA_bootbinaries_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/HAMOA_bootbinaries_immutable_${PV}.zip;name=bootbinaries-immutable \
     https://${FW_ARTIFACTORY}/${PV}/LICENSE.txt;downloadfilename=LICENSE.${BPN};name=license \
     "
 SRC_URI[license.sha256sum] = "3ad8f1fd82f2918c858cec2d0887b7df6f71a06416beecfdb3efe7d62874d863"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00019.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00019.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "b26be9d7254fecae3732f20f98e519f3efc154efcb7e2e12888b321cfeb25a33"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00023.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00023.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "38bb3cfb8b4c810a5476d2d6613f40e758ee070759035b553992047a68c7bdd5"
+SRC_URI[bootbinaries-immutable.sha256sum] = "389a4a0ff56daf2811d790d2062f97a9b2dfcb32a2c82dfaf324ff7801d98a03"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00137.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a7db0177218ce14cf52d514d3f9413f905b83004a4318b279cbbf73242676fd3"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00140.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "f27bf162caa0dd6e80d0ba3e86b4afecb8fc4cfa9ad1578174d89a2f7ec46d3a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490.inc
@@ -7,6 +7,7 @@ BOOTBINARIES = "QCM6490_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES_IMMUTABLE}_${PV}.zip;name=bootbinaries-immutable \
     "
 
 QCOM_BOOT_IMG_SUBDIR = "qcm6490"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00137.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "24315170167192c63e4969d85d4b20b2bd9311f6b2a72220af571d2ebaa51e2a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00140.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "48f5a141cd8fa620a1869a5b8a0c2b4ec9db5f7bf06d03c84a1b5a4a33a4a135"
+SRC_URI[bootbinaries-immutable.sha256sum] = "91425b049945911f1c11a4652fb1f1c3309e174e650b55d0790f5cad61803bea"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300.inc
@@ -7,6 +7,7 @@ BOOTBINARIES = "QCS8300_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES_IMMUTABLE}_${PV}.zip;name=bootbinaries-immutable \
     "
 
 QCOM_BOOT_IMG_SUBDIR = "qcs8300"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00137.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "54c2b7634807a78dc77f3371004a63ab510b46ae1fc92dbfdc72de1b6d18459e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00140.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "5c17689bdee8793f58e68ebc077e2508555a4ccce601a3c2dc8c68f6267931d3"
+SRC_URI[bootbinaries-immutable.sha256sum] = "f6ddfaa62f19e9a6d944c7f01d1aa5a7dee05f3cb66d9b20970b3834b15ee61e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100.inc
@@ -7,6 +7,7 @@ BOOTBINARIES = "QCS9100_bootbinaries"
 
 SRC_URI = " \
     https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES}_${PV}.zip;name=bootbinaries \
+    https://${FW_ARTIFACTORY}/${PV}/${BOOTBINARIES_IMMUTABLE}_${PV}.zip;name=bootbinaries-immutable \
     "
 
 QCOM_BOOT_IMG_SUBDIR = "qcs9100"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00137.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00137.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "6150c43a55ec95a9e11e288df1a1670a7dc75981485de93376969cb573c9a3c5"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00140.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "8c3f95c0f87305cf0ed88152a9d3bddd30c1757392fe1cc005203a7f2a60dcd3"
+SRC_URI[bootbinaries-immutable.sha256sum] = "6b1427b865121966061671d4a1743a87935f5c6132d67bf09d3f3b79b9cd15b4"


### PR DESCRIPTION
Update boot firmware recipes for QCM6490, QCS9100, QCS8300, QCS615, Hamoa and Purwa to latest release and add support for platforms that ship boot firmware split across primary and immutable archives