### PR TITLE
qcom-fastcv-binaries: fix PBT_BUILD_DATE for the 1.8.8 prebuilt

### DIFF
--- a/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
+++ b/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
@@ -4,7 +4,7 @@ LICENSE = "LicenseRef-LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/${PN}/NOLOGINBINARYLICENSEQTI.pdf;md5=4ceffe94cb40cdce6d2f4fb93cc063d1 \
                     file://${UNPACKDIR}/usr/share/doc/${PN}/NOTICE;md5=4b722aa0574e24873e07b94e40b92e4d "
 
-PBT_BUILD_DATE = "260707"
+PBT_BUILD_DATE = "260719"
 ARTIFACTORY_URL = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/computervision-fastcv.qclinux.0.1/${PBT_BUILD_DATE}/prebuilt_yocto_wrynose"
 PBT_ARCH = "armv8a"
 


### PR DESCRIPTION
The upgrade to 1.8.8 switched the artifactory path to the wrynose prebuilt and updated the SRC_URI checksum, but left PBT_BUILD_DATE at
260707. That directory only contains the 1.8.7 tarball, so do_fetch fails with a 404 unless the file is already in DL_DIR or a mirror.

CI did not catch this most likely because an earlier run had already downloaded the 1.8.8 tarball into the shared DL_DIR, where it is looked up by file name and checksum, so the broken URL was never hit again.

The 1.8.8 tarball matching the checksum in the recipe is published under 260719, so update PBT_BUILD_DATE to point at it.

Fixes: 7551c3bdcd5d ("qcom-fastcv-binaries: upgrade 1.8.7 -> 1.8.8")
Assisted-by: Claude Code:claude-fable-5-1