### PR TITLE
shikra-evk: fix CQM/CQS IMX577 DTBO entry

### DIFF
--- a/conf/machine/shikra-evk.conf
+++ b/conf/machine/shikra-evk.conf
@@ -10,7 +10,7 @@ KERNEL_DEVICETREE ?= " \
                       qcom/shikra-cqm-evk.dtb \
                       qcom/shikra-cqs-evk.dtb \
                       qcom/shikra-iqs-evk.dtb \
-                      qcom/shikra-cqm-evk-imx577-camera.dtbo \
+                      qcom/shikra-cqm-cqs-evk-imx577-camera.dtbo \
                       qcom/shikra-iqs-evk-imx577-camera.dtbo \
                       "
 


### PR DESCRIPTION
The machine configuration still listed shikra-cqm-evk-imx577-camera.dtbo in KERNEL_DEVICETREE. The camera overlay name used for this target is shikra-cqm-cqs-evk-imx577-camera.dtbo, so the stale entry points to a non-existent artifact.

Update KERNEL_DEVICETREE to use the current combined CQM/CQS camera DTBO name.