### PR TITLE
ci/kas-container-shell-helper: run with the build's kas configuration

### DIFF
--- a/ci/kas-container-shell-helper.sh
+++ b/ci/kas-container-shell-helper.sh
@@ -17,4 +17,4 @@ SCRIPT=${SCRIPT#$TOPDIR/}
 # on ci the kas-container is not on the default path
 KAS_CONTAINER=${KAS_CONTAINER:-$(which kas-container)}
 
-exec $KAS_CONTAINER shell $TOPDIR/ci/base.yml --command "/repo/$SCRIPT /repo /work"
+exec $KAS_CONTAINER shell ${KAS_YAMLS:-$TOPDIR/ci/base.yml} --command "/repo/$SCRIPT /repo /work"


### PR DESCRIPTION
The helper always starts kas with ci/base.yml, so the buildstats step between a job's world and image builds rewrites bblayers.conf for a smaller layer set. bitbake then treats its parse cache as stale and the image build parses all 3851 recipes again instead of loading them, 40 s against about 10 s for a cache hit, on each of the 36 nightly jobs that build world.

Use KAS_YAMLS when the caller exports it, as compile.yml does, and keep ci/base.yml as the default for the layer checks.