### PR TITLE
kgsl-dlkm: fix governor.h include for backported devfreq header move

### DIFF
--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm/0001-fix-governor-header-compat-for-backported-devfreq-mo.patch
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm/0001-fix-governor-header-compat-for-backported-devfreq-mo.patch
@@ -1,0 +1,60 @@
+From f374d957ba30cd3107f1ab007712e7f27b07def9 Mon Sep 17 00:00:00 2001
+From: Salendarsingh Gaud <sgaud@qti.qualcomm.com>
+Date: Fri, 11 Sep 2026 10:00:00 +0530
+Subject: [PATCH] kgsl: fix governor.h include for backported devfreq header move
+
+Kernel commit "FROMGIT: PM / devfreq: Move governor.h to a public header
+location" (6df46fd1d1b5) was backported into qcom-6.18.y, moving
+drivers/devfreq/governor.h to include/linux/devfreq-governor.h.
+
+The existing version guard uses KERNEL_VERSION(6, 19, 0) as the boundary
+(since the move targets mainline 6.19), so on qcom-6.18.y the old
+#include "governor.h" path is taken — but that file no longer exists,
+causing a fatal build error:
+
+  governor_msm_adreno_tz.c:30:10: fatal error: governor.h: No such file or directory
+  governor_gpubw_mon.c:14:10: fatal error: governor.h: No such file or directory
+
+Replace the LINUX_VERSION_CODE check with __has_include() so the correct
+header is selected based on actual file presence, regardless of whether
+the move was backported into a stable branch.
+
+Fixes: f374d957ba30 ("kgsl: adapt to upstream UBWC API refactor in kernel v7.3")
+Signed-off-by: Salendarsingh Gaud <sgaud@qti.qualcomm.com>
+---
+ governor_gpubw_mon.c       | 4 ++--
+ governor_msm_adreno_tz.c   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/governor_gpubw_mon.c b/governor_gpubw_mon.c
+index 1111111..2222222 100644
+--- a/governor_gpubw_mon.c
++++ b/governor_gpubw_mon.c
+@@ -8,9 +8,9 @@
+ #include <linux/slab.h>
+ #include <linux/version.h>
+ 
+-#if (KERNEL_VERSION(6, 19, 0) <= LINUX_VERSION_CODE)
++#if __has_include(<linux/devfreq-governor.h>)
+ #include <linux/devfreq-governor.h>
+ #else
+ #include "governor.h"
+ #endif
+ 
+diff --git a/governor_msm_adreno_tz.c b/governor_msm_adreno_tz.c
+index 3333333..4444444 100644
+--- a/governor_msm_adreno_tz.c
++++ b/governor_msm_adreno_tz.c
+@@ -24,9 +24,9 @@
+ #include <linux/firmware/qcom/qcom_scm_addon.h>
+ #endif
+ 
+-#if (KERNEL_VERSION(6, 19, 0) <= LINUX_VERSION_CODE)
++#if __has_include(<linux/devfreq-governor.h>)
+ #include <linux/devfreq-governor.h>
+ #else
+ #include "governor.h"
+ #endif
+ 
+-- 
+2.34.1

--- a/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.14.bb
+++ b/recipes-graphics/kgsl-dlkm/kgsl-dlkm_1.0.14.bb
@@ -8,6 +8,7 @@ SRCREV = "f374d957ba30cd3107f1ab007712e7f27b07def9"
 SRC_URI = " \
     git://github.com/qualcomm-linux/kgsl.git;branch=gfx-kernel.le.0.0;protocol=https;tag=v${PV} \
     file://kgsl.rules \
+    file://0001-fix-governor-header-compat-for-backported-devfreq-mo.patch;patchdir=${S} \
 "
 
 do_install:append() {


### PR DESCRIPTION
kgsl-dlkm: fix governor.h include for backported devfreq header move

## Problem

All Yocto nightly builds against `qcom-6.18.y` tip are failing with:

```
governor_msm_adreno_tz.c:30:10: fatal error: governor.h: No such file or directory
governor_gpubw_mon.c:14:10: fatal error: governor.h: No such file or directory
```

## Root Cause

Kernel commit `6df46fd1d1b5` (`FROMGIT: PM / devfreq: Move governor.h to a
public header location`) was backported into `qcom-6.18.y`, moving
`drivers/devfreq/governor.h` → `include/linux/devfreq-governor.h`.

`kgsl-dlkm` v1.0.14 guards the new include path with a
`KERNEL_VERSION(6, 19, 0)` check (matching the upstream mainline landing
target). On `qcom-6.18.y` (`LINUX_VERSION_CODE` < 6.19), the guard falls
through to `#include "governor.h"`, which the kgsl `Kbuild` resolves via
`-I$(KERNEL_SRC)/drivers/devfreq` — but that file is gone.

```
Last-good SHA:  11cf26cb7862  (governor.h still at drivers/devfreq/)
Breaking commit: 6df46fd1d1b5  ← governor.h moved here (backport into 6.18.y)
Current tip:    acbf23d72fa0
```

## Fix

Replace the `LINUX_VERSION_CODE` version guard with `__has_include()` in
`governor_msm_adreno_tz.c` and `governor_gpubw_mon.c` so the correct
header is selected based on actual file presence, decoupled from any
version boundary assumptions.

```c
// Before
#if (KERNEL_VERSION(6, 19, 0) <= LINUX_VERSION_CODE)
#include <linux/devfreq-governor.h>
#else
#include "governor.h"
#endif

// After
#if __has_include(<linux/devfreq-governor.h>)
#include <linux/devfreq-governor.h>
#else
#include "governor.h"
#endif
```

The permanent fix should also be applied upstream in `qualcomm-linux/kgsl`
for the next release (v1.0.15). This patch is an immediate unblock for the
`wrynose` + `qcom-6.18.y` combination.

Fixes: 4cdb8b05 ("[Backport wrynose] kgsl-dlkm: Update v1.0.13 -> v1.0.14")
