### PR TITLE
u-boot-qcom: update SRCREV to latest qcom-next commit

### DIFF
--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -7,7 +7,8 @@ COMPATIBLE_MACHINE:aarch64 = "(qcom)"
 
 PV = "2026.07+2026.10-rc1+git"
 
-SRCREV = "be2aa51173238a0b6fe3f4dcf02f333e1a27ffbe"
+# tag: qcom-next-v2026.07-20260903
+SRCREV = "94cbcc22f2b357218b2a599c3be559718e92b7df"
 SRCBRANCH = "nobranch=1"
 
 SRC_URI = "git://github.com/qualcomm-linux/u-boot.git;${SRCBRANCH};protocol=https;name=uboot"


### PR DESCRIPTION
Bump SRCREV from be2aa5117323 to 94cbcc22f2b3, pulling in the latest fixes and updates from the Qualcomm u-boot tree.

Changelog:
- Improve multi-partition capsule update to be UEFI-spec compliant
- Relocate efi_secureboot.config fragment and add doc for performing secure boot in U-Boot
- Optimizations to improve boot KPI of U-Boot
- Add HS200/HS400 support in Qualcomm MMC driver