### PR TITLE
image_types_qcom: hard link the ESP image into the qcomflash directory

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -53,7 +53,7 @@ deploy_partition_files() {
 
 create_qcomflash_pkg() {
     # esp image
-    [ -n "${QCOM_ESP_FILE}" ] && install -m 0644 ${QCOM_ESP_FILE} efi.bin
+    [ -n "${QCOM_ESP_FILE}" ] && cp -l -L ${QCOM_ESP_FILE} efi.bin
 
     # dtb image
     if [ -n "${QCOM_DTB_DEFAULT}" ] && \


### PR DESCRIPTION
create_qcomflash_pkg installs the ESP image into a directory that exists only so it can be tarred, and never modifies it there, the same situation rootfs.img was in. The copy reads and writes the 512 MiB image once more per image, on a task that is already the heaviest disk writer of the image build, for a file whose only reader is the tar that follows.

Hard link it instead, so the tarball is built from the deployed file and nothing is written.