### PR TITLE
adreno: Update 1.877.3 -> 1.887.1

### DIFF
--- a/recipes-graphics/adreno/qcom-adreno_1.887.1.bb
+++ b/recipes-graphics/adreno/qcom-adreno_1.887.1.bb
@@ -10,8 +10,8 @@ LIC_FILES_CHKSUM = "file://NO.LOGIN.BINARY.LICENSE.QTI.pdf;md5=4ceffe94cb40cdce6
 
 # no top-level dir in the archive, unpack to subdir to prevent UNPACKDIR pollution
 SRC_URI = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/gfx-adreno.le.0.0/${PBT_BUILD_DATE}/prebuilt_yocto/${BPN}_${PV}_armv8a.tar.gz;subdir=${BP}"
-PBT_BUILD_DATE = "260728"
-SRC_URI[sha256sum] = "11c141b6bed7cad32a7b171bb71b886b299e0c6bc6407a1e542b7c57d4bd798d"
+PBT_BUILD_DATE = "260903"
+SRC_URI[sha256sum] = "c699bfcdf69f3c4c272d2b5614d0405619950369ae2cdced6a0930f499ee30f5"
 
 # These are listed here in order to identify RDEPENDS
 DEPENDS += " glib-2.0 libdrm \
@@ -98,7 +98,12 @@ do_install () {
     cp ${S}/etc/modprobe.d/qcom-adreno.conf ${D}/${sysconfdir}/modprobe.d/qcom-adreno.conf
 }
 
-FILES:${PN}-common = "${libdir}/libllvm-*.so.* \
+FILES:${PN}-common = "${libdir}/libQCGPUCompiler.so.* \
+                      ${libdir}/libQCGPUCompilerCore.so.* \
+                      ${libdir}/libqclccompiler.so.* \
+                      ${libdir}/libqgpucompiler-lgc.so.* \
+                      ${libdir}/libqgpucompilercore-lgc.so.* \
+                      ${libdir}/libqclccompiler-lgc.so.* \
                       ${libdir}/libgsl.so.1 \
                       ${libdir}/libadreno_utils.so.1 \
                       ${libdir}/libq3dtools_*.so.* \


### PR DESCRIPTION
Update qcom-adreno version from 1.877.3 to 1.887.1

Changes for 1.887.1:
* Add OpenCL profiling support to improve compute workload analysis and performance debugging.
* Enhance standards compliance and cross-platform compatibility through improvements to memory scope and atomic operation handling.
* Improve platform capability reporting for more accurate exposure of supported graphics and compute features.
* Update graphics compiler components to improve compatibility with newer toolchains and development environments.
* Enhance deployment flexibility through dynamic shader compiler component loading.
* Improve support for multi-adapter configurations and heterogeneous system environments.
* Enhance external buffer import handling and pixel format interoperability.
* Improve compatibility with DRM-based graphics environments.
* Improve build portability, maintainability, and overall driver infrastructure.
* Deliver stability, reliability, and compatibility improvements across OpenGL ES, Vulkan, OpenCL, compiler, and runtime components.
* Replace libllvm-*.so.* with new libraries and Enhance LLVM backend integration to support flexible runtime selection of multiple compiler backends.