### PR TITLE
fit-dtb-compatible: shikra-evk: Add HDMI, DLC panel and LVDS overlay support

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -250,3 +250,9 @@ FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype2-camx-staging] = \
 # ---------- glymur ----------
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-staging] = "glymur-crd glymur-staging"
 FIT_DTB_COMPATIBLE[qcom_glymur-crd-camx] = "glymur-crd glymur-crd-camx"
+
+# ---------- shikra ----------
+FIT_DTB_COMPATIBLE[qcom_shikracqm-itp-hdmi] = "shikra-cqm-evk shikra-cqm-cqs-evk-hdmi"
+FIT_DTB_COMPATIBLE[qcom_shikracqs-itp-hdmi] = "shikra-cqs-evk shikra-cqm-cqs-evk-hdmi"
+FIT_DTB_COMPATIBLE[qcom_shikraiqs-itp-dlc] = "shikra-iqs-evk shikra-iqs-evk-dlc-panel"
+FIT_DTB_COMPATIBLE[qcom_shikraiqs-itp-lvds] = "shikra-iqs-evk shikra-iqs-evk-lvds-auo_g133han01"

--- a/conf/machine/shikra-evk.conf
+++ b/conf/machine/shikra-evk.conf
@@ -12,6 +12,9 @@ KERNEL_DEVICETREE ?= " \
                       qcom/shikra-iqs-evk.dtb \
                       qcom/shikra-cqm-evk-imx577-camera.dtbo \
                       qcom/shikra-iqs-evk-imx577-camera.dtbo \
+                      qcom/shikra-cqm-cqs-evk-hdmi.dtbo \
+                      qcom/shikra-iqs-evk-dlc-panel.dtbo \
+                      qcom/shikra-iqs-evk-lvds-auo,g133han01.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Add FIT DTB compatible entries and KERNEL_DEVICETREE entries for the Shikra EVK display overlay configurations:

- shikra-cqm-evk-hdmi: CQM EVK with LT9611UXD HDMI bridge overlay
- shikra-cqs-evk-hdmi: CQS EVK with LT9611UXD HDMI bridge overlay
- shikra-iqs-evk-dlc-panel: IQS EVK with DLC panel overlay
- shikra-iqs-evk-lvds-auo,g133han01: IQS EVK with AUO G133HAN01 LVDS panel overlay