### PR TITLE
camera-service: upgrade 1.0.5 to 1.0.6

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-multimedia/camera-service/camera-service_1.0.6.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/qualcomm/camera-service"
 
 SRC_URI = "git://github.com/qualcomm/camera-service;protocol=https;nobranch=1;tag=${PV}"
 
-SRCREV = "1c3bc85b8cd35502b29895cc875c51bbcb2cb68f"
+SRCREV = "681edd83cb65849dc29c9fc890bbefc4df3034ca"
 
 # Limit this recipe to ARMv8 (aarch64) only, because it depends
 # on camxcommon-headers which is explicitly restricted to ARMv8 (aarch64).


### PR DESCRIPTION
Upgrade camera-service recipe from v1.0.5 to v1.0.6.

Changes in this release:

- Fix Android tag compilation issue
- Update udev rules to accommodate the new service name
- Enable offline JPEG encode support and fix Kodiak build issues
- Add support for Shikra Soc
- Update default color space and HDR mode values
- Restrict camera service launch action to camera driver events
- Enable downstream Pebble target and associated library names
- Enable Binder support for Pebble target
- Add support for device status change event propagation
- Add locking to protect capture buffer map access
- Fix race condition in client_cameraid_map handling
- Skip frame sequence checks in ProviderExtension mode
- Release buffers after snapshot stream cancellation