### PR TITLE
Fix PBT_BUILD_DATE left stale in qcom-fastcv-binaries v1.8.8 upgrade

### DIFF
--- a/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
+++ b/recipes-multimedia/fastcv/qcom-fastcv-binaries_1.8.8.bb
@@ -4,7 +4,7 @@ LICENSE = "LicenseRef-LICENSE.qcom-2"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/usr/share/doc/${PN}/NOLOGINBINARYLICENSEQTI.pdf;md5=4ceffe94cb40cdce6d2f4fb93cc063d1 \
                     file://${UNPACKDIR}/usr/share/doc/${PN}/NOTICE;md5=4b722aa0574e24873e07b94e40b92e4d "
 
-PBT_BUILD_DATE = "260707"
+PBT_BUILD_DATE = "260719"
 ARTIFACTORY_URL = "https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/computervision-fastcv.qclinux.0.1/${PBT_BUILD_DATE}/prebuilt_yocto_wrynose"
 PBT_ARCH = "armv8a"
 


### PR DESCRIPTION
The 1.8.7 -> 1.8.8 upgrade of qcom-fastcv-binaries bumped PV but left PBT_BUILD_DATE pointing at the 260707 artifact directory, so ARTIFACTORY_URL resolved to a build that doesn't exist causing do_fetch to fail.

Update PBT_BUILD_DATE to 260719 to match the artifact this recipe is meant to consume.