### PR TITLE
qcom-ptool: update qcom-ptool revision

### DIFF
--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "cc3d5fc6744447cc2a453ffb161281fdbac5f3eb"
+SRCREV = "b63a84c16f4247178024d3f7a532441d0a4e1d01"


### PR DESCRIPTION
The following changes were merged in qcom-ptool:

Ali Erdinc Koroglu (1):
      tests: add pytest-based unit tests

Amer Alshanawany (1):
      qcom_ptool: loaders: parse uniqueguid from partition config

Christopher Obbard (1):
      qrb2210-unoq: update partition layout for the downstream edk2 boot firmware

Igor Opaniuk (6):
      pyproject: drop duplicate pytest ini_options section
      README: fix project name in title
      pyproject: declare PyYAML and jsonschema runtime deps
      README: document PyYAML and jsonschema runtime deps
      loaders: add YAML partition loader with schema validation
      tests: cover the YAML loader and schema

Vivek Puar (2):
      platforms/kaanapali-mtp: update partition type GUIDs for Kaanapali-MTP
      platforms/sm8750-mtp: update partition type GUIDs for SM8750-MTP