### PR TITLE
Add BOE dv215fhm-r01 LVDS panel overlay and fit compatible

### DIFF
--- a/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
+++ b/conf/machine/include/fit-dtb-compatible-linux-qcom.inc
@@ -57,6 +57,8 @@ FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-emmc] = \
     "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-emmc"
 FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-staging-emmc] = \
     "lemans-evk lemans-evk-ifp-mezzanine lemans-staging lemans-evk-staging lemans-evk-emmc"
+FIT_DTB_COMPATIBLE[qcom_qcs9075-iot-subtype1-lvds] = \
+    "lemans-evk lemans-evk-ifp-mezzanine lemans-evk-lvds-boe_dv215fhm-r01"
 
 FIT_DTB_COMPATIBLE[qcom_qcs9100-qam-el2gh-staging] = \
     "qcs9100-ride lemans-staging"
@@ -151,6 +153,9 @@ FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging] = \
 FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-staging-emmc] = \
     "monaco-evk monaco-evk-ifp-mezzanine monaco-staging monaco-evk-staging monaco-evk-emmc"
 
+FIT_DTB_COMPATIBLE[qcom_qcs8275-iot-subtype3-lvds] = \
+    "monaco-evk monaco-evk-ifp-mezzanine monaco-evk-lvds-boe_dv215fhm-r01"
+
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-el2gh-staging] = "qcs8300-ride monaco-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp] = "qcs8300-ride monaco-el2"
 FIT_DTB_COMPATIBLE[qcom_qcs8300-adp-staging] = \
@@ -213,6 +218,8 @@ FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype9-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
 FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-staging] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine kodiak-staging qcs6490-rb3gen2-industrial-mezzanine-staging"
+FIT_DTB_COMPATIBLE[qcom_qcs6490-iot-subtype9-lvds] = \
+    "qcs6490-rb3gen2 qcs6490-rb3gen2-industrial-mezzanine qcs6490-rb3gen2-industrial-mezzanine-lvds-boe_dv215fhm-r01"
 
 FIT_DTB_COMPATIBLE[qcom_qcs5430-iot-subtype2-el2kvm] = \
     "qcs6490-rb3gen2 qcs6490-rb3gen2-vision-mezzanine kodiak-el2"

--- a/conf/machine/iq-8275-evk.conf
+++ b/conf/machine/iq-8275-evk.conf
@@ -18,6 +18,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/monaco-ac-evk.dtb \
                       qcom/monaco-evk-camx.dtbo \
                       qcom/monaco-evk-ifp-mezzanine.dtbo \
+                      qcom/monaco-evk-lvds-boe,dv215fhm-r01.dtbo \
                       qcom/monaco-evk-staging.dtbo \
                       qcom/monaco-staging.dtbo \
                       qcom/monaco-evk-emmc.dtbo \

--- a/conf/machine/iq-9075-evk.conf
+++ b/conf/machine/iq-9075-evk.conf
@@ -21,6 +21,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/lemans-staging.dtbo \
                       qcom/lemans-evk-emmc.dtbo \
                       qcom/lemans-evk-sd-card.dtbo \
+                      qcom/lemans-evk-lvds-boe,dv215fhm-r01.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \

--- a/conf/machine/rb3gen2-core-kit.conf
+++ b/conf/machine/rb3gen2-core-kit.conf
@@ -22,6 +22,7 @@ LINUX_QCOM_KERNEL_DEVICETREE ?= " \
                       qcom/kodiak-el2.dtbo \
                       qcom/kodiak-staging.dtbo \
                       qcom/qcs5430-fps-camx.dtbo \
+                      qcom/qcs6490-rb3gen2-industrial-mezzanine-lvds-boe,dv215fhm-r01.dtbo \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
Add BOE dv215fhm-r01 LVDS panel overlay and fit compatible for Lemans mezzanine, Monaco mezzanine and QCS6490 Industrial mezzanine kit.