### PR TITLE
qcom-armv7a: drop ifc6540 from the DTS list

### DIFF
--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -32,7 +32,6 @@ KERNEL_DEVICETREE ?= " \
     qcom/qcom-apq8064-asus-nexus7-flo.dtb \
     qcom/qcom-apq8064-ifc6410.dtb \
     qcom/qcom-apq8074-dragonboard.dtb \
-    qcom/qcom-apq8084-ifc6540.dtb \
     qcom/qcom-msm8974-lge-nexus5-hammerhead.dtb \
 "
 


### PR DESCRIPTION
Recent kernels have dropped support for the IFC6540. Remove it from the KERNEL_DEVICETREE list for the qcom-armv7a machine to prevent build failures with the recent linux-yocto-dev.