### PR TITLE
iris-video-dlkm: upgrade v1.0.27 -> v1.0.28

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.28.bb
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_1.0.28.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://blacklist-video.conf.venus \
     file://blacklist-video.conf.vidc \
 "
-SRCREV  = "ba6d8523b39600f2dae231dca1024fb282cd9348"
+SRCREV  = "269addefac0f3378a152cd2cfca18b83103e9300"
 
 inherit module update-alternatives
 


### PR DESCRIPTION
This tag v1.0.28 brings the following updates for Qcom Iris:

- Fix green line issue in encoder output.
- Enable IR_PERIOD capability on Purwa.
- Align UBWC configuration and QCOM TEE PAS support with upstream kernel changes.