### PR TITLE
qmi-framework: upgrade 0.1.3 -> 0.1.4

### DIFF
--- a/recipes-support/qmi-framework/qmi-framework_0.1.4.bb
+++ b/recipes-support/qmi-framework/qmi-framework_0.1.4.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=65b8cd575e75211d9d4ca8603167da1c"
 
 DEPENDS = "glib-2.0"
-SRCREV = "6ea813ce9fdb1126b1aa18f5447befe9119be437"
+SRCREV = "38adce019b985011bac95efe494a42e7083126f7"
 
 SRC_URI = "git://github.com/quic/qmi-framework.git;protocol=https;branch=main;tag=v${PV}"
 


### PR DESCRIPTION
Upgrade qmi-framework from version 0.1.3 to 0.1.4.

This is a minimal recipe-only bump:
- rename `qmi-framework_0.1.3.bb` to `qmi-framework_0.1.4.bb`
- update `SRCREV` to the v0.1.4 tag commit