### PR TITLE
ci: use specific variable for build-id

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -90,7 +90,7 @@ jobs:
             version: 14
           local_conf_header:
             build-id: |
-              BUILD_ID = "${BUILD_ID}"
+              QCOM_BUILD_ID = "${BUILD_ID}"
           EOF
         env:
           INPUTS_CACHE_DIR: ${{inputs.cache_dir}}

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -69,7 +69,9 @@ local_conf_header:
     # Use a weak assignment so the CI override wins regardless of how kas
     # orders the merged local.conf fragments.
     OS_RELEASE_FIELDS:append = " BUILD_ID"
-    BUILD_ID ?= "local-${DATETIME}"
+    QCOM_BUILD_ID ?= "local-${DATETIME}"
+    BUILD_ID ?= "${QCOM_BUILD_ID}"
+    BUILD_ID[vardepsexclude] ?= "QCOM_BUILD_ID"
 
 machine: unset
 


### PR DESCRIPTION
The variable BUILD_ID should be excluded from the dependencies. To do this more easily, the variable QCOM_BUILD_ID is introduced.

The content of BUILD_ID is usually always different each time it's runs or parsed. This happens because the variable contains the value of DATETIME or the ${{ github.run_id }}-${{ github.run_attempt }} github ci action. Therefore, we should rule out running any task again if it is solely due to changes in the BUILD_ID.
