### PR TITLE
linux-qcom: Support low-memory kernel configuration

### DIFF
--- a/ci/lowmem.yml
+++ b/ci/lowmem.yml
@@ -1,0 +1,11 @@
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+target:
+  - qcom-lowmem-image
+
+local_conf_header:
+  lowmem-kernel: |
+    DISTRO_FEATURES:append = " lowmem"

--- a/recipes-kernel/linux/linux-qcom-6.18/configs/lowmem-additions.cfg
+++ b/recipes-kernel/linux/linux-qcom-6.18/configs/lowmem-additions.cfg
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+#
+# Low-memory kernel config fragment — activated via DISTRO_FEATURES = "lowmem".
+#
+# Applied to ANY machine that sets: DISTRO_FEATURES:append = " lowmem"
+# Merged on top of: defconfig + prune.config + qcom.config + bsp-additions.cfg
+#
+# Only options that are NOT already handled by prune.config / qcom.config
+# are listed here. For additional candidates to evaluate, see:
+# meta-qcom/docs/low-memory-kodiak-all-approaches.md
+
+# Reduce SLUB allocator metadata overhead (~1-2 MB saved)
+CONFIG_SLUB_TINY=y
+
+# Disable Transparent Huge Pages (~16-32 MB saved)
+# THP pools 2 MB pages in the background — wasteful on a 2 GB board.
+CONFIG_TRANSPARENT_HUGEPAGE=n

--- a/recipes-kernel/linux/linux-qcom-next/configs/lowmem-additions.cfg
+++ b/recipes-kernel/linux/linux-qcom-next/configs/lowmem-additions.cfg
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+#
+# Low-memory kernel config fragment — activated via DISTRO_FEATURES = "lowmem".
+#
+# Applied to ANY machine that sets: DISTRO_FEATURES:append = " lowmem"
+# Merged on top of: defconfig + prune.config + qcom.config + bsp-additions.cfg
+#
+# Only options that are NOT already handled by prune.config / qcom.config
+# are listed here. For additional candidates to evaluate, see:
+# meta-qcom/docs/low-memory-kodiak-all-approaches.md
+
+# Reduce SLUB allocator metadata overhead (~1-2 MB saved)
+CONFIG_SLUB_TINY=y
+
+# Disable Transparent Huge Pages (~16-32 MB saved)
+# THP pools 2 MB pages in the background — wasteful on a 2 GB board.
+CONFIG_TRANSPARENT_HUGEPAGE=n

--- a/recipes-kernel/linux/linux-qcom-next_git.bb
+++ b/recipes-kernel/linux/linux-qcom-next_git.bb
@@ -29,6 +29,7 @@ SRC_URI = "git://github.com/qualcomm-linux/kernel.git;${SRCBRANCH};protocol=http
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://configs/lowmem-additions.cfg \
 "
 
 # To build tip of qcom-next branch set preferred

--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -34,6 +34,7 @@ SRC_URI = " \
 # Additional kernel configs.
 SRC_URI += " \
     file://configs/bsp-additions.cfg \
+    file://configs/lowmem-additions.cfg \
 "
 
 # To build tip of qcom-6.18.y branch set preferred


### PR DESCRIPTION
Introduce a low-memory kernel configuration profile for Qualcomm-based targets when the "lowmem" DISTRO_FEATURE is enabled.

To reduce kernel memory footprint and optimize the image for memory-constrained devices:

  - Enable CONFIG_SLUB_TINY to minimize SLUB allocator metadata overhead.
  - Disable CONFIG_TRANSPARENT_HUGEPAGE to reduce memory consumption and avoid the additional overhead associated with huge page management.

These configuration changes are applied conditionally based on the presence of "lowmem" in DISTRO_FEATURES, allowing standard builds to retain their existing kernel configuration while providing a leaner kernel image for low-memory deployments.