### PR TITLE
ci/performance: enable root-only udev trigger

### DIFF
--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -3,5 +3,4 @@ header:
 
 local_conf_header:
   cmdline-perf: |
-    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"
-    KERNEL_CMDLINE_EXTRA:append = "${@' initramfs.udev-root-only=1' if d.getVar('INITRAMFS_IMAGE') == 'initramfs-rootfs-image' else ''}"
+    KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux initramfs.udev-root-only=1"


### PR DESCRIPTION
The initramfs udev framework now supports root-only triggering for all supported initramfs images and falls back to a full trigger when the root device cannot be resolved.

Enable the optimization unconditionally in the performance command line instead of limiting it to initramfs-rootfs-image.

This relies on the following OE-Core changes:
https://github.com/openembedded/openembedded-core/commit/d3a196f5742425fb24cfc21bb380f3e96c49253c
https://github.com/openembedded/openembedded-core/commit/fda394c2b91b3c66545f75dc13f7e8649e3cdb6d