### PR TITLE
camx-dlkm: Update camx driver to v1.0.6

### DIFF
--- a/recipes-multimedia/camx/camx-dlkm_1.0.6.bb
+++ b/recipes-multimedia/camx/camx-dlkm_1.0.6.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     git://github.com/qualcomm-linux/camera-driver.git;protocol=https;branch=camera-kernel.qclinux.0.0;tag=v${PV} \
 "
 
-SRCREV = "0f16924ff6a7f9bb56a7e958016da2ed8a174f2f"
+SRCREV = "82ac3a671a5b0a4e3b3ac4519208af1d37a93eb6"
 
 inherit module
 


### PR DESCRIPTION
This tag v1.0.6 brings a below updates:

- Shikra platform support.
- Multi-camera VFE clock/BW state corruption fixes.
- IRQ controller lock handling improvements.
- Reduced stack usage in ioctl and packet processing paths.