### PR TITLE
AGENTS.md: trailer order, backport conventions, skills catalog and CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,5 +148,46 @@ Signed-off-by: $(git config user.name) <$(git config user.email)>
 
 Never fabricate a name or email; always read them from `git config`.
 
+Trailer order matters: `Assisted-by` goes **before** `Signed-off-by`, so the
+sign-off is always the last trailer written by the author. A complete
+agent-assisted commit message looks like this:
+
+```text
+recipe-name: summary of the changes
+
+Explain the problem first, then the change, in plain English.
+
+Assisted-by: AGENT_NAME:MODEL_VERSION
+Signed-off-by: Author Name <author@example.com>
+```
+
+Do not append `Assisted-by` after `Signed-off-by` (for example with
+`git commit -s` followed by `git interpret-trailers --trailer Assisted-by=...`);
+write both trailers in the order above in a single commit message instead.
+
 Fixups within the same patch series are not allowed; changes should be
 corrected in the patch where they are introduced.
+
+## 8) Backporting to a release branch
+
+Fixes land on `master` first and are then backported to the release branch
+(currently `wrynose`). Merged pull requests labelled `backport wrynose` are
+backported automatically by `.github/workflows/backport.yml`; when a manual
+backport is needed (conflicts, or a change that only applies to the release
+branch), follow the same conventions the automation uses:
+
+1. Create a topic branch from the latest release branch, for example
+   `backport/<pr-number>-to-wrynose`.
+2. Cherry-pick the original commits with `git cherry-pick -x <sha>`, which
+   appends the `(cherry picked from commit <sha>)` line for you. Keep the
+   original subject, body, and trailers unchanged, and add your own
+   `Signed-off-by` after the cherry-pick line if it is not already present.
+3. Open the pull request against the release branch with the subject
+   prefixed by the target branch, for example
+   `[Backport wrynose] recipe-name: summary of the changes`, and link the
+   original pull request in the description.
+
+The `[Backport <branch>]` prefix belongs to the pull request subject only.
+The commits themselves are normal patches whose only backport marker is the
+`(cherry picked from commit ...)` line; never add the prefix to a commit
+subject.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,19 @@ This file guides automation agents to run builds / checks the same way CI does:
 
 meta-qcom is an OpenEmbedded / Yocto Project hardware enablement layer for Qualcomm based platforms.
 
+## Agent skills
+
+Reusable agent skills for the qualcomm-linux projects are maintained in
+[qcom-linux-skills](https://github.com/qualcomm-linux/qcom-linux-skills),
+in the `SKILL.md` format understood by Claude Code, Codex, Cursor and
+similar agents. Several of them cover the workflows described in this file,
+such as `qcom-yocto-build-image` (build images with kas-container),
+`qcom-yocto-pre-pr-checks` (the CI-parity checks from section 4),
+`qcom-yocto-update-base-lock` (refresh `ci/base.lock.yml`), and
+`qcom-flash-qdl` / `qcom-boot-validate` (flash and boot-test a board).
+Install them with the repository's `install.sh` and prefer an existing
+skill over re-deriving the workflow; improvements go back to that catalog.
+
 ## 1) Prerequisites
 
 1. `kas-container` available on PATH, or set `KAS_CONTAINER=/abs/path/to/kas-container`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Updates to the agent guide to make agent-driven development here more reliable:

- **Trailer order**: document that `Assisted-by` goes before `Signed-off-by`, with a complete commit message example. Several commits in history (from different agents) have them reversed, typically from signing off first and appending the trailer afterwards.
- **Backport conventions**: new section matching what `.github/workflows/backport.yml` does. Branch as `backport/<pr>-to-wrynose`, `git cherry-pick -x`, keep the patch otherwise unchanged. The `[Backport <branch>]` prefix belongs in the pull request subject only, never in a commit subject.
- **Agent skills**: point to https://github.com/qualcomm-linux/qcom-linux-skills and name the skills that map to the workflows documented in the guide.
- **CLAUDE.md symlink**: Claude Code reads `CLAUDE.md` and not `AGENTS.md`, and its documentation recommends a symlink when a repo already maintains `AGENTS.md`, so both tools share one guide.