### PR TITLE
eva-driver: Add EVA kernel driver recipe

### DIFF
--- a/recipes-multimedia/eva/eva-driver_1.0.1.bb
+++ b/recipes-multimedia/eva/eva-driver_1.0.1.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "Qualcomm EVA (CVP) driver"
+HOMEPAGE = "https://github.com/qualcomm-linux/eva-driver"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://Kbuild;beginline=1;endline=1;md5=829e563511c9a1d6d41f17a7a4989d6a"
+
+SRC_URI = " \
+    git://github.com/qualcomm-linux/eva-driver.git;protocol=https;branch=eva-kernel.qclinux.0.0;tag=${PV} \
+"
+
+SRCREV = "6e20debbe82a3939ad3ec5e09ddf6662224ff7bd"
+
+inherit module
+
+MAKE_TARGETS = "modules"
+MODULES_INSTALL_TARGET = "modules_install"
+
+EXTRA_OEMAKE += "INCLUDEDIR=${STAGING_DIR_TARGET}${includedir}"
+INSANE_SKIP:${PN} += "installed-vs-shipped"
+# INSANE_SKIP allows to omit the packaging of the .conf files which we just want to install on the target
+
+do_install:append() {
+    install -d ${D}${includedir}/eva/media
+    install -m 0644 ${S}/include/uapi/eva/media/*.h ${D}${includedir}/eva/media/
+}
+
+KERNEL_MODULE_AUTOLOAD += "msm-eva"
+KERNEL_MODULE_PROBECONF += "msm-eva"
+module_conf_msm-eva = "options msm_eva mp_load_pil=0"
+
+# This package is designed to run exclusively on ARMv8 (aarch64) machines.
+# Therefore, builds for other architectures are not necessary and are explicitly excluded.
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
Add a recipe for the Qualcomm EVA (Engine for Visual Analytics) kernel driver.

The EVA driver provides the kernel-space interface to Qualcomm's vision acceleration hardware. It manages device
initialization, memory handling, firmware interaction, buffer management, and communication between userspace clients and EVA hardware.

The recipe builds and installs the msm-eva kernel module along with the associated UAPI headers required by userspace components to interact with the driver.

The driver forms the foundation of the EVA software stack and is consumed by higher-level vision runtimes such as Snapdragon Vision (SV), enabling applications to access hardware-accelerated vision capabilities on supported Qualcomm platforms.

Note: This PR is for review only and it will be merged only after getting the eva-driver overlay exception.