### PR TITLE
android-tools-conf: allow pinning the adbd UDC

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
@@ -5,8 +5,12 @@ set -e
 # Wait before touching configfs, unless the unit tells us it is not needed.
 sleep "${ANDROID_GADGET_UDC_DELAY:-10}"
 
-# Speed-only selection:
-# 1) Pick UDC with highest maximum_speed
+# UDC selection:
+# 0) An explicit UDC always wins, taken from the 'adbd.udc=<name>' kernel
+#    command line argument. Needed on boards with several equally capable OTG
+#    ports, where the speed-based selection below cannot tell which one is
+#    wired for debug.
+# 1) Otherwise pick UDC with highest maximum_speed
 # 2) Tie-breaker: lexicographic order (first one found via sort)
 #
 # Recognized speeds:
@@ -51,21 +55,33 @@ read_max_speed() {
 best_udc=""
 best_max_rank=-1
 
-# Iterate all UDCs and select the best one by maximum_speed.
-for udc in $(ls -1 "$UDC_FOLDER" 2>/dev/null | sort); do
-    udc_path="$UDC_FOLDER/$udc"
-    [ -d "$udc_path" ] || continue
-
-    max_text="$(read_max_speed "$udc_path")"
-    max_rank="$(speed_rank "$max_text")"
-
-    # Initialize or update if we found a faster controller
-    # Strict inequality (>): maintains lexicographical order (first one wins) on ties
-    if [ -z "$best_udc" ] || [ "$max_rank" -gt "$best_max_rank" ]; then
-        best_udc="$udc"
-        best_max_rank="$max_rank"
+# An explicit UDC overrides the speed-based selection below.
+udc_override="$(sed -n -e '/adbd\.udc=/ s/.*adbd\.udc=\([^ ]*\).*/\1/p' /proc/cmdline)"
+if [ -n "$udc_override" ]; then
+    if [ -d "$UDC_FOLDER/$udc_override" ]; then
+        best_udc="$udc_override"
+    else
+        echo "Warning: requested UDC '$udc_override' not present, falling back to autodetection." >&2
     fi
-done
+fi
+
+# Iterate all UDCs and select the best one by maximum_speed.
+if [ -z "$best_udc" ]; then
+    for udc in $(ls -1 "$UDC_FOLDER" 2>/dev/null | sort); do
+        udc_path="$UDC_FOLDER/$udc"
+        [ -d "$udc_path" ] || continue
+
+        max_text="$(read_max_speed "$udc_path")"
+        max_rank="$(speed_rank "$max_text")"
+
+        # Initialize or update if we found a faster controller
+        # Strict inequality (>): maintains lexicographical order (first one wins) on ties
+        if [ -z "$best_udc" ] || [ "$max_rank" -gt "$best_max_rank" ]; then
+            best_udc="$udc"
+            best_max_rank="$max_rank"
+        fi
+    done
+fi
 
 if [ -z "$best_udc" ]; then
     echo "Error: No UDC controller found in $UDC_FOLDER" >&2

--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
@@ -2,7 +2,8 @@
 
 set -e
 
-sleep 10
+# Wait before touching configfs, unless the unit tells us it is not needed.
+sleep "${ANDROID_GADGET_UDC_DELAY:-10}"
 
 # Speed-only selection:
 # 1) Pick UDC with highest maximum_speed

--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf/android-gadget-start
@@ -17,11 +17,11 @@ GADGET_PATH="/sys/kernel/config/usb_gadget/adb"
 
 if [ ! -d "$UDC_FOLDER" ]; then
     echo "Error: UDC folder '$UDC_FOLDER' not found." >&2
-    return 1
+    exit 1
 fi
 if [ ! -d "$GADGET_PATH" ]; then
     echo "Error: Gadget path '$GADGET_PATH' does not exist." >&2
-    return 1
+    exit 1
 fi
 
 # Return a normalized rank for a speed string.
@@ -69,7 +69,7 @@ done
 
 if [ -z "$best_udc" ]; then
     echo "Error: No UDC controller found in $UDC_FOLDER" >&2
-    return 1
+    exit 1
 fi
 
 echo "Binding Gadget to UDC: $best_udc (maximum_speed='$(read_max_speed "$UDC_FOLDER/$best_udc")')" >&2


### PR DESCRIPTION
On boards with two equally capable OTG ports, `android-gadget-start` has no
way to say which one adb should use. It ranks `/sys/class/udc` entries by
`maximum_speed` and breaks ties lexicographically, so on nord-ride-embedded —
where both controllers are `dr_mode = "otg"` behind a Type-C role switch and
both use a QMP USB3+DP PHY — `a400000.usb` (usb_1) always wins over
`a600000.usb` (usb_0). adb comes up on usb_1 and there is no supported way to
move it to usb_0.

This series adds an explicit override, preceded by two fixes to problems found
in the same script along the way.

- **android-tools-conf: honour ANDROID_GADGET_UDC_DELAY** — the script sleeps a
  hardcoded 10s, ignoring the `ANDROID_GADGET_UDC_DELAY=0` set by meta-oe's
  `10-adbd-configfs.conf`. Every adbd start pays 10s before adb is usable, and
  the drop-in's comment misleads anyone reading the unit. Default stays 10s.
- **android-tools-conf: exit instead of return on error** — three top-level
  error paths use `return 1`, but the script is executed as `ExecStartPost`,
  not sourced. In dash that is invalid, so configfs setup failures surface as a
  shell diagnostic instead of a clean service failure.
- **android-tools-conf: allow pinning the adbd UDC** — accept an explicit UDC
  from the `adbd.udc=<name>` kernel command line argument or `ADBD_UDC` in
  `/etc/default/android-tools-adbd`, command line winning. An unknown name logs
  a warning and falls back to the speed-based scan, so a typo or renamed node
  cannot leave a board without adb.

Boards that set neither override are unaffected.