### PR TITLE
iris-video-dlkm: purwa : hamoa : load qcom-iris instead of iris_vpu 

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
@@ -49,6 +49,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:kaanapali = "150"
 # On sm8750, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:sm8750 = "150"
 
+# On purwa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:purwa = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"

--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.27.bb
@@ -52,6 +52,9 @@ ALTERNATIVE_PRIORITY_${PN}-bl-vidc:sm8750 = "150"
 # On purwa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
 ALTERNATIVE_PRIORITY_${PN}-bl-vidc:purwa = "150"
 
+# On hamoa, prioritize blacklisting unsupported iris_vpu to load qcom-iris.
+ALTERNATIVE_PRIORITY_${PN}-bl-vidc:hamoa = "150"
+
 ALTERNATIVE:${PN}-bl-venus = "blacklist-video"
 ALTERNATIVE_TARGET_${PN}-bl-venus = "${sysconfdir}/modprobe.d/blacklist-video.conf.venus"
 ALTERNATIVE_PRIORITY_${PN}-bl-venus = "100"


### PR DESCRIPTION
On Purva and Hamou targets, 
When iris-video-dlkm is installed (for example, in qcom-multimedia-proprietary-image),
the default update-alternatives priority activates `blacklist-video.conf.venus`,
which results in qcom_iris being blacklisted and prevents the in-kernel driver
from loading and functioning correctly.

The in-tree qcom-iris driver supports all video capabilities and features
required for purva and hamoa. Therefore, the out-of-tree iris_vpu driver is not
needed on this platform.

Raise the update-alternatives priority of the `bl-vidc sub-package` to 150 ,
ensuring it takes precedence over bl-venus and becomes the active alternative.
This activates `blacklist-video.conf.vidc` , effectively blacklisting iris_vpu while
allowing qcom_iris to load and operate as expected.