### PR TITLE
qcom-rtss-can: add recipe for RTSS CAN userspace deamon

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-support/qcom-rtss-can/qcom-rtss-can_1.0.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-support/qcom-rtss-can/qcom-rtss-can_1.0.0.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Qualcomm RTSS CAN userspace daemon"
+DESCRIPTION = "Userspace daemon acting as a gateway between SocketCAN \
+applications and RTSS using the RTSS mailbox UMD libraries."
+
+HOMEPAGE = "https://github.com/qualcomm/rtss-can"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=223037c4be0bfc6cf757035432adf983"
+
+# Build-time dependencies.
+DEPENDS = " \
+    glib-2.0 \
+    qcom-rtss-mailbox-umd \
+    qcom-rtss-mailbox-dlkm \
+"
+
+SRC_URI = "git://github.com/qualcomm/rtss-can.git;branch=rtss-can.le.1.0;protocol=https"
+SRCREV = "c7ba2c41bbca75699c44d1c9f25890b8efa0c9c1"
+
+inherit cmake pkgconfig
+
+# The RTSS mailbox UMD and DLKM recipes support these machines.
+COMPATIBLE_MACHINE = "qcs9100-ride-sx|qcs8300-ride-sx|iq-9075-evk|iq-8275-evk"
+
+# Runtime commands, userspace libraries, and kernel modules.
+RDEPENDS:${PN} = " \
+    iproute2 \
+    kmod \
+    qcom-rtss-mailbox-umd \
+    can-utils-access \
+    kernel-module-can \
+    kernel-module-can-raw \
+    kernel-module-can-gw \
+    kernel-module-vcan \
+    kernel-module-rtss-mailbox \
+"
+
+# The daemon is installed in this phase but is not automatically started.
+# No systemd service is provided by this change.


### PR DESCRIPTION
### Target milestone: qli-2.1 pull-request freeze

### Background

The RTSS subsystem on Qualcomm SoCs includes a dedicated CAN controller that is not directly accessible from the Linux CAN stack. This recipe builds rtss_can, a userspace daemon that bridges that gap by routing traffic between Linux SocketCAN virtual interfaces and RTSS mailbox channels, allowing standard SocketCAN applications to communicate with CAN hardware managed by RTSS. The daemon depends on qcom-rtss-mailbox-umd for the librtss_mailbox interface and on linux-libc-headers for the SocketCAN kernel UAPI headers (linux/can.h, linux/can/raw.h).  

### PR dependency
https://github.com/qualcomm-linux/meta-qcom/pull/3084

### Tracking 
https://github.com/qualcomm-linux/meta-qcom/issues/3123

### Testing
Default bootup verified on lemans and monaco targets.