### PR TITLE
firmware-qcom-boot-shikra: update tag 00065 -> 00072

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra.inc
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Shikra-EVK platform"
 LICENSE = "LicenseRef-LICENSE.qcom-2"
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/LICENSE.qcom-2.txt;md5=165287851294f2fb8ac8cbc5e24b02b0"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/LICENSE.qcom-2;md5=165287851294f2fb8ac8cbc5e24b02b0"
 
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/SHIKRA_bootbinaries.1.0/shikra_bootbinaries.1.0-test-device-public"
 BOOTBINARIES = "SHIKRA_bootbinaries"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00065.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00065.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-shikra.inc
-
-SRC_URI[bootbinaries.sha256sum] = "536415482ad869f65b727b5244dc82e3579d24e62cd9273ebbbed904159c3665"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00072.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00072.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-shikra.inc
+
+SRC_URI[bootbinaries.sha256sum] = "a123a9e7e4d7627962a39e6eb0d3773a52d7c43481961eda2e4bb21663b4e7db"


### PR DESCRIPTION
The license content is identical (same md5), only the file
name changed from LICENSE.qcom-2.txt to LICENSE.qcom-2 to
match the other boot firmware archives.

Known fixes:
feat: enable high-speed SD card support in UEFI and device programming tools
feat: add low-power controller interrupt mappings and update shared-memory sizing
fix: update power-management interface settings for Shikra platforms
fix: align retention voltage values with supported power-controller steps
chore: revert always-on power configuration changes