### PR TITLE
Enable camera support for Talos lyra EVK board

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -192,7 +192,7 @@ FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
 FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs615-iot-subtype8] = \
-    "talos-lyra-evk"
+    "talos-lyra-evk talos-lyra-evk-camx"
 
 # ---------- kodiak ----------
 FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"

--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -191,6 +191,8 @@ FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2"
 FIT_DTB_COMPATIBLE[qcom_talos-evk-lvds-auo_g133han01-staging] = \
     "talos-evk talos-evk-lvds-auo_g133han01 talos-el2 talos-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs615-iot-subtype8] = \
+    "talos-lyra-evk"
 
 # ---------- kodiak ----------
 FIT_DTB_COMPATIBLE[qcom_qcm6490-idp-staging] = "qcm6490-idp kodiak-staging"

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -19,6 +19,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-staging.dtbo \
                       qcom/talos-evk-staging.dtbo \
                       qcom/talos-lyra-evk.dtb \
+                      qcom/talos-lyra-evk-camx.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/iq-615-evk.conf
+++ b/conf/machine/iq-615-evk.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/talos-el2.dtbo \
                       qcom/talos-staging.dtbo \
                       qcom/talos-evk-staging.dtbo \
+                      qcom/talos-lyra-evk.dtb \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Add Talos Lyra EVK camera support to the machine IQ-615 and add the corresponding FIT compatible mapping.

Talos Lyra EVK, a QCS615-based System on Module (SoM) paired with a common carrier board.

The Talos Lyra SoM is a compact compute module integrating the QCS615 SoC, PMICs, memory, and essential connectivity. It is designed to be paired with multiple carrier boards to support different use cases.

Talos Lyra is a distinct SoM revision of the existing Talos EVK SoM. The key differences are:
Adds Apache (Lite-on-Module) WLAN on SoC Card.
Removes SPI-attached CAN transceiver module.
SDC2 Supported SDIO based WLAN on existing Talos SoM, while now it is used for SD card connector only.

Changes:
Add Talos Lyra EVK CAMX DTB to LINUX_QCOM_KERNEL_DEVICETREE to the IQ-615 machine.

Add FIT DTB compatible string for talos-lyra-evk-camx.dtbo to ensure the correct DTB is selected during boot.