### PR TITLE
firmware-qcom-boot: update KLMT and Hamoa boot firmware

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00023.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00023.bb
@@ -1,4 +1,0 @@
-require firmware-qcom-boot-iq-x7181.inc
-
-SRC_URI[bootbinaries.sha256sum] = "38bb3cfb8b4c810a5476d2d6613f40e758ee070759035b553992047a68c7bdd5"
-SRC_URI[bootbinaries-immutable.sha256sum] = "389a4a0ff56daf2811d790d2062f97a9b2dfcb32a2c82dfaf324ff7801d98a03"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00027.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-iq-x7181_00027.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-iq-x7181.inc
+
+SRC_URI[bootbinaries.sha256sum] = "8d654b956a537182d035e1e6bb3c41c2d2b78c6672d0e5936d2668b938ef1c67"
+SRC_URI[bootbinaries-immutable.sha256sum] = "4d170f40d09c52c109420edccaafba9aa7b1243e9b2c57d090f6c239a805b5c5"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00140.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-qcs615.inc
-
-SRC_URI[bootbinaries.sha256sum] = "f27bf162caa0dd6e80d0ba3e86b4afecb8fc4cfa9ad1578174d89a2f7ec46d3a"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00142.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs615_00142.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-qcs615.inc
+
+SRC_URI[bootbinaries.sha256sum] = "4704b117672ef778c4680522b753af00641e91fc2f7fb351d942559e09458352"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00140.bb
@@ -1,4 +1,0 @@
-require firmware-qcom-boot-qcs6490.inc
-
-SRC_URI[bootbinaries.sha256sum] = "48f5a141cd8fa620a1869a5b8a0c2b4ec9db5f7bf06d03c84a1b5a4a33a4a135"
-SRC_URI[bootbinaries-immutable.sha256sum] = "91425b049945911f1c11a4652fb1f1c3309e174e650b55d0790f5cad61803bea"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00142.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs6490_00142.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs6490.inc
+
+SRC_URI[bootbinaries.sha256sum] = "22e45047b3349a1611d27167616dd04f08e8351120ac121f6921b47b9f709216"
+SRC_URI[bootbinaries-immutable.sha256sum] = "a5f48c1646eb640377b66fa13064f2efe6f667e60f714b0e06c34dc66b7c94fb"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00140.bb
@@ -1,4 +1,0 @@
-require firmware-qcom-boot-qcs8300.inc
-
-SRC_URI[bootbinaries.sha256sum] = "5c17689bdee8793f58e68ebc077e2508555a4ccce601a3c2dc8c68f6267931d3"
-SRC_URI[bootbinaries-immutable.sha256sum] = "f6ddfaa62f19e9a6d944c7f01d1aa5a7dee05f3cb66d9b20970b3834b15ee61e"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00142.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs8300_00142.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs8300.inc
+
+SRC_URI[bootbinaries.sha256sum] = "22182317cfe5b09f8cc9bc428d755391561cb9d25c9e77aeca4e62195d4b97e8"
+SRC_URI[bootbinaries-immutable.sha256sum] = "ffc05bf1323d828f8c944421d8cadaf1c45697032b26b9f34ecce042ddae291d"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00140.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00140.bb
@@ -1,4 +1,0 @@
-require firmware-qcom-boot-qcs9100.inc
-
-SRC_URI[bootbinaries.sha256sum] = "8c3f95c0f87305cf0ed88152a9d3bddd30c1757392fe1cc005203a7f2a60dcd3"
-SRC_URI[bootbinaries-immutable.sha256sum] = "6b1427b865121966061671d4a1743a87935f5c6132d67bf09d3f3b79b9cd15b4"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00142.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00142.bb
@@ -1,0 +1,4 @@
+require firmware-qcom-boot-qcs9100.inc
+
+SRC_URI[bootbinaries.sha256sum] = "17d2c5bae5c17b665bafd9bba8962f41aec7be2f874cde90b0976730f0098bf6"
+SRC_URI[bootbinaries-immutable.sha256sum] = "1aa0b67671ef026a40ca133f32128d07fffd614a47cf51eaa5cd5c7d4941d034"


### PR DESCRIPTION
Update boot firmware recipes for the latest public releases:

  - QCS615, QCM6490, QCS8300, and QCS9100: 00140 -> 00142
  - IQ-X7181 / Hamoa: 00023 -> 00027
  
Known fixes included in the updated releases:

  - Update secure firmware access-control policy
  - Improve secure service behavior during boot
  - Improve secure media application handling
  - Harden trusted application validation
  - Update Hamoa BOOT, UEFI, and secure app firmware
  - Add Hamoa PCIe and secondary storage boot support
  - Improve Hamoa capsule update secure-app loading
