### PR TITLE
Revert RB1 switch to the edk2 firmware

### DIFF
--- a/conf/machine/rb1-core-kit.conf
+++ b/conf/machine/rb1-core-kit.conf
@@ -6,6 +6,7 @@ require conf/machine/include/qcom-qcm2290.inc
 
 MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
 
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 UBOOT_CONFIG = "qrb2210-rb1"
 
 QCOM_DTB_DEFAULT ?= "qrb2210-rb1"
@@ -19,9 +20,11 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-rb1-hexagon-dsp-binaries \
 "
 
-QCOM_CDT_FILE = "cdt_rb1_core_kit"
-QCOM_BOOT_FILES_SUBDIR = "qrb2210"
-QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qrb2210-rb1/emmc"
+# Helper util to tell the android bootloader to mark the boot as successfull.
+# The boot firmware will switch to slot B and fail to boot otherwise.
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "qbootctl"
 
-QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qrb2210"
-QCOM_CDT_FIRMWARE = "firmware-qcom-cdt-qrb2210"
+QCOM_BOOT_FILES_SUBDIR = "qrb2210-rb1"
+QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qrb2210-rb1-abl/emmc"
+
+QCOM_BOOT_FIRMWARE = "firmware-qcom-boot-qrb2210-rb1"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qrb2210-rb1_23.12.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Prebuilt bootlader images for Qualcomm RB1"
+
+LICENSE = "LicenseRef-LICENSE.qcom"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cbbe399f2c983ad51768f4561587f000"
+
+SRC_URI = "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"
+SRC_URI[sha256sum] = "c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d"
+
+BOOTBINARIES = "rb1-bootloader-emmc-linux-47528"
+
+QCOM_BOOT_IMG_SUBDIR = "qrb2210-rb1"
+
+include firmware-qcom-boot-common.inc

--- a/recipes-bsp/partition/qcom-ptool.inc
+++ b/recipes-bsp/partition/qcom-ptool.inc
@@ -3,4 +3,4 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b0a8acd90d872086b279ead88af03369"
 
 SRC_URI = "git://github.com/qualcomm-linux/qcom-ptool.git;branch=main;protocol=https"
-SRCREV = "b63a84c16f4247178024d3f7a532441d0a4e1d01"
+SRCREV = "9a38c842132362bb635edfe2b1172a7d12f9a875"


### PR DESCRIPTION
Lately the RB1 devices have shown a lot of issues in the CI starting from the device not booting and ending with random crashes. Revert the firmware to the previous baseline.