### PR TITLE
ci/linux-yocto-dev: ignore version-going-backwards errors

### DIFF
--- a/ci/linux-yocto-dev.yml
+++ b/ci/linux-yocto-dev.yml
@@ -4,3 +4,4 @@ header:
 local_conf_header:
   kernelprovider: |
     PREFERRED_PROVIDER_virtual/kernel = "linux-yocto-dev"
+    ERROR_QA:remove:pn-linux-yocto-dev = "version-going-backwards"


### PR DESCRIPTION
Per its nature, the linux-yocto-dev recipe doesn't have a stable version, it is based purely on the Git commit id, which can go backwards in the alphanumeric space. Remove the check from the recipe's ERROR_QA.