### PR TITLE
firmware-qcom-boot-shikra: update tag 00072 -> 00078

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00072.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00072.bb
@@ -1,3 +1,0 @@
-require firmware-qcom-boot-shikra.inc
-
-SRC_URI[bootbinaries.sha256sum] = "a123a9e7e4d7627962a39e6eb0d3773a52d7c43481961eda2e4bb21663b4e7db"

--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00078.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-shikra_00078.bb
@@ -1,0 +1,3 @@
+require firmware-qcom-boot-shikra.inc
+
+SRC_URI[bootbinaries.sha256sum] = "1ccb06dc7ff54f788b7c7971e89a6424cffcec7adb2e7af24e530d665dbd5ca4"


### PR DESCRIPTION
Update Shikra bootbinaries from build 00072 to 00078.  

The 00078 boot firmware update includes UEFI changes to support efivar.