### PR TITLE
ci: move debug to the weekly profile and trim the catchall variants

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -281,6 +281,14 @@ jobs:
                 name: qcom-distro-catchall
             kernel:
                 type: rt-6.18-distro-kvm
+          - distro:
+                name: debug
+            kernel:
+                type: rt-6.18-distro-kvm
+          - distro:
+                name: performance
+            kernel:
+                type: rt-6.18-distro-kvm
           # Exclude jobs from compile_warm_up
           - machine: glymur-crd
             distro:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -257,7 +257,7 @@ jobs:
             yamlfile: ':ci/qcom-distro-catchall.yml'
           - name: debug
             yamlfile: ':ci/qcom-distro-catchall.yml:ci/debug.yml'
-            profile: full
+            profile: weekly
           - name: performance
             yamlfile: ':ci/qcom-distro-catchall.yml:ci/performance.yml'
             profile: full

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -256,10 +256,10 @@ jobs:
           - name: qcom-distro-catchall
             yamlfile: ':ci/qcom-distro-catchall.yml'
           - name: debug
-            yamlfile: ':ci/qcom-distro-catchall.yml:ci/debug.yml'
+            yamlfile: ':ci/qcom-distro-catchall.yml:ci/debug.yml:ci/nospdx.yml'
             profile: weekly
           - name: performance
-            yamlfile: ':ci/qcom-distro-catchall.yml:ci/performance.yml'
+            yamlfile: ':ci/qcom-distro-catchall.yml:ci/performance.yml:ci/nospdx.yml'
             profile: full
         kernel:
           - type: default

--- a/ci/debug.yml
+++ b/ci/debug.yml
@@ -5,7 +5,7 @@ local_conf_header:
   debug-build: |
     DEBUG_BUILD = "1"
     IMAGE_GEN_DEBUGFS = "1"
-    IMAGE_FSTYPES_DEBUGFS = "tar.bz2"
+    IMAGE_FSTYPES_DEBUGFS = "tar.zst"
 
   cmdline-dbg: |
     KERNEL_CMDLINE_EXTRA_FTRACE = "ftrace=tracing_on trace_buf_size=5M trace_event=timer:timer_expire_entry,timer:timer_expire_exit,timer:hrtimer_cancel,timer:hrtimer_expire_entry,timer:hrtimer_expire_exit,timer:hrtimer_init,timer:hrtimer_start,irq:*,workqueue:*,sched:sched_migrate_task,sched:sched_pi_setprio,sched:sched_switch,sched:sched_wakeup,sched:sched_wakeup_new,power:clock_set_rate,power:clock_enable,power:clock_disable,power:cpu_frequency,regulator:*,thermal:thermal_zone_trip,thermal:thermal_temperature,thermal:cdev_update,rpmh:rpmh_send_msg"

--- a/ci/nospdx.yml
+++ b/ci/nospdx.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+local_conf_header:
+  nospdx: |
+    IMAGE_CLASSES:remove = "create-spdx-image-3.0"


### PR DESCRIPTION
The debug rows are 62 of the nightly's 129 machine-hours and, at 77 minutes
each, the last jobs to finish. On top of that, the rt-6.18-distro-kvm kernel
entry turns the debug and performance rows into qcom-distro builds the
qcom-distro row already produces, so 32 jobs per run publish a duplicate
under the wrong name.

Drop the hijacked rt-kvm rows of debug and performance, move debug to the
weekly profile (which had no rows of its own), compress the debugfs tarball
with zstd instead of bzip2, and skip the image-level SBOM on debug and
performance through a new ci/nospdx.yml fragment.

The matrix goes from 221 to 189 configurations. Nightly and push runs lose
all debug rows; the weekly keeps them, at a fraction of the cost. The
published debug tarball is renamed from .rootfs-dbg.tar.bz2 to
.rootfs-dbg.tar.zst.